### PR TITLE
Add minimal rustfmt.toml and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+end_of_line = lf
+
+[*.rs]
+indent_style = space
+indent_size = 4

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,9 @@
+max_width = 100
+hard_tabs = false
+tab_spaces = 4
+array_width = 80
+chain_width = 80
+single_line_if_else_max_width = 50
+spaces_around_ranges = false
+newline_style = "Unix"
+edition = "2018"


### PR DESCRIPTION
Here is a minimal `rustfmt.toml` and an `.editorconfig` to go with it.

Some options have been adjusted:
* `{chain,array}_width = 80` (up from 50, this is what Substrate does)
* `newline_style = "Unix"` (for consistency)
* `edition = "2018"`

Remaining options just state pre-existing defaults explicitly.