### PR TITLE
rustfmt: remove a nightly option

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,6 +4,5 @@ tab_spaces = 4
 array_width = 80
 chain_width = 80
 single_line_if_else_max_width = 50
-spaces_around_ranges = false
 newline_style = "Unix"
 edition = "2018"


### PR DESCRIPTION
Removing an option that is only available in nightly toolchains to silence a warning.