### PR TITLE
UTXO: Use the Identity hasher for UtxoStore

### DIFF
--- a/pallets/utxo/src/lib.rs
+++ b/pallets/utxo/src/lib.rs
@@ -163,7 +163,7 @@ pub mod pallet {
     #[pallet::storage]
     #[pallet::getter(fn utxo_store)]
     pub(super) type UtxoStore<T: Config> =
-        StorageMap<_, Blake2_256, H256, Option<TransactionOutput>, ValueQuery>;
+        StorageMap<_, Identity, H256, Option<TransactionOutput>, ValueQuery>;
 
     #[pallet::event]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]


### PR DESCRIPTION
Since the key used to access UTXOs from the store already is a hash,
there is no need to hash it again to obtain the storage key. Not doing
it has a number of advantages:

* Slight speedup due to not hashing that much.
* Client code can recover the keys (hashes) from the store easily. That
  means that the hash reported by polkadot.js UI when querying the
  storage can be used as a value for `outpoint` entry in transactions.
* The `Identity` hasher implements `ReversibleStorageHasher`. That gives
  access to some extra useful methods such as `UtxoStore::<T>::iter()`.