### PR TITLE
Do not double-encode transactions when hashing them

### DIFF
--- a/pallets/utxo/src/lib.rs
+++ b/pallets/utxo/src/lib.rs
@@ -291,7 +291,7 @@ pub mod pallet {
         // Check that outputs are valid
         for output in tx.outputs.iter() {
             ensure!(output.value > 0, "output value must be nonzero");
-            let hash = BlakeTwo256::hash_of(&(&tx.encode(), output_index));
+            let hash = BlakeTwo256::hash_of(&(&tx, output_index));
             output_index = output_index.checked_add(1).ok_or("output index overflow")?;
             ensure!(!<UtxoStore<T>>::contains_key(hash), "output already exists");
 
@@ -351,7 +351,7 @@ pub mod pallet {
 
         let mut index: u64 = 0;
         for output in &tx.outputs {
-            let hash = BlakeTwo256::hash_of(&(&tx.encode(), index));
+            let hash = BlakeTwo256::hash_of(&(&tx, index));
             index = index.checked_add(1).ok_or("output index overflow")?;
             log::debug!("inserting to UtxoStore {:?} as key {:?}", output, hash);
             <UtxoStore<T>>::insert(hash, Some(output));

--- a/pallets/utxo/src/tests.rs
+++ b/pallets/utxo/src/tests.rs
@@ -52,7 +52,7 @@ fn test_simple_tx() {
 
         let alice_sig = crypto::sr25519_sign(SR25519, &alice_pub_key, &tx.encode()).unwrap();
         tx.inputs[0].sig_script = H512::from(alice_sig);
-        let new_utxo_hash = BlakeTwo256::hash_of(&(&tx.encode(), 0 as u64));
+        let new_utxo_hash = BlakeTwo256::hash_of(&(&tx, 0 as u64));
 
         assert_ok!(Utxo::spend(Origin::signed(0), tx));
         assert!(!UtxoStore::<Test>::contains_key(H256::from(GENESIS_UTXO)));
@@ -224,7 +224,7 @@ fn tx_from_alice_to_karl() {
         tx.inputs[0].sig_script = H512::from(alice_sig);
 
         assert_ok!(Utxo::spend(Origin::signed(0), tx.clone()));
-        let new_utxo_hash = BlakeTwo256::hash_of(&(&tx.encode(), 1 as u64));
+        let new_utxo_hash = BlakeTwo256::hash_of(&(&tx, 1 as u64));
 
         // then send rest of the tokens to karl (proving that the first tx was successful)
         let mut tx = Transaction {


### PR DESCRIPTION
`BlakeTwo256::hash_of()` automatically SCALE-encodes the input already, making `tx.encode()` unnecessary.

Python test code: BLAKE2b hash of i32 0x00:
```
test = scalecodec.I32().process_encode(0).to_hex()[2:]
print(hashlib.blake2b(bytes.fromhex(test), digest_size=32).hexdigest())
```

outputs: 
```
11da6d1f761ddf9bdb4c9d6e5303ebd41f61858d0a5647a1a7bfe089bf921be9
```

Substrate's BlakeTwo256 test code, i32 and i32.encode():
```
let data = 0x00;
println!("{:#?}", BlakeTwo256::hash_of(&data));
println!("{:#?}", BlakeTwo256::hash_of(&data.encode()));
```
outputs:
```
0x11da6d1f761ddf9bdb4c9d6e5303ebd41f61858d0a5647a1a7bfe089bf921be9
0xab31e92ac585eb0db73243666ddba9d91c4ccfd72809be250a0e02d5a3545b1a
```

The input to `hash_of()` is automatically encoded, making the call to `encode()` unnecessary. 