### PR TITLE
Add the chainscript code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +751,23 @@ dependencies = [
  "cipher",
  "poly1305",
  "zeroize",
+]
+
+[[package]]
+name = "chainscript"
+version = "0.1.0"
+dependencies = [
+ "displaydoc",
+ "frame-support",
+ "hex-literal 0.3.3",
+ "parity-scale-codec",
+ "proptest",
+ "ripemd160",
+ "sha-1 0.9.8",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -1195,6 +1227,17 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4600,6 +4643,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand 0.8.4",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
 name = "prost"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4854,6 +4917,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5029,6 +5101,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd160"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5107,6 +5190,18 @@ dependencies = [
  "rustls",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -7835,6 +7930,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ panic = 'unwind'
 [workspace]
 members = [
     'node',
+    'libs/chainscript',
     'pallets/*',
     'runtime',
 ]

--- a/libs/chainscript/.gitignore
+++ b/libs/chainscript/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/libs/chainscript/.gitignore
+++ b/libs/chainscript/.gitignore
@@ -1,2 +1,0 @@
-/target
-Cargo.lock

--- a/libs/chainscript/Cargo.toml
+++ b/libs/chainscript/Cargo.toml
@@ -17,14 +17,14 @@ ripemd160 = { default-features = false, version = "0.9.1" }
 displaydoc = { default-features = false, version = "0.2" }
 
 # Substrate dependencies
-sp-core = { default-features = false, version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
-sp-io = {default-features = false, version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
-sp-std = { default-features = false, version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
-frame-support = { default-features = false, version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
+sp-core = { default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
+sp-io = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
+sp-std = { default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
+frame-support = { default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
 
 [dev-dependencies]
 # serde = '1.0.119'
-sp-runtime = {default-features = false, version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
+sp-runtime = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
 hex-literal = "0.3.1"
 proptest = "1.0.0"
 

--- a/libs/chainscript/Cargo.toml
+++ b/libs/chainscript/Cargo.toml
@@ -14,6 +14,7 @@ targets = ['x86_64-unknown-linux-gnu']
 # external dependencies
 sha-1 = { default-features = false, version = "0.9.7" }
 ripemd160 = { default-features = false, version = "0.9.1" }
+displaydoc = { default-features = false, version = "0.2" }
 
 # Substrate dependencies
 sp-core = { default-features = false, version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}

--- a/libs/chainscript/Cargo.toml
+++ b/libs/chainscript/Cargo.toml
@@ -17,6 +17,8 @@ ripemd160 = { default-features = false, version = "0.9.1" }
 displaydoc = { default-features = false, version = "0.2" }
 
 # Substrate dependencies
+
+codec = { default-features = false, features = ['derive'], package = 'parity-scale-codec', version = '2.0.0' }
 sp-core = { default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
 sp-io = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
 sp-std = { default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
@@ -32,6 +34,7 @@ proptest = "1.0.0"
 default = ['std', 'testcontext']
 testcontext = []
 std = [
+        "codec/std",
         "sp-io/std",
         "sp-core/std",
         "sp-std/std",

--- a/libs/chainscript/Cargo.toml
+++ b/libs/chainscript/Cargo.toml
@@ -25,6 +25,7 @@ libsecp256k1 = { version = "0.3.4", optional = true }
 # serde = '1.0.119'
 sp-runtime = {default-features = false, version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
 hex-literal = "0.3.1"
+proptest = "1.0.0"
 
 [features]
 default = ['std', 'testcontext']

--- a/libs/chainscript/Cargo.toml
+++ b/libs/chainscript/Cargo.toml
@@ -20,7 +20,6 @@ displaydoc = { default-features = false, version = "0.2" }
 sp-core = { default-features = false, version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
 sp-io = {default-features = false, version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
 sp-std = { default-features = false, version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
-libsecp256k1 = { version = "0.3.4", optional = true }
 
 [dev-dependencies]
 # serde = '1.0.119'
@@ -30,7 +29,7 @@ proptest = "1.0.0"
 
 [features]
 default = ['std', 'testcontext']
-testcontext = [ "libsecp256k1" ]
+testcontext = []
 std = [
         "sp-io/std",
         "sp-core/std",

--- a/libs/chainscript/Cargo.toml
+++ b/libs/chainscript/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+authors = ['Lukas Kuklinek <lukas.kuklinek@mintlayer.com>']
+description = 'An interpreter for bitcoin script and its dialects'
+edition = '2018'
+name = 'chainscript'
+readme = 'README.md'
+version = '0.1.0'
+
+[package.metadata.docs.rs]
+targets = ['x86_64-unknown-linux-gnu']
+
+[dependencies]
+# external dependencies
+sha-1 = { default-features = false, version = "0.9.7" }
+ripemd160 = { default-features = false, version = "0.9.1" }
+
+# Substrate dependencies
+sp-core = { default-features = false, version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
+sp-io = {default-features = false, version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
+sp-std = { default-features = false, version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
+libsecp256k1 = { version = "0.3.4", optional = true }
+
+[dev-dependencies]
+# serde = '1.0.119'
+sp-runtime = {default-features = false, version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
+hex-literal = "0.3.1"
+
+[features]
+default = ['std', 'testcontext']
+testcontext = [ "libsecp256k1" ]
+std = [
+        "sp-io/std",
+        "sp-core/std",
+        "sp-std/std",
+        "sp-runtime/std",
+]

--- a/libs/chainscript/Cargo.toml
+++ b/libs/chainscript/Cargo.toml
@@ -20,6 +20,7 @@ displaydoc = { default-features = false, version = "0.2" }
 sp-core = { default-features = false, version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
 sp-io = {default-features = false, version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
 sp-std = { default-features = false, version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
+frame-support = { default-features = false, version = '3.0.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
 
 [dev-dependencies]
 # serde = '1.0.119'
@@ -35,4 +36,5 @@ std = [
         "sp-core/std",
         "sp-std/std",
         "sp-runtime/std",
+        "frame-support/std",
 ]

--- a/libs/chainscript/Cargo.toml
+++ b/libs/chainscript/Cargo.toml
@@ -5,6 +5,7 @@ edition = '2018'
 name = 'chainscript'
 readme = 'README.md'
 version = '0.1.0'
+license = 'MIT'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/libs/chainscript/LICENSE
+++ b/libs/chainscript/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 RBB S.r.l
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/chainscript/README.md
+++ b/libs/chainscript/README.md
@@ -12,5 +12,5 @@ the following modules:
 * `src/script.rs`
 * `src/util.rs`
 
-For more detailed docs, see the [module-leve comments](src/lib.rs) in the top-level module
+For more detailed docs, see the [module-level comments](src/lib.rs) in the top-level module
 or alternatively run `cargo doc --open`.

--- a/libs/chainscript/README.md
+++ b/libs/chainscript/README.md
@@ -1,0 +1,16 @@
+# Chainscript
+
+A rust library providing an interpreter and a set of tools for working with Bitcoinscript-like
+bytecode languages.
+
+Code that deals with opcodes and script manipulation is originally [based on the `rust-bitcoin`
+project](https://github.com/rust-bitcoin/rust-bitcoin/tree/bd5d875e8ac87). That applies to
+the following modules:
+
+* `src/error.rs`
+* `src/opcodes.rs`
+* `src/script.rs`
+* `src/util.rs`
+
+For more detailed docs, see the [module-leve comments](src/lib.rs) in the top-level module
+or alternatively run `cargo doc --open`.

--- a/libs/chainscript/src/context.rs
+++ b/libs/chainscript/src/context.rs
@@ -32,63 +32,63 @@
 /// * The interface is not fully finalized. It is likely to change as new requirements come in. E.g.
 ///   it may be currently too limited to support signature batching.
 pub trait Context {
-	/// Maximum number of bytes pushable to the stack
-	const MAX_SCRIPT_ELEMENT_SIZE: usize = 520;
+    /// Maximum number of bytes pushable to the stack
+    const MAX_SCRIPT_ELEMENT_SIZE: usize = 520;
 
-	/// Maximum number of public keys per multisig
-	const MAX_PUBKEYS_PER_MULTISIG: usize;
+    /// Maximum number of public keys per multisig
+    const MAX_PUBKEYS_PER_MULTISIG: usize;
 
-	/// Maximum script length in bytes
-	const MAX_SCRIPT_SIZE: usize;
+    /// Maximum script length in bytes
+    const MAX_SCRIPT_SIZE: usize;
 
-	/// Signature, parsed and verified for correct format.
-	type Signature;
+    /// Signature, parsed and verified for correct format.
+    type Signature;
 
-	/// Public key type.
-	type Public;
+    /// Public key type.
+    type Public;
 
-	/// Transaction hash type used by the chain for signatures.
-	type TxHash: AsRef<[u8]>;
+    /// Transaction hash type used by the chain for signatures.
+    type TxHash: AsRef<[u8]>;
 
-	/// Extract a signature and check it is in the correct format.
-	fn parse_signature(&self, sig: &[u8]) -> Option<Self::Signature>;
+    /// Extract a signature and check it is in the correct format.
+    fn parse_signature(&self, sig: &[u8]) -> Option<Self::Signature>;
 
-	/// Extract a pubkey and check it is in the correct format.
-	fn parse_pubkey(&self, pk: &[u8]) -> Option<Self::Public>;
+    /// Extract a pubkey and check it is in the correct format.
+    fn parse_pubkey(&self, pk: &[u8]) -> Option<Self::Public>;
 
-	/// Hash the transaction.
-	///
-	/// Signature is passed in as well to give the method an opportunity to extract sighash and
-	/// decide which parts of the transaction should contribute to the hash.
-	fn hash_transaction(&self, signature: &Self::Signature, subscript: &[u8]) -> Self::TxHash;
+    /// Hash the transaction.
+    ///
+    /// Signature is passed in as well to give the method an opportunity to extract sighash and
+    /// decide which parts of the transaction should contribute to the hash.
+    fn hash_transaction(&self, signature: &Self::Signature, subscript: &[u8]) -> Self::TxHash;
 
-	/// Verify signature.
-	fn verify_signature(
-		&self,
-		sig: &Self::Signature,
-		pk: &Self::Public,
-		msg: &Self::TxHash,
-	) -> bool;
+    /// Verify signature.
+    fn verify_signature(
+        &self,
+        sig: &Self::Signature,
+        pk: &Self::Public,
+        msg: &Self::TxHash,
+    ) -> bool;
 
-	/// Check absolute time lock.
-	fn check_lock_time(&self, _lock_time: i64) -> bool {
-		false
-	}
+    /// Check absolute time lock.
+    fn check_lock_time(&self, _lock_time: i64) -> bool {
+        false
+    }
 
-	/// Check relative time lock.
-	fn check_sequence(&self, _sequence: i64) -> bool {
-		false
-	}
+    /// Check relative time lock.
+    fn check_sequence(&self, _sequence: i64) -> bool {
+        false
+    }
 
-	/// Enforce minimal push.
-	fn enforce_minimal_push(&self) -> bool {
-		true
-	}
+    /// Enforce minimal push.
+    fn enforce_minimal_push(&self) -> bool {
+        true
+    }
 
-	/// Force the condition for OP_(NOT)IF to be either `[]` or `[0x01]`, fail script otherwise.
-	fn enforce_minimal_if(&self) -> bool {
-		true
-	}
+    /// Force the condition for OP_(NOT)IF to be either `[]` or `[0x01]`, fail script otherwise.
+    fn enforce_minimal_if(&self) -> bool {
+        true
+    }
 }
 
 // A test context implementation.
@@ -96,56 +96,56 @@ pub trait Context {
 #[cfg(any(test, feature = "testcontext"))]
 pub mod testcontext {
 
-	use super::*;
-	use crate::util::sha256;
-	use core::convert::TryFrom;
+    use super::*;
+    use crate::util::sha256;
+    use core::convert::TryFrom;
 
-	#[derive(Default)]
-	pub struct TestContext {
-		transaction: Vec<u8>,
-	}
+    #[derive(Default)]
+    pub struct TestContext {
+        transaction: Vec<u8>,
+    }
 
-	/// Test context.
-	///
-	/// The Context implementation for testing. The transaction hash (just 4 bytes for tesing) has
-	/// to be provided explicitly as a byte string. Signature scheme is very simple: The bitwise xor
-	/// of transaction hash, signature and public key has to be equal to zero. Not recommended for
-	/// production.
-	impl TestContext {
-		pub fn new(transaction: Vec<u8>) -> Self {
-			Self { transaction }
-		}
-	}
+    /// Test context.
+    ///
+    /// The Context implementation for testing. The transaction hash (just 4 bytes for tesing) has
+    /// to be provided explicitly as a byte string. Signature scheme is very simple: The bitwise xor
+    /// of transaction hash, signature and public key has to be equal to zero. Not recommended for
+    /// production.
+    impl TestContext {
+        pub fn new(transaction: Vec<u8>) -> Self {
+            Self { transaction }
+        }
+    }
 
-	impl Context for TestContext {
-		const MAX_PUBKEYS_PER_MULTISIG: usize = 20;
-		const MAX_SCRIPT_SIZE: usize = 10000;
+    impl Context for TestContext {
+        const MAX_PUBKEYS_PER_MULTISIG: usize = 20;
+        const MAX_SCRIPT_SIZE: usize = 10000;
 
-		// Signatures, keys and transaction IDs are just 4-byte binary data each.
-		type Signature = [u8; 4];
-		type Public = [u8; 4];
-		type TxHash = [u8; 4];
+        // Signatures, keys and transaction IDs are just 4-byte binary data each.
+        type Signature = [u8; 4];
+        type Public = [u8; 4];
+        type TxHash = [u8; 4];
 
-		fn parse_signature(&self, sig: &[u8]) -> Option<Self::Signature> {
-			Self::Signature::try_from(sig).ok()
-		}
+        fn parse_signature(&self, sig: &[u8]) -> Option<Self::Signature> {
+            Self::Signature::try_from(sig).ok()
+        }
 
-		fn parse_pubkey(&self, pk: &[u8]) -> Option<Self::Public> {
-			Self::Public::try_from(pk).ok()
-		}
+        fn parse_pubkey(&self, pk: &[u8]) -> Option<Self::Public> {
+            Self::Public::try_from(pk).ok()
+        }
 
-		fn hash_transaction(&self, _sig: &Self::Signature, subscript: &[u8]) -> Self::TxHash {
-			let data = [&self.transaction[..], subscript].concat();
-			Self::TxHash::try_from(&sha256(&data)[0..4]).unwrap()
-		}
+        fn hash_transaction(&self, _sig: &Self::Signature, subscript: &[u8]) -> Self::TxHash {
+            let data = [&self.transaction[..], subscript].concat();
+            Self::TxHash::try_from(&sha256(&data)[0..4]).unwrap()
+        }
 
-		fn verify_signature(
-			&self,
-			sig: &Self::Signature,
-			pk: &Self::Public,
-			msg: &Self::TxHash,
-		) -> bool {
-			sig.iter().zip(pk.iter()).zip(msg.iter()).all(|((&s, &p), &m)| (s ^ p ^ m) == 0)
-		}
-	}
+        fn verify_signature(
+            &self,
+            sig: &Self::Signature,
+            pk: &Self::Public,
+            msg: &Self::TxHash,
+        ) -> bool {
+            sig.iter().zip(pk.iter()).zip(msg.iter()).all(|((&s, &p), &m)| (s ^ p ^ m) == 0)
+        }
+    }
 }

--- a/libs/chainscript/src/context.rs
+++ b/libs/chainscript/src/context.rs
@@ -1,3 +1,22 @@
+// Copyright (c) 2021 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): L. Kuklinek
+
+//! Context provide interface between script engine and blockchain
+
 /// Context for the script interpreter.
 ///
 /// This trait defines how the interpreter interfaces with the blockchain. It allows the client
@@ -66,7 +85,7 @@ pub trait Context {
 		true
 	}
 
-	/// Force the condition for OP_(NOT)IF to be either [] or [0x01], fail script otherwise.
+	/// Force the condition for OP_(NOT)IF to be either `[]` or `[0x01]`, fail script otherwise.
 	fn enforce_minimal_if(&self) -> bool {
 		true
 	}

--- a/libs/chainscript/src/context.rs
+++ b/libs/chainscript/src/context.rs
@@ -1,0 +1,132 @@
+/// Context for the script interpreter.
+///
+/// This trait defines how the interpreter interfaces with the blockchain. It allows the client
+/// to adjust the behaviour of the interpreter by having pluggable signature verification routines
+/// and by selectively enabling various interpreter features. It is expected that all data the
+/// interpreter takes as implicit inputs (such as transaction hashes that the signatures sign,
+/// block height for time locks, etc.) are provided by a type that implements Context.
+///
+/// ## TODO
+///
+/// * This interface is currently rather monolithic. It may be sensible to break it down into
+///   multiple smaller ones for greater flexibility in the future.
+/// * The interface is not fully finalized. It is likely to change as new requirements come in. E.g.
+///   it may be currently too limited to support signature batching.
+pub trait Context {
+	/// Maximum number of bytes pushable to the stack
+	const MAX_SCRIPT_ELEMENT_SIZE: usize = 520;
+
+	/// Maximum number of public keys per multisig
+	const MAX_PUBKEYS_PER_MULTISIG: usize;
+
+	/// Maximum script length in bytes
+	const MAX_SCRIPT_SIZE: usize;
+
+	/// Signature, parsed and verified for correct format.
+	type Signature;
+
+	/// Public key type.
+	type Public;
+
+	/// Transaction hash type used by the chain for signatures.
+	type TxHash: AsRef<[u8]>;
+
+	/// Extract a signature and check it is in the correct format.
+	fn parse_signature(&self, sig: &[u8]) -> Option<Self::Signature>;
+
+	/// Extract a pubkey and check it is in the correct format.
+	fn parse_pubkey(&self, pk: &[u8]) -> Option<Self::Public>;
+
+	/// Hash the transaction.
+	///
+	/// Signature is passed in as well to give the method an opportunity to extract sighash and
+	/// decide which parts of the transaction should contribute to the hash.
+	fn hash_transaction(&self, signature: &Self::Signature, subscript: &[u8]) -> Self::TxHash;
+
+	/// Verify signature.
+	fn verify_signature(
+		&self,
+		sig: &Self::Signature,
+		pk: &Self::Public,
+		msg: &Self::TxHash,
+	) -> bool;
+
+	/// Check absolute time lock.
+	fn check_lock_time(&self, _lock_time: i64) -> bool {
+		false
+	}
+
+	/// Check relative time lock.
+	fn check_sequence(&self, _sequence: i64) -> bool {
+		false
+	}
+
+	/// Enforce minimal push.
+	fn enforce_minimal_push(&self) -> bool {
+		true
+	}
+
+	/// Force the condition for OP_(NOT)IF to be either [] or [0x01], fail script otherwise.
+	fn enforce_minimal_if(&self) -> bool {
+		true
+	}
+}
+
+// A test context implementation.
+// Used for testing and as an example of what a Context might look like.
+#[cfg(any(test, feature = "testcontext"))]
+pub mod testcontext {
+
+	use super::*;
+	use crate::util::sha256;
+	use core::convert::TryFrom;
+
+	#[derive(Default)]
+	pub struct TestContext {
+		transaction: Vec<u8>,
+	}
+
+	/// Test context.
+	///
+	/// The Context implementation for testing. The transaction hash (just 4 bytes for tesing) has
+	/// to be provided explicitly as a byte string. Signature scheme is very simple: The bitwise xor
+	/// of transaction hash, signature and public key has to be equal to zero. Not recommended for
+	/// production.
+	impl TestContext {
+		pub fn new(transaction: Vec<u8>) -> Self {
+			Self { transaction }
+		}
+	}
+
+	impl Context for TestContext {
+		const MAX_PUBKEYS_PER_MULTISIG: usize = 20;
+		const MAX_SCRIPT_SIZE: usize = 10000;
+
+		// Signatures, keys and transaction IDs are just 4-byte binary data each.
+		type Signature = [u8; 4];
+		type Public = [u8; 4];
+		type TxHash = [u8; 4];
+
+		fn parse_signature(&self, sig: &[u8]) -> Option<Self::Signature> {
+			Self::Signature::try_from(sig).ok()
+		}
+
+		fn parse_pubkey(&self, pk: &[u8]) -> Option<Self::Public> {
+			Self::Public::try_from(pk).ok()
+		}
+
+		fn hash_transaction(&self, _sig: &Self::Signature, subscript: &[u8]) -> Self::TxHash {
+			let data = [&self.transaction[..], subscript].concat();
+			Self::TxHash::try_from(&sha256(&data)[0..4]).unwrap()
+		}
+
+		fn verify_signature(
+			&self,
+			sig: &Self::Signature,
+			pk: &Self::Public,
+			msg: &Self::TxHash,
+		) -> bool {
+			sig.iter().zip(pk.iter()).zip(msg.iter()).all(|((&s, &p), &m)| (s ^ p ^ m) == 0)
+		}
+	}
+}

--- a/libs/chainscript/src/error.rs
+++ b/libs/chainscript/src/error.rs
@@ -1,0 +1,57 @@
+use core::fmt;
+
+/// Ways that a script might fail. Not everything is split up as
+/// much as it could be; patches welcome if more detailed errors
+/// would help you.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
+pub enum Error {
+	/// Something did a non-minimal push; for more information see
+	/// `https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#Push_operators`
+	NonMinimalPush,
+	/// Some opcode expected a parameter, but it was missing or truncated
+	EarlyEndOfScript,
+	/// Tried to read an array off the stack as a number when it was more than 4 bytes
+	NumericOverflow,
+	#[cfg(feature = "bitcoinconsensus")]
+	/// Error validating the script with bitcoinconsensus library
+	BitcoinConsensus(bitcoinconsensus::Error),
+	#[cfg(feature = "bitcoinconsensus")]
+	/// Can not find the spent output
+	UnknownSpentOutput(OutPoint),
+	#[cfg(feature = "bitcoinconsensus")]
+	/// Can not serialize the spending transaction
+	SerializationError,
+}
+
+impl fmt::Display for Error {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		let str = match *self {
+			Error::NonMinimalPush => "non-minimal datapush",
+			Error::EarlyEndOfScript => "unexpected end of script",
+			Error::NumericOverflow => "numeric overflow (number on stack larger than 4 bytes)",
+			#[cfg(feature = "bitcoinconsensus")]
+			Error::BitcoinConsensus(ref _n) => "bitcoinconsensus verification failed",
+			#[cfg(feature = "bitcoinconsensus")]
+			Error::UnknownSpentOutput(ref _point) => "unknown spent output Transaction::verify()",
+			#[cfg(feature = "bitcoinconsensus")]
+			Error::SerializationError =>
+				"can not serialize the spending transaction in Transaction::verify()",
+		};
+		f.write_str(str)
+	}
+}
+
+#[cfg(feature = "std")]
+impl ::std::error::Error for Error {}
+
+#[cfg(feature = "bitcoinconsensus")]
+#[doc(hidden)]
+impl From<bitcoinconsensus::Error> for Error {
+	fn from(err: bitcoinconsensus::Error) -> Error {
+		match err {
+			_ => Error::BitcoinConsensus(err),
+		}
+	}
+}
+
+pub type Result<T> = core::result::Result<T, Error>;

--- a/libs/chainscript/src/error.rs
+++ b/libs/chainscript/src/error.rs
@@ -1,12 +1,11 @@
-use core::fmt;
+use displaydoc::Display;
 
 /// Ways that a script might fail. Not everything is split up as
 /// much as it could be; patches welcome if more detailed errors
 /// would help you.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy, Display)]
 pub enum Error {
-	/// Something did a non-minimal push; for more information see
-	/// `https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#Push_operators`
+	/// Something did a non-minimal push
 	NonMinimalPush,
 	/// Some opcode expected a parameter, but it was missing or truncated
 	EarlyEndOfScript,
@@ -14,12 +13,18 @@ pub enum Error {
 	NumericOverflow,
 	/// Illegal instruction executed
 	IllegalOp,
-	/// Syntactically inforrect OP_(NOT)IF/OP_ELSE/OP_ENDIF
+	/// Syntactically incorrect OP_(NOT)IF/OP_ELSE/OP_ENDIF
 	UnbalancedIfElse,
 	/// Stack has insufficient number of elements in it
 	NotEnoughElementsOnStack,
 	/// Invalid operand to a script operation.
 	InvalidOperand,
+	/// OP_*VERIFY failed verification or OP_RETURN was executed.
+	VerifyFail,
+	/// Signature is not in correct format.
+	SignatureFormat,
+	/// Pubkey is not in correct format.
+	PubkeyFormat,
 	#[cfg(feature = "bitcoinconsensus")]
 	/// Error validating the script with bitcoinconsensus library
 	BitcoinConsensus(bitcoinconsensus::Error),
@@ -29,28 +34,6 @@ pub enum Error {
 	#[cfg(feature = "bitcoinconsensus")]
 	/// Can not serialize the spending transaction
 	SerializationError,
-}
-
-impl fmt::Display for Error {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		let str = match *self {
-			Error::NonMinimalPush => "non-minimal datapush",
-			Error::EarlyEndOfScript => "unexpected end of script",
-			Error::NumericOverflow => "numeric overflow (number on stack larger than 4 bytes)",
-			Error::IllegalOp => "illegal script operation executed",
-			Error::UnbalancedIfElse => "OP_IF/OP_NOTIF/OP_ELSE/OP_ENDIF not syntactically correct",
-			Error::NotEnoughElementsOnStack => "stack does not have enough elements",
-			Error::InvalidOperand => "invalid operand to a script operation",
-			#[cfg(feature = "bitcoinconsensus")]
-			Error::BitcoinConsensus(ref _n) => "bitcoinconsensus verification failed",
-			#[cfg(feature = "bitcoinconsensus")]
-			Error::UnknownSpentOutput(ref _point) => "unknown spent output Transaction::verify()",
-			#[cfg(feature = "bitcoinconsensus")]
-			Error::SerializationError =>
-				"can not serialize the spending transaction in Transaction::verify()",
-		};
-		f.write_str(str)
-	}
 }
 
 #[cfg(feature = "std")]

--- a/libs/chainscript/src/error.rs
+++ b/libs/chainscript/src/error.rs
@@ -46,6 +46,8 @@ pub enum Error {
     PubkeyFormat,
     /// Push data too large.
     PushSize,
+    /// Non-push operation present in context where only data push opcodes are allowed.
+    PushOnly,
     /// Maximum script size exceeded.
     ScriptSize,
     /// Incorrect number of public keys for multisig

--- a/libs/chainscript/src/error.rs
+++ b/libs/chainscript/src/error.rs
@@ -25,6 +25,16 @@ pub enum Error {
 	SignatureFormat,
 	/// Pubkey is not in correct format.
 	PubkeyFormat,
+	/// Push data too large.
+	PushSize,
+	/// Maximum script size exceeded.
+	ScriptSize,
+	/// Incorrect number of public keys for multisig
+	PubkeyCount,
+	/// Incorrect number of signatures for multisig
+	SigCount,
+	/// Multisig lacks extra 0 dummy.
+	NullDummy,
 	#[cfg(feature = "bitcoinconsensus")]
 	/// Error validating the script with bitcoinconsensus library
 	BitcoinConsensus(bitcoinconsensus::Error),

--- a/libs/chainscript/src/error.rs
+++ b/libs/chainscript/src/error.rs
@@ -54,28 +54,9 @@ pub enum Error {
 	SigCount,
 	/// Multisig lacks extra 0 dummy.
 	NullDummy,
-	#[cfg(feature = "bitcoinconsensus")]
-	/// Error validating the script with bitcoinconsensus library
-	BitcoinConsensus(bitcoinconsensus::Error),
-	#[cfg(feature = "bitcoinconsensus")]
-	/// Can not find the spent output
-	UnknownSpentOutput(OutPoint),
-	#[cfg(feature = "bitcoinconsensus")]
-	/// Can not serialize the spending transaction
-	SerializationError,
 }
 
 #[cfg(feature = "std")]
 impl ::std::error::Error for Error {}
-
-#[cfg(feature = "bitcoinconsensus")]
-#[doc(hidden)]
-impl From<bitcoinconsensus::Error> for Error {
-	fn from(err: bitcoinconsensus::Error) -> Error {
-		match err {
-			_ => Error::BitcoinConsensus(err),
-		}
-	}
-}
 
 pub type Result<T> = core::result::Result<T, Error>;

--- a/libs/chainscript/src/error.rs
+++ b/libs/chainscript/src/error.rs
@@ -40,6 +40,8 @@ pub enum Error {
     InvalidOperand,
     /// OP_*VERIFY failed verification or OP_RETURN was executed.
     VerifyFail,
+    /// Stack not clean after a script run.
+    StackNotClean,
     /// Signature is not in correct format.
     SignatureFormat,
     /// Pubkey is not in correct format.

--- a/libs/chainscript/src/error.rs
+++ b/libs/chainscript/src/error.rs
@@ -24,36 +24,36 @@ use displaydoc::Display;
 /// would help you.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy, Display)]
 pub enum Error {
-	/// Something did a non-minimal push
-	NonMinimalPush,
-	/// Some opcode expected a parameter, but it was missing or truncated
-	EarlyEndOfScript,
-	/// Tried to read an array off the stack as a number when it was more than 4 bytes
-	NumericOverflow,
-	/// Illegal instruction executed
-	IllegalOp,
-	/// Syntactically incorrect OP_(NOT)IF/OP_ELSE/OP_ENDIF
-	UnbalancedIfElse,
-	/// Stack has insufficient number of elements in it
-	NotEnoughElementsOnStack,
-	/// Invalid operand to a script operation.
-	InvalidOperand,
-	/// OP_*VERIFY failed verification or OP_RETURN was executed.
-	VerifyFail,
-	/// Signature is not in correct format.
-	SignatureFormat,
-	/// Pubkey is not in correct format.
-	PubkeyFormat,
-	/// Push data too large.
-	PushSize,
-	/// Maximum script size exceeded.
-	ScriptSize,
-	/// Incorrect number of public keys for multisig
-	PubkeyCount,
-	/// Incorrect number of signatures for multisig
-	SigCount,
-	/// Multisig lacks extra 0 dummy.
-	NullDummy,
+    /// Something did a non-minimal push
+    NonMinimalPush,
+    /// Some opcode expected a parameter, but it was missing or truncated
+    EarlyEndOfScript,
+    /// Tried to read an array off the stack as a number when it was more than 4 bytes
+    NumericOverflow,
+    /// Illegal instruction executed
+    IllegalOp,
+    /// Syntactically incorrect OP_(NOT)IF/OP_ELSE/OP_ENDIF
+    UnbalancedIfElse,
+    /// Stack has insufficient number of elements in it
+    NotEnoughElementsOnStack,
+    /// Invalid operand to a script operation.
+    InvalidOperand,
+    /// OP_*VERIFY failed verification or OP_RETURN was executed.
+    VerifyFail,
+    /// Signature is not in correct format.
+    SignatureFormat,
+    /// Pubkey is not in correct format.
+    PubkeyFormat,
+    /// Push data too large.
+    PushSize,
+    /// Maximum script size exceeded.
+    ScriptSize,
+    /// Incorrect number of public keys for multisig
+    PubkeyCount,
+    /// Incorrect number of signatures for multisig
+    SigCount,
+    /// Multisig lacks extra 0 dummy.
+    NullDummy,
 }
 
 #[cfg(feature = "std")]

--- a/libs/chainscript/src/error.rs
+++ b/libs/chainscript/src/error.rs
@@ -12,6 +12,14 @@ pub enum Error {
 	EarlyEndOfScript,
 	/// Tried to read an array off the stack as a number when it was more than 4 bytes
 	NumericOverflow,
+	/// Illegal instruction executed
+	IllegalOp,
+	/// Syntactically inforrect OP_(NOT)IF/OP_ELSE/OP_ENDIF
+	UnbalancedIfElse,
+	/// Stack has insufficient number of elements in it
+	NotEnoughElementsOnStack,
+	/// Invalid operand to a script operation.
+	InvalidOperand,
 	#[cfg(feature = "bitcoinconsensus")]
 	/// Error validating the script with bitcoinconsensus library
 	BitcoinConsensus(bitcoinconsensus::Error),
@@ -29,6 +37,10 @@ impl fmt::Display for Error {
 			Error::NonMinimalPush => "non-minimal datapush",
 			Error::EarlyEndOfScript => "unexpected end of script",
 			Error::NumericOverflow => "numeric overflow (number on stack larger than 4 bytes)",
+			Error::IllegalOp => "illegal script operation executed",
+			Error::UnbalancedIfElse => "OP_IF/OP_NOTIF/OP_ELSE/OP_ENDIF not syntactically correct",
+			Error::NotEnoughElementsOnStack => "stack does not have enough elements",
+			Error::InvalidOperand => "invalid operand to a script operation",
 			#[cfg(feature = "bitcoinconsensus")]
 			Error::BitcoinConsensus(ref _n) => "bitcoinconsensus verification failed",
 			#[cfg(feature = "bitcoinconsensus")]

--- a/libs/chainscript/src/error.rs
+++ b/libs/chainscript/src/error.rs
@@ -1,3 +1,22 @@
+// Copyright (c) 2021 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): L. Kuklinek
+
+//! Listing of all the error states
+
 use displaydoc::Display;
 
 /// Ways that a script might fail. Not everything is split up as

--- a/libs/chainscript/src/interpreter.rs
+++ b/libs/chainscript/src/interpreter.rs
@@ -18,11 +18,11 @@
 //! Chain script interpreter
 
 use crate::{
-	context::Context,
-	error::Error,
-	opcodes,
-	script::{self, Instruction, Script},
-	util,
+    context::Context,
+    error::Error,
+    opcodes,
+    script::{self, Instruction, Script},
+    util,
 };
 use frame_support::ensure;
 use sp_std::{borrow::Cow, cmp, ops, ops::Range, prelude::*};
@@ -38,695 +38,698 @@ type Item<'a> = Cow<'a, [u8]>;
 pub struct Stack<'a>(Vec<Item<'a>>);
 
 impl<'a> Stack<'a> {
-	/// Get stack length.
-	fn len(&self) -> usize {
-		self.0.len()
-	}
+    /// Get stack length.
+    fn len(&self) -> usize {
+        self.0.len()
+    }
 
-	/// Check the stack has at least given number of elements and return the length.
-	fn at_least(&self, num: usize) -> crate::Result<usize> {
-		Some(self.len()).filter(|&l| l >= num).ok_or(Error::NotEnoughElementsOnStack)
-	}
+    /// Check the stack has at least given number of elements and return the length.
+    fn at_least(&self, num: usize) -> crate::Result<usize> {
+        Some(self.len()).filter(|&l| l >= num).ok_or(Error::NotEnoughElementsOnStack)
+    }
 
-	/// Pop an item off of the stack.
-	fn pop(&mut self) -> crate::Result<Item<'a>> {
-		self.0.pop().ok_or(Error::NotEnoughElementsOnStack)
-	}
+    /// Pop an item off of the stack.
+    fn pop(&mut self) -> crate::Result<Item<'a>> {
+        self.0.pop().ok_or(Error::NotEnoughElementsOnStack)
+    }
 
-	/// Pop an item of the top of the stack and convert it to bool.
-	fn pop_bool(&mut self) -> crate::Result<bool> {
-		Ok(script::read_scriptbool(&self.pop()?))
-	}
+    /// Pop an item of the top of the stack and convert it to bool.
+    fn pop_bool(&mut self) -> crate::Result<bool> {
+        Ok(script::read_scriptbool(&self.pop()?))
+    }
 
-	/// Pop an item off the stack and convert it to int.
-	fn pop_int(&mut self) -> crate::Result<i64> {
-		script::read_scriptint(&self.pop()?)
-	}
+    /// Pop an item off the stack and convert it to int.
+    fn pop_int(&mut self) -> crate::Result<i64> {
+        script::read_scriptint(&self.pop()?)
+    }
 
-	/// Push an item onto the stack.
-	fn push(&mut self, item: Item<'a>) {
-		self.0.push(item)
-	}
+    /// Push an item onto the stack.
+    fn push(&mut self, item: Item<'a>) {
+        self.0.push(item)
+    }
 
-	/// Push a boolean item onto the stack.
-	fn push_bool(&mut self, b: bool) {
-		self.push_int(b as i64);
-	}
+    /// Push a boolean item onto the stack.
+    fn push_bool(&mut self, b: bool) {
+        self.push_int(b as i64);
+    }
 
-	/// Push an integer item onto the stack.
-	fn push_int(&mut self, x: i64) {
-		self.push(script::build_scriptint(x).into());
-	}
+    /// Push an integer item onto the stack.
+    fn push_int(&mut self, x: i64) {
+        self.push(script::build_scriptint(x).into());
+    }
 
-	/// Get an element at given position from the top of the stack.
-	pub fn top(&self, idx: usize) -> crate::Result<&Item<'a>> {
-		self.at_least(idx + 1).map(|len| &self.0[len - idx - 1])
-	}
+    /// Get an element at given position from the top of the stack.
+    pub fn top(&self, idx: usize) -> crate::Result<&Item<'a>> {
+        self.at_least(idx + 1).map(|len| &self.0[len - idx - 1])
+    }
 
-	/// Map range counting from the top of the stack to the internal vector indexing.
-	fn top_range(&self, r: Range<usize>) -> crate::Result<Range<usize>> {
-		self.at_least(r.end).map(|len| (len - r.end)..(len - r.start))
-	}
+    /// Map range counting from the top of the stack to the internal vector indexing.
+    fn top_range(&self, r: Range<usize>) -> crate::Result<Range<usize>> {
+        self.at_least(r.end).map(|len| (len - r.end)..(len - r.start))
+    }
 
-	/// Take a slice of the top of the stack.
-	fn top_slice(&self, r: Range<usize>) -> crate::Result<&[Item<'a>]> {
-		Ok(&self.0[self.top_range(r)?])
-	}
+    /// Take a slice of the top of the stack.
+    fn top_slice(&self, r: Range<usize>) -> crate::Result<&[Item<'a>]> {
+        Ok(&self.0[self.top_range(r)?])
+    }
 
-	/// Take a mutable slice of the top of the stack.
-	fn top_slice_mut(&mut self, r: Range<usize>) -> crate::Result<&mut [Item<'a>]> {
-		let i = self.top_range(r)?;
-		Ok(&mut self.0[i])
-	}
+    /// Take a mutable slice of the top of the stack.
+    fn top_slice_mut(&mut self, r: Range<usize>) -> crate::Result<&mut [Item<'a>]> {
+        let i = self.top_range(r)?;
+        Ok(&mut self.0[i])
+    }
 
-	/// Drop given number of elements
-	fn drop(&mut self, num_drop: usize) -> crate::Result<()> {
-		let len = self.at_least(num_drop)?;
-		self.0.truncate(len - num_drop);
-		Ok(())
-	}
+    /// Drop given number of elements
+    fn drop(&mut self, num_drop: usize) -> crate::Result<()> {
+        let len = self.at_least(num_drop)?;
+        self.0.truncate(len - num_drop);
+        Ok(())
+    }
 
-	/// Duplicate slice indexed from the top of the stack. The new items are added to the top of
-	/// the stack.
-	fn dup(&mut self, r: Range<usize>) -> crate::Result<()> {
-		self.top_range(r).map(|i| self.0.extend_from_within(i))
-	}
+    /// Duplicate slice indexed from the top of the stack. The new items are added to the top of
+    /// the stack.
+    fn dup(&mut self, r: Range<usize>) -> crate::Result<()> {
+        self.top_range(r).map(|i| self.0.extend_from_within(i))
+    }
 
-	/// Swap the top `n` elements with the next `n` elements on the stack.
-	fn swap(&mut self, n: usize) -> crate::Result<()> {
-		let (top, next) = self.top_slice_mut(0..(2 * n))?.split_at_mut(n);
-		top.swap_with_slice(next);
-		Ok(())
-	}
+    /// Swap the top `n` elements with the next `n` elements on the stack.
+    fn swap(&mut self, n: usize) -> crate::Result<()> {
+        let (top, next) = self.top_slice_mut(0..(2 * n))?.split_at_mut(n);
+        top.swap_with_slice(next);
+        Ok(())
+    }
 
-	/// Remove `n`-th element, counting from the top of the stack.
-	fn remove(&mut self, n: usize) -> crate::Result<Item<'a>> {
-		let len = self.at_least(n + 1)?;
-		Ok(self.0.remove(len - n - 1))
-	}
+    /// Remove `n`-th element, counting from the top of the stack.
+    fn remove(&mut self, n: usize) -> crate::Result<Item<'a>> {
+        let len = self.at_least(n + 1)?;
+        Ok(self.0.remove(len - n - 1))
+    }
 }
 
 /// Execution stack keeps track of masks of IF/ELSE branches being executed.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct ExecStack {
-	stack: Vec<bool>,
-	num_idle: usize,
+    stack: Vec<bool>,
+    num_idle: usize,
 }
 
 impl ExecStack {
-	/// Push mask onto the stack. Executing: true, not executing: false.
-	fn push(&mut self, executing: bool) {
-		self.stack.push(executing);
-		self.num_idle += (!executing) as usize;
-	}
+    /// Push mask onto the stack. Executing: true, not executing: false.
+    fn push(&mut self, executing: bool) {
+        self.stack.push(executing);
+        self.num_idle += (!executing) as usize;
+    }
 
-	/// Pop the top item off the stack.
-	fn pop(&mut self) -> Option<bool> {
-		let executing = self.stack.pop()?;
-		self.num_idle -= (!executing) as usize;
-		Some(executing)
-	}
+    /// Pop the top item off the stack.
+    fn pop(&mut self) -> Option<bool> {
+        let executing = self.stack.pop()?;
+        self.num_idle -= (!executing) as usize;
+        Some(executing)
+    }
 
-	/// Check if we are currently executing, i.e. no branch is masked out.
-	fn executing(&self) -> bool {
-		self.num_idle == 0
-	}
+    /// Check if we are currently executing, i.e. no branch is masked out.
+    fn executing(&self) -> bool {
+        self.num_idle == 0
+    }
 
-	/// Check the execution stack is empty, i.e. we are not inside of a conditional.
-	fn is_empty(&self) -> bool {
-		self.stack.is_empty()
-	}
+    /// Check the execution stack is empty, i.e. we are not inside of a conditional.
+    fn is_empty(&self) -> bool {
+        self.stack.is_empty()
+    }
 }
 
 impl<'a> From<Vec<Item<'a>>> for Stack<'a> {
-	fn from(items: Vec<Item<'a>>) -> Self {
-		Self(items)
-	}
+    fn from(items: Vec<Item<'a>>) -> Self {
+        Self(items)
+    }
 }
 
 /// Run given script with given initial stack.
 ///
 /// Consumes the stack. Returns either an error or the final stack.
 pub fn run_script<'a, Ctx: Context>(
-	ctx: &Ctx,
-	script: &'a Script,
-	mut stack: Stack<'a>,
+    ctx: &Ctx,
+    script: &'a Script,
+    mut stack: Stack<'a>,
 ) -> crate::Result<Stack<'a>> {
-	if script.len() > Ctx::MAX_SCRIPT_SIZE {
-		return Err(Error::ScriptSize)
-	}
+    if script.len() > Ctx::MAX_SCRIPT_SIZE {
+        return Err(Error::ScriptSize);
+    }
 
-	let mut instr_iter = script.instructions_iter(ctx.enforce_minimal_push());
-	let mut subscript: &[u8] = instr_iter.subscript();
-	let mut exec_stack = ExecStack::default();
-	let mut alt_stack = Stack::<'a>::default();
+    let mut instr_iter = script.instructions_iter(ctx.enforce_minimal_push());
+    let mut subscript: &[u8] = instr_iter.subscript();
+    let mut exec_stack = ExecStack::default();
+    let mut alt_stack = Stack::<'a>::default();
 
-	while let Some(instr) = instr_iter.next() {
-		let instr = instr?;
+    while let Some(instr) = instr_iter.next() {
+        let instr = instr?;
 
-		let executing = exec_stack.executing();
-		match instr {
-			Instruction::PushBytes(data) => {
-				ensure!(data.len() <= Ctx::MAX_SCRIPT_ELEMENT_SIZE, Error::PushSize);
-				if executing {
-					stack.push(data.into());
-				}
-			},
-			Instruction::Op(opcode) => match opcode.classify() {
-				opcodes::Class::NoOp => (),
-				opcodes::Class::IllegalOp => return Err(Error::IllegalOp),
-				opcodes::Class::ReturnOp if executing => return Err(Error::VerifyFail),
-				opcodes::Class::PushNum(x) if executing => stack.push_int(x as i64),
-				opcodes::Class::PushBytes(_) => {
-					unreachable!("Already handled using Instruction::PushBytes")
-				},
-				opcodes::Class::PushData(_) => {
-					unreachable!("Already handled using Instruction::PushBytes")
-				},
-				opcodes::Class::AltStack(opc) => match opc {
-					opcodes::AltStack::OP_TOALTSTACK => alt_stack.push(stack.pop()?),
-					opcodes::AltStack::OP_FROMALTSTACK => stack.push(alt_stack.pop()?),
-				},
-				opcodes::Class::Signature(sig_opcode) => {
-					match sig_opcode {
-						opcodes::Signature::OP_CODESEPARATOR => subscript = instr_iter.subscript(),
-						opcodes::Signature::OP_CHECKSIG | opcodes::Signature::OP_CHECKSIGVERIFY => {
-							let pubkey = stack.pop()?;
-							let sig = stack.pop()?;
-							// Treat plain CHECKSIG as 1-of-1 MULTISIG
-							let result = check_multisig(
-								ctx,
-								core::iter::once(sig.as_ref()),
-								core::iter::once(pubkey.as_ref()),
-								subscript,
-							)?;
-							stack.push_bool(result);
-						},
-						opcodes::Signature::OP_CHECKMULTISIG |
-						opcodes::Signature::OP_CHECKMULTISIGVERIFY => {
-							// Extract keys
-							let nkey = stack.pop_int()?;
-							ensure!(nkey >= 0, Error::PubkeyCount);
-							let nkey = nkey as usize;
-							ensure!(nkey <= Ctx::MAX_PUBKEYS_PER_MULTISIG, Error::PubkeyCount);
-							let keys = stack.top_slice(0..nkey)?.iter().map(AsRef::as_ref);
+        let executing = exec_stack.executing();
+        match instr {
+            Instruction::PushBytes(data) => {
+                ensure!(data.len() <= Ctx::MAX_SCRIPT_ELEMENT_SIZE, Error::PushSize);
+                if executing {
+                    stack.push(data.into());
+                }
+            }
+            Instruction::Op(opcode) => match opcode.classify() {
+                opcodes::Class::NoOp => (),
+                opcodes::Class::IllegalOp => return Err(Error::IllegalOp),
+                opcodes::Class::ReturnOp if executing => return Err(Error::VerifyFail),
+                opcodes::Class::PushNum(x) if executing => stack.push_int(x as i64),
+                opcodes::Class::PushBytes(_) => {
+                    unreachable!("Already handled using Instruction::PushBytes")
+                }
+                opcodes::Class::PushData(_) => {
+                    unreachable!("Already handled using Instruction::PushBytes")
+                }
+                opcodes::Class::AltStack(opc) => match opc {
+                    opcodes::AltStack::OP_TOALTSTACK => alt_stack.push(stack.pop()?),
+                    opcodes::AltStack::OP_FROMALTSTACK => stack.push(alt_stack.pop()?),
+                },
+                opcodes::Class::Signature(sig_opcode) => {
+                    match sig_opcode {
+                        opcodes::Signature::OP_CODESEPARATOR => subscript = instr_iter.subscript(),
+                        opcodes::Signature::OP_CHECKSIG | opcodes::Signature::OP_CHECKSIGVERIFY => {
+                            let pubkey = stack.pop()?;
+                            let sig = stack.pop()?;
+                            // Treat plain CHECKSIG as 1-of-1 MULTISIG
+                            let result = check_multisig(
+                                ctx,
+                                core::iter::once(sig.as_ref()),
+                                core::iter::once(pubkey.as_ref()),
+                                subscript,
+                            )?;
+                            stack.push_bool(result);
+                        }
+                        opcodes::Signature::OP_CHECKMULTISIG
+                        | opcodes::Signature::OP_CHECKMULTISIGVERIFY => {
+                            // Extract keys
+                            let nkey = stack.pop_int()?;
+                            ensure!(nkey >= 0, Error::PubkeyCount);
+                            let nkey = nkey as usize;
+                            ensure!(nkey <= Ctx::MAX_PUBKEYS_PER_MULTISIG, Error::PubkeyCount);
+                            let keys = stack.top_slice(0..nkey)?.iter().map(AsRef::as_ref);
 
-							// Extract signatures
-							let nsig = script::read_scriptint(stack.top(nkey)?)?;
-							ensure!(nsig >= 0, Error::SigCount);
-							let nsig = nsig as usize;
-							ensure!(nsig <= nkey, Error::SigCount);
-							let sig_range = (nkey + 1)..(nsig + nkey + 1);
-							let sigs = stack.top_slice(sig_range)?.iter().map(AsRef::as_ref);
+                            // Extract signatures
+                            let nsig = script::read_scriptint(stack.top(nkey)?)?;
+                            ensure!(nsig >= 0, Error::SigCount);
+                            let nsig = nsig as usize;
+                            ensure!(nsig <= nkey, Error::SigCount);
+                            let sig_range = (nkey + 1)..(nsig + nkey + 1);
+                            let sigs = stack.top_slice(sig_range)?.iter().map(AsRef::as_ref);
 
-							// Verify
-							let result = check_multisig(ctx, sigs, keys, subscript)?;
+                            // Verify
+                            let result = check_multisig(ctx, sigs, keys, subscript)?;
 
-							// Clean up stack, ensure! dummy 0.
-							stack.drop(nsig + nkey + 1)?;
-							if !stack.pop()?.is_empty() {
-								return Err(Error::NullDummy)
-							}
-							stack.push_bool(result);
-						},
-					}
-					ensure!(!sig_opcode.is_verify() || stack.pop_bool()?, Error::VerifyFail);
-				},
-				opcodes::Class::ControlFlow(cf) => match cf {
-					opcodes::ControlFlow::OP_IF | opcodes::ControlFlow::OP_NOTIF => {
-						let cond = executing && {
-							let cond = match stack.pop()?.as_ref() {
-								c if !ctx.enforce_minimal_if() => script::read_scriptbool(c),
-								&[] => false,
-								&[1u8] => true,
-								_ => return Err(Error::InvalidOperand),
-							};
-							cond ^ (cf == opcodes::ControlFlow::OP_NOTIF)
-						};
-						exec_stack.push(cond);
-					},
-					opcodes::ControlFlow::OP_ELSE => {
-						let top_executing = exec_stack.pop().ok_or(Error::UnbalancedIfElse)?;
-						exec_stack.push(!top_executing);
-					},
-					opcodes::ControlFlow::OP_ENDIF => {
-						let _ = exec_stack.pop().ok_or(Error::UnbalancedIfElse)?;
-					},
-				},
-				opcodes::Class::Ordinary(opcode) if executing => {
-					execute_opcode(opcode, &mut stack)?;
-				},
-				_ => (),
-			},
-		}
-	}
+                            // Clean up stack, ensure! dummy 0.
+                            stack.drop(nsig + nkey + 1)?;
+                            if !stack.pop()?.is_empty() {
+                                return Err(Error::NullDummy);
+                            }
+                            stack.push_bool(result);
+                        }
+                    }
+                    ensure!(
+                        !sig_opcode.is_verify() || stack.pop_bool()?,
+                        Error::VerifyFail
+                    );
+                }
+                opcodes::Class::ControlFlow(cf) => match cf {
+                    opcodes::ControlFlow::OP_IF | opcodes::ControlFlow::OP_NOTIF => {
+                        let cond = executing && {
+                            let cond = match stack.pop()?.as_ref() {
+                                c if !ctx.enforce_minimal_if() => script::read_scriptbool(c),
+                                &[] => false,
+                                &[1u8] => true,
+                                _ => return Err(Error::InvalidOperand),
+                            };
+                            cond ^ (cf == opcodes::ControlFlow::OP_NOTIF)
+                        };
+                        exec_stack.push(cond);
+                    }
+                    opcodes::ControlFlow::OP_ELSE => {
+                        let top_executing = exec_stack.pop().ok_or(Error::UnbalancedIfElse)?;
+                        exec_stack.push(!top_executing);
+                    }
+                    opcodes::ControlFlow::OP_ENDIF => {
+                        let _ = exec_stack.pop().ok_or(Error::UnbalancedIfElse)?;
+                    }
+                },
+                opcodes::Class::Ordinary(opcode) if executing => {
+                    execute_opcode(opcode, &mut stack)?;
+                }
+                _ => (),
+            },
+        }
+    }
 
-	// Check OP_IF/OP_NOTIF has been closed properly wiht OP_ENDIF.
-	if !exec_stack.is_empty() {
-		return Err(Error::UnbalancedIfElse)
-	}
+    // Check OP_IF/OP_NOTIF has been closed properly wiht OP_ENDIF.
+    if !exec_stack.is_empty() {
+        return Err(Error::UnbalancedIfElse);
+    }
 
-	Ok(stack)
+    Ok(stack)
 }
 
 /// Check whether given signatures are valid for given pubkeys.
 /// Some pubkeys may not have signatures to go with them.
 fn check_multisig<'a, Ctx: Context>(
-	ctx: &Ctx,
-	mut sigs: impl Iterator<Item = &'a [u8]> + ExactSizeIterator,
-	mut pubkeys: impl Iterator<Item = &'a [u8]> + ExactSizeIterator,
-	subscript: &[u8],
+    ctx: &Ctx,
+    mut sigs: impl Iterator<Item = &'a [u8]> + ExactSizeIterator,
+    mut pubkeys: impl Iterator<Item = &'a [u8]> + ExactSizeIterator,
+    subscript: &[u8],
 ) -> crate::Result<bool> {
-	// Check each signature has its corresponding pubkey.
-	while let Some(sig) = sigs.next() {
-		let sig = ctx.parse_signature(sig).ok_or(Error::SignatureFormat)?;
-		let txhash = ctx.hash_transaction(&sig, subscript);
-		// Find pubkey matching this signature.
-		loop {
-			if pubkeys.len() < sigs.len() + 1 {
-				// Not enough pubkeys to cover all the remaining signatures.
-				// We add 1 to the number of signatures left in the condition to account for the
-				// signature being processed that has just been taken out of the iterator.
-				return Ok(false)
-			}
-			let pubkey = ctx.parse_pubkey(pubkeys.next().unwrap()).ok_or(Error::PubkeyFormat)?;
-			if ctx.verify_signature(&sig, &pubkey, &txhash) {
-				break
-			}
-		}
-	}
-	Ok(true)
+    // Check each signature has its corresponding pubkey.
+    while let Some(sig) = sigs.next() {
+        let sig = ctx.parse_signature(sig).ok_or(Error::SignatureFormat)?;
+        let txhash = ctx.hash_transaction(&sig, subscript);
+        // Find pubkey matching this signature.
+        loop {
+            if pubkeys.len() < sigs.len() + 1 {
+                // Not enough pubkeys to cover all the remaining signatures.
+                // We add 1 to the number of signatures left in the condition to account for the
+                // signature being processed that has just been taken out of the iterator.
+                return Ok(false);
+            }
+            let pubkey = ctx.parse_pubkey(pubkeys.next().unwrap()).ok_or(Error::PubkeyFormat)?;
+            if ctx.verify_signature(&sig, &pubkey, &txhash) {
+                break;
+            }
+        }
+    }
+    Ok(true)
 }
 
 /// Execute an ["ordinay"](opcodes::Ordinary) opcode.
 fn execute_opcode(opcode: opcodes::Ordinary, stack: &mut Stack<'_>) -> crate::Result<()> {
-	use opcodes::Ordinary as Opc;
+    use opcodes::Ordinary as Opc;
 
-	match opcode {
-		// Verify. Do nothing now, the actual verification is handled below this match statement.
-		Opc::OP_VERIFY => (),
+    match opcode {
+        // Verify. Do nothing now, the actual verification is handled below this match statement.
+        Opc::OP_VERIFY => (),
 
-		// Main stack manipulation
-		Opc::OP_DROP => stack.drop(1)?,
-		Opc::OP_2DROP => stack.drop(2)?,
-		Opc::OP_DUP => stack.dup(0..1)?,
-		Opc::OP_2DUP => stack.dup(0..2)?,
-		Opc::OP_3DUP => stack.dup(0..3)?,
-		Opc::OP_OVER => stack.dup(1..2)?,
-		Opc::OP_2OVER => stack.dup(2..4)?,
-		Opc::OP_SWAP => stack.swap(1)?,
-		Opc::OP_2SWAP => stack.swap(2)?,
-		Opc::OP_2ROT => {
-			let top = stack.top_slice_mut(0..6)?;
-			let nth = |n: usize| top[n].clone();
-			let to_put = [nth(2), nth(3), nth(4), nth(5), nth(0), nth(1)];
-			top.clone_from_slice(&to_put);
-		},
-		Opc::OP_NIP => {
-			let x = stack.pop()?;
-			let _ = stack.pop()?;
-			stack.push(x);
-		},
-		Opc::OP_PICK => {
-			let i = stack.pop_int()?;
-			ensure!(i >= 0, Error::InvalidOperand);
-			stack.push(stack.top(i as usize)?.clone());
-		},
-		Opc::OP_ROLL => {
-			let i = stack.pop_int()?;
-			ensure!(i >= 0, Error::InvalidOperand);
-			let x = stack.remove(i as usize)?;
-			stack.push(x);
-		},
-		Opc::OP_ROT => {
-			let x = stack.remove(2)?;
-			stack.push(x);
-		},
-		Opc::OP_TUCK => {
-			let x = stack.top(0)?.clone();
-			stack.swap(1)?;
-			stack.push(x);
-		},
-		Opc::OP_IFDUP => {
-			let item = stack.top(0)?;
-			if script::read_scriptbool(item) {
-				let item_clone = item.clone();
-				stack.push(item_clone);
-			}
-		},
-		Opc::OP_DEPTH => {
-			ensure!(stack.len() < i32::MAX as usize, Error::NumericOverflow);
-			stack.push_int(stack.len() as i64);
-		},
+        // Main stack manipulation
+        Opc::OP_DROP => stack.drop(1)?,
+        Opc::OP_2DROP => stack.drop(2)?,
+        Opc::OP_DUP => stack.dup(0..1)?,
+        Opc::OP_2DUP => stack.dup(0..2)?,
+        Opc::OP_3DUP => stack.dup(0..3)?,
+        Opc::OP_OVER => stack.dup(1..2)?,
+        Opc::OP_2OVER => stack.dup(2..4)?,
+        Opc::OP_SWAP => stack.swap(1)?,
+        Opc::OP_2SWAP => stack.swap(2)?,
+        Opc::OP_2ROT => {
+            let top = stack.top_slice_mut(0..6)?;
+            let nth = |n: usize| top[n].clone();
+            let to_put = [nth(2), nth(3), nth(4), nth(5), nth(0), nth(1)];
+            top.clone_from_slice(&to_put);
+        }
+        Opc::OP_NIP => {
+            let x = stack.pop()?;
+            let _ = stack.pop()?;
+            stack.push(x);
+        }
+        Opc::OP_PICK => {
+            let i = stack.pop_int()?;
+            ensure!(i >= 0, Error::InvalidOperand);
+            stack.push(stack.top(i as usize)?.clone());
+        }
+        Opc::OP_ROLL => {
+            let i = stack.pop_int()?;
+            ensure!(i >= 0, Error::InvalidOperand);
+            let x = stack.remove(i as usize)?;
+            stack.push(x);
+        }
+        Opc::OP_ROT => {
+            let x = stack.remove(2)?;
+            stack.push(x);
+        }
+        Opc::OP_TUCK => {
+            let x = stack.top(0)?.clone();
+            stack.swap(1)?;
+            stack.push(x);
+        }
+        Opc::OP_IFDUP => {
+            let item = stack.top(0)?;
+            if script::read_scriptbool(item) {
+                let item_clone = item.clone();
+                stack.push(item_clone);
+            }
+        }
+        Opc::OP_DEPTH => {
+            ensure!(stack.len() < i32::MAX as usize, Error::NumericOverflow);
+            stack.push_int(stack.len() as i64);
+        }
 
-		// Stack item queries
-		Opc::OP_SIZE => {
-			let top_len = stack.top(0)?.len();
-			ensure!(top_len < i32::MAX as usize, Error::NumericOverflow);
-			stack.push_int(top_len as i64);
-		},
-		Opc::OP_EQUAL | Opc::OP_EQUALVERIFY => {
-			let y = stack.pop()?;
-			let x = stack.pop()?;
-			stack.push_bool(x == y);
-		},
+        // Stack item queries
+        Opc::OP_SIZE => {
+            let top_len = stack.top(0)?.len();
+            ensure!(top_len < i32::MAX as usize, Error::NumericOverflow);
+            stack.push_int(top_len as i64);
+        }
+        Opc::OP_EQUAL | Opc::OP_EQUALVERIFY => {
+            let y = stack.pop()?;
+            let x = stack.pop()?;
+            stack.push_bool(x == y);
+        }
 
-		// Arithmetic
-		Opc::OP_1ADD => op_num1(stack, |x| x + 1)?,
-		Opc::OP_1SUB => op_num1(stack, |x| x - 1)?,
-		Opc::OP_NEGATE => op_num1(stack, ops::Neg::neg)?,
-		Opc::OP_ABS => op_num1(stack, i64::abs)?,
-		Opc::OP_NOT => op_num1(stack, |x| (x == 0) as i64)?,
-		Opc::OP_0NOTEQUAL => op_num1(stack, |x| (x != 0) as i64)?,
-		Opc::OP_ADD => op_num2(stack, ops::Add::add)?,
-		Opc::OP_SUB => op_num2(stack, ops::Sub::sub)?,
-		Opc::OP_BOOLAND => op_num2(stack, |x, y| (x != 0 && y != 0) as i64)?,
-		Opc::OP_BOOLOR => op_num2(stack, |x, y| (x != 0 || y != 0) as i64)?,
-		Opc::OP_NUMEQUAL | Opc::OP_NUMEQUALVERIFY => op_num2(stack, |x, y| (x == y) as i64)?,
-		Opc::OP_NUMNOTEQUAL => op_num2(stack, |x, y| (x != y) as i64)?,
-		Opc::OP_LESSTHAN => op_num2(stack, |x, y| (x < y) as i64)?,
-		Opc::OP_GREATERTHAN => op_num2(stack, |x, y| (x > y) as i64)?,
-		Opc::OP_LESSTHANOREQUAL => op_num2(stack, |x, y| (x <= y) as i64)?,
-		Opc::OP_GREATERTHANOREQUAL => op_num2(stack, |x, y| (x >= y) as i64)?,
-		Opc::OP_MIN => op_num2(stack, cmp::min)?,
-		Opc::OP_MAX => op_num2(stack, cmp::max)?,
-		Opc::OP_WITHIN => {
-			let hi = stack.pop_int()?;
-			let lo = stack.pop_int()?;
-			let x = stack.pop_int()?;
-			stack.push_int((lo..hi).contains(&x) as i64);
-		},
+        // Arithmetic
+        Opc::OP_1ADD => op_num1(stack, |x| x + 1)?,
+        Opc::OP_1SUB => op_num1(stack, |x| x - 1)?,
+        Opc::OP_NEGATE => op_num1(stack, ops::Neg::neg)?,
+        Opc::OP_ABS => op_num1(stack, i64::abs)?,
+        Opc::OP_NOT => op_num1(stack, |x| (x == 0) as i64)?,
+        Opc::OP_0NOTEQUAL => op_num1(stack, |x| (x != 0) as i64)?,
+        Opc::OP_ADD => op_num2(stack, ops::Add::add)?,
+        Opc::OP_SUB => op_num2(stack, ops::Sub::sub)?,
+        Opc::OP_BOOLAND => op_num2(stack, |x, y| (x != 0 && y != 0) as i64)?,
+        Opc::OP_BOOLOR => op_num2(stack, |x, y| (x != 0 || y != 0) as i64)?,
+        Opc::OP_NUMEQUAL | Opc::OP_NUMEQUALVERIFY => op_num2(stack, |x, y| (x == y) as i64)?,
+        Opc::OP_NUMNOTEQUAL => op_num2(stack, |x, y| (x != y) as i64)?,
+        Opc::OP_LESSTHAN => op_num2(stack, |x, y| (x < y) as i64)?,
+        Opc::OP_GREATERTHAN => op_num2(stack, |x, y| (x > y) as i64)?,
+        Opc::OP_LESSTHANOREQUAL => op_num2(stack, |x, y| (x <= y) as i64)?,
+        Opc::OP_GREATERTHANOREQUAL => op_num2(stack, |x, y| (x >= y) as i64)?,
+        Opc::OP_MIN => op_num2(stack, cmp::min)?,
+        Opc::OP_MAX => op_num2(stack, cmp::max)?,
+        Opc::OP_WITHIN => {
+            let hi = stack.pop_int()?;
+            let lo = stack.pop_int()?;
+            let x = stack.pop_int()?;
+            stack.push_int((lo..hi).contains(&x) as i64);
+        }
 
-		// Hashes
-		Opc::OP_RIPEMD160 => op_hash(stack, util::ripemd160)?,
-		Opc::OP_SHA1 => op_hash(stack, util::sha1)?,
-		Opc::OP_SHA256 => op_hash(stack, util::sha256)?,
-		Opc::OP_HASH160 => op_hash(stack, util::hash160)?,
-		Opc::OP_HASH256 => op_hash(stack, util::hash256)?,
-	}
+        // Hashes
+        Opc::OP_RIPEMD160 => op_hash(stack, util::ripemd160)?,
+        Opc::OP_SHA1 => op_hash(stack, util::sha1)?,
+        Opc::OP_SHA256 => op_hash(stack, util::sha256)?,
+        Opc::OP_HASH160 => op_hash(stack, util::hash160)?,
+        Opc::OP_HASH256 => op_hash(stack, util::hash256)?,
+    }
 
-	ensure!(!opcode.is_verify() || stack.pop_bool()?, Error::VerifyFail);
-	Ok(())
+    ensure!(!opcode.is_verify() || stack.pop_bool()?, Error::VerifyFail);
+    Ok(())
 }
 
 /// Perform an unary arithmetic operation on the top of the stack.
 fn op_num1(stack: &mut Stack, f: impl FnOnce(i64) -> i64) -> crate::Result<()> {
-	let x = stack.pop_int()?;
-	stack.push_int(f(x));
-	Ok(())
+    let x = stack.pop_int()?;
+    stack.push_int(f(x));
+    Ok(())
 }
 
 /// Perform a binary arithmetic operation on the top of the stack.
 fn op_num2(stack: &mut Stack, f: impl FnOnce(i64, i64) -> i64) -> crate::Result<()> {
-	let y = stack.pop_int()?;
-	let x = stack.pop_int()?;
-	stack.push_int(f(x, y));
-	Ok(())
+    let y = stack.pop_int()?;
+    let x = stack.pop_int()?;
+    stack.push_int(f(x, y));
+    Ok(())
 }
 
 /// Perform a byte-array based function on the top stack item. Useful for hashes.
 fn op_hash<T: AsRef<[u8]>>(stack: &mut Stack, f: impl FnOnce(&[u8]) -> T) -> crate::Result<()> {
-	let result = f(&stack.pop()?);
-	stack.push(Cow::Owned(result.as_ref().to_vec()));
-	Ok(())
+    let result = f(&stack.pop()?);
+    stack.push(Cow::Owned(result.as_ref().to_vec()));
+    Ok(())
 }
 
 #[cfg(test)]
 mod test {
-	use super::*;
-	use crate::{context::testcontext::TestContext, script::Builder};
-	use hex_literal::hex;
-	use proptest::{collection::SizeRange, prelude::*};
+    use super::*;
+    use crate::{context::testcontext::TestContext, script::Builder};
+    use hex_literal::hex;
+    use proptest::{collection::SizeRange, prelude::*};
 
-	#[test]
-	fn unit_exec_stack() {
-		let mut exec_stack = ExecStack::default();
-		assert!(exec_stack.executing());
+    #[test]
+    fn unit_exec_stack() {
+        let mut exec_stack = ExecStack::default();
+        assert!(exec_stack.executing());
 
-		exec_stack.push(true);
-		assert!(exec_stack.executing());
-		exec_stack.push(false);
-		assert!(!exec_stack.executing());
-		exec_stack.push(true);
-		assert!(!exec_stack.executing());
+        exec_stack.push(true);
+        assert!(exec_stack.executing());
+        exec_stack.push(false);
+        assert!(!exec_stack.executing());
+        exec_stack.push(true);
+        assert!(!exec_stack.executing());
 
-		// [true, false, true]
-		let _ = exec_stack.pop();
-		// [true, false]
-		assert!(!exec_stack.executing());
-		let _ = exec_stack.pop();
-		// [true]
-		assert!(exec_stack.executing());
-		let _ = exec_stack.pop();
-		// []
-		assert!(exec_stack.executing());
+        // [true, false, true]
+        let _ = exec_stack.pop();
+        // [true, false]
+        assert!(!exec_stack.executing());
+        let _ = exec_stack.pop();
+        // [true]
+        assert!(exec_stack.executing());
+        let _ = exec_stack.pop();
+        // []
+        assert!(exec_stack.executing());
 
-		assert!(exec_stack.stack.is_empty());
-	}
+        assert!(exec_stack.stack.is_empty());
+    }
 
-	fn testcase_op_verify(update_stack: impl FnOnce(&mut Stack), expected: crate::Result<Stack>) {
-		let script = Builder::new().push_opcode(opcodes::all::OP_VERIFY).into_script();
-		let mut stack = Stack::default();
-		update_stack(&mut stack);
-		let result = run_script(&TestContext::default(), &script, stack);
-		assert_eq!(result, expected);
-	}
+    fn testcase_op_verify(update_stack: impl FnOnce(&mut Stack), expected: crate::Result<Stack>) {
+        let script = Builder::new().push_opcode(opcodes::all::OP_VERIFY).into_script();
+        let mut stack = Stack::default();
+        update_stack(&mut stack);
+        let result = run_script(&TestContext::default(), &script, stack);
+        assert_eq!(result, expected);
+    }
 
-	#[test]
-	fn unit_op_verify_true() {
-		testcase_op_verify(|s| s.push_bool(true), Ok(Stack::default()));
-	}
+    #[test]
+    fn unit_op_verify_true() {
+        testcase_op_verify(|s| s.push_bool(true), Ok(Stack::default()));
+    }
 
-	#[test]
-	fn unit_op_verify_false() {
-		testcase_op_verify(|s| s.push_bool(false), Err(Error::VerifyFail));
-	}
+    #[test]
+    fn unit_op_verify_false() {
+        testcase_op_verify(|s| s.push_bool(false), Err(Error::VerifyFail));
+    }
 
-	#[test]
-	fn unit_op_verify_empty() {
-		testcase_op_verify(|_| (), Err(Error::NotEnoughElementsOnStack));
-	}
+    #[test]
+    fn unit_op_verify_empty() {
+        testcase_op_verify(|_| (), Err(Error::NotEnoughElementsOnStack));
+    }
 
-	#[test]
-	fn unit_if_then_else_syntax() {
-		use opcodes::all::{OP_ELSE, OP_ENDIF, OP_IF, OP_NOTIF};
-		let should_fail = |script: Script| {
-			let stack = Stack(vec![vec![].into(), vec![].into()]);
-			let result = run_script(&TestContext::default(), &script, stack);
-			assert_eq!(result, Err(Error::UnbalancedIfElse));
-		};
-		should_fail(Builder::new().push_opcode(OP_IF).into_script());
-		should_fail(Builder::new().push_opcode(OP_IF).push_opcode(OP_ELSE).into_script());
-		should_fail(Builder::new().push_opcode(OP_IF).push_opcode(OP_NOTIF).into_script());
-		should_fail(Builder::new().push_opcode(OP_ELSE).into_script());
-		should_fail(Builder::new().push_opcode(OP_ENDIF).into_script());
-		should_fail(
-			Builder::new()
-				.push_opcode(OP_IF)
-				.push_opcode(OP_IF)
-				.push_opcode(OP_ELSE)
-				.push_opcode(OP_ENDIF)
-				.into_script(),
-		);
-		should_fail(
-			Builder::new()
-				.push_opcode(OP_IF)
-				.push_opcode(OP_ELSE)
-				.push_opcode(OP_ENDIF)
-				.push_opcode(OP_ENDIF)
-				.into_script(),
-		);
-	}
+    #[test]
+    fn unit_if_then_else_syntax() {
+        use opcodes::all::{OP_ELSE, OP_ENDIF, OP_IF, OP_NOTIF};
+        let should_fail = |script: Script| {
+            let stack = Stack(vec![vec![].into(), vec![].into()]);
+            let result = run_script(&TestContext::default(), &script, stack);
+            assert_eq!(result, Err(Error::UnbalancedIfElse));
+        };
+        should_fail(Builder::new().push_opcode(OP_IF).into_script());
+        should_fail(Builder::new().push_opcode(OP_IF).push_opcode(OP_ELSE).into_script());
+        should_fail(Builder::new().push_opcode(OP_IF).push_opcode(OP_NOTIF).into_script());
+        should_fail(Builder::new().push_opcode(OP_ELSE).into_script());
+        should_fail(Builder::new().push_opcode(OP_ENDIF).into_script());
+        should_fail(
+            Builder::new()
+                .push_opcode(OP_IF)
+                .push_opcode(OP_IF)
+                .push_opcode(OP_ELSE)
+                .push_opcode(OP_ENDIF)
+                .into_script(),
+        );
+        should_fail(
+            Builder::new()
+                .push_opcode(OP_IF)
+                .push_opcode(OP_ELSE)
+                .push_opcode(OP_ENDIF)
+                .push_opcode(OP_ENDIF)
+                .into_script(),
+        );
+    }
 
-	#[test]
-	fn unit_multisig() {
-		let ctx = TestContext::default();
-		let txhash = ctx.hash_transaction(&[0u8; 4], &[]);
-		let sign_by = |pk: [u8; 4]| -> [u8; 4] {
-			[pk[0] ^ txhash[0], pk[1] ^ txhash[1], pk[2] ^ txhash[2], pk[3] ^ txhash[3]]
-		};
+    #[test]
+    fn unit_multisig() {
+        let ctx = TestContext::default();
+        let txhash = ctx.hash_transaction(&[0u8; 4], &[]);
+        let sign_by = |pk: [u8; 4]| -> [u8; 4] {
+            [pk[0] ^ txhash[0], pk[1] ^ txhash[1], pk[2] ^ txhash[2], pk[3] ^ txhash[3]]
+        };
 
-		let keys = [hex!("01010101"), hex!("02020202"), hex!("03030303"), hex!("04040404")];
-		let sig0 = sign_by(hex!("00000000"));
-		let sig1 = sign_by(hex!("01010101"));
-		let sig2 = sign_by(hex!("02020202"));
-		let sig3 = sign_by(hex!("03030303"));
-		let sig4 = sign_by(hex!("04040404"));
+        let keys = [hex!("01010101"), hex!("02020202"), hex!("03030303"), hex!("04040404")];
+        let sig0 = sign_by(hex!("00000000"));
+        let sig1 = sign_by(hex!("01010101"));
+        let sig2 = sign_by(hex!("02020202"));
+        let sig3 = sign_by(hex!("03030303"));
+        let sig4 = sign_by(hex!("04040404"));
 
-		let test_case = |sigs: &[[u8; 4]], expected: crate::Result<bool>| {
-			let result = check_multisig(
-				&ctx,
-				sigs.iter().map(AsRef::as_ref),
-				keys.iter().map(AsRef::as_ref),
-				&[],
-			);
-			assert_eq!(result, expected);
-		};
+        let test_case = |sigs: &[[u8; 4]], expected: crate::Result<bool>| {
+            let result = check_multisig(
+                &ctx,
+                sigs.iter().map(AsRef::as_ref),
+                keys.iter().map(AsRef::as_ref),
+                &[],
+            );
+            assert_eq!(result, expected);
+        };
 
-		// sig0 is not in the set of public keys, this should fail
-		test_case(&[sig1, sig0][..], Ok(false));
-		// This should be fine, sig1 and sig2 in the correct order
-		test_case(&[sig1, sig2][..], Ok(true));
-		// Try first and last
-		test_case(&[sig1, sig4][..], Ok(true));
-		// And last two
-		test_case(&[sig3, sig4][..], Ok(true));
-		// This should fail due to incorrect signature order
-		test_case(&[sig2, sig1][..], Ok(false));
-		// Now with all the signatures.
-		test_case(&[sig1, sig2, sig3, sig4][..], Ok(true));
-		// Duplicate signature should not count as two sigs.
-		test_case(&[sig1, sig1][..], Ok(false));
-		// Last one should fail.
-		test_case(&[sig1, sig2, sig3, sig0][..], Ok(false));
-	}
+        // sig0 is not in the set of public keys, this should fail
+        test_case(&[sig1, sig0][..], Ok(false));
+        // This should be fine, sig1 and sig2 in the correct order
+        test_case(&[sig1, sig2][..], Ok(true));
+        // Try first and last
+        test_case(&[sig1, sig4][..], Ok(true));
+        // And last two
+        test_case(&[sig3, sig4][..], Ok(true));
+        // This should fail due to incorrect signature order
+        test_case(&[sig2, sig1][..], Ok(false));
+        // Now with all the signatures.
+        test_case(&[sig1, sig2, sig3, sig4][..], Ok(true));
+        // Duplicate signature should not count as two sigs.
+        test_case(&[sig1, sig1][..], Ok(false));
+        // Last one should fail.
+        test_case(&[sig1, sig2, sig3, sig0][..], Ok(false));
+    }
 
-	// Generate stack item as an array of bytes
-	fn gen_item_bytes<'a>(num_bytes: Range<usize>) -> impl Strategy<Value = Item<'a>> {
-		prop::collection::vec(prop::num::u8::ANY, num_bytes).prop_map(|v| v.into())
-	}
+    // Generate stack item as an array of bytes
+    fn gen_item_bytes<'a>(num_bytes: Range<usize>) -> impl Strategy<Value = Item<'a>> {
+        prop::collection::vec(prop::num::u8::ANY, num_bytes).prop_map(|v| v.into())
+    }
 
-	// Generate stack with given item generation strategy.
-	fn gen_stack<'a>(
-		gen_item: impl Strategy<Value = Item<'a>>,
-		size: impl Into<SizeRange>,
-	) -> impl Strategy<Value = Stack<'a>> {
-		prop::collection::vec(gen_item, size).prop_map(Stack)
-	}
+    // Generate stack with given item generation strategy.
+    fn gen_stack<'a>(
+        gen_item: impl Strategy<Value = Item<'a>>,
+        size: impl Into<SizeRange>,
+    ) -> impl Strategy<Value = Stack<'a>> {
+        prop::collection::vec(gen_item, size).prop_map(Stack)
+    }
 
-	proptest! {
-		// Interpreter should not panic regardless of its inputs, even garbage.
-		#[test]
-		fn prop_dont_panic(stack in gen_stack(gen_item_bytes(0..40), 0..40),
-						   script: Vec<u8>) {
-			let script: Script = script.into();
-			let _ = run_script(&TestContext::default(), &script, stack);
-		}
+    proptest! {
+        // Interpreter should not panic regardless of its inputs, even garbage.
+        #[test]
+        fn prop_dont_panic(stack in gen_stack(gen_item_bytes(0..40), 0..40),
+                           script: Vec<u8>) {
+            let script: Script = script.into();
+            let _ = run_script(&TestContext::default(), &script, stack);
+        }
 
-		#[test]
-		fn prop_exec_stack_push(items in prop::collection::vec(prop::bool::ANY, 0..9)) {
-			let mut exec_stack = ExecStack::default();
-			items.iter().for_each(|i| exec_stack.push(*i));
+        #[test]
+        fn prop_exec_stack_push(items in prop::collection::vec(prop::bool::ANY, 0..9)) {
+            let mut exec_stack = ExecStack::default();
+            items.iter().for_each(|i| exec_stack.push(*i));
 
-			// Check the final state of the execution stack
-			assert_eq!(items, exec_stack.stack);
-			// Check number of idle lanes is correct
-			assert_eq!(items.iter().filter(|i| !**i).count(), exec_stack.num_idle);
-			// Check whether executing indicator is correct
-			assert_eq!(items.iter().all(|i| *i), exec_stack.executing());
-		}
+            // Check the final state of the execution stack
+            assert_eq!(items, exec_stack.stack);
+            // Check number of idle lanes is correct
+            assert_eq!(items.iter().filter(|i| !**i).count(), exec_stack.num_idle);
+            // Check whether executing indicator is correct
+            assert_eq!(items.iter().all(|i| *i), exec_stack.executing());
+        }
 
-		#[test]
-		fn prop_exec_stack_push_pop(items0 in prop::collection::vec(prop::bool::ANY, 0..9),
-									items1 in prop::collection::vec(prop::bool::ANY, 1..9)) {
-			let mut exec_stack = ExecStack::default();
-			items0.iter().for_each(|i| exec_stack.push(*i));
-			let orig_exec_stack = exec_stack.clone();
+        #[test]
+        fn prop_exec_stack_push_pop(items0 in prop::collection::vec(prop::bool::ANY, 0..9),
+                                    items1 in prop::collection::vec(prop::bool::ANY, 1..9)) {
+            let mut exec_stack = ExecStack::default();
+            items0.iter().for_each(|i| exec_stack.push(*i));
+            let orig_exec_stack = exec_stack.clone();
 
-			// Push a bunch of extra items and pop them again
-			items1.iter().for_each(|i| exec_stack.push(*i));
-			items1.iter().for_each(|_| exec_stack.pop().map(|_| ()).unwrap());
+            // Push a bunch of extra items and pop them again
+            items1.iter().for_each(|i| exec_stack.push(*i));
+            items1.iter().for_each(|_| exec_stack.pop().map(|_| ()).unwrap());
 
-			// Check we got to the original state
-			assert_eq!(orig_exec_stack, exec_stack);
-		}
+            // Check we got to the original state
+            assert_eq!(orig_exec_stack, exec_stack);
+        }
 
-		#[test]
-		fn prop_2dup(mut stack in gen_stack(gen_item_bytes(0..40), 2..10)) {
-			let res = execute_opcode(opcodes::Ordinary::OP_2DUP, &mut stack);
-			prop_assert!(res.is_ok());
-			prop_assert_eq!(stack.top(0), stack.top(2));
-			prop_assert_eq!(stack.top(1), stack.top(3));
-		}
+        #[test]
+        fn prop_2dup(mut stack in gen_stack(gen_item_bytes(0..40), 2..10)) {
+            let res = execute_opcode(opcodes::Ordinary::OP_2DUP, &mut stack);
+            prop_assert!(res.is_ok());
+            prop_assert_eq!(stack.top(0), stack.top(2));
+            prop_assert_eq!(stack.top(1), stack.top(3));
+        }
 
-		#[test]
-		fn prop_swap_swap(orig_stack in gen_stack(gen_item_bytes(0..40), 2..5)) {
-			let mut stack = orig_stack.clone();
-			execute_opcode(opcodes::Ordinary::OP_SWAP, &mut stack).unwrap();
-			execute_opcode(opcodes::Ordinary::OP_SWAP, &mut stack).unwrap();
-			prop_assert_eq!(orig_stack.0, stack.0);
-		}
+        #[test]
+        fn prop_swap_swap(orig_stack in gen_stack(gen_item_bytes(0..40), 2..5)) {
+            let mut stack = orig_stack.clone();
+            execute_opcode(opcodes::Ordinary::OP_SWAP, &mut stack).unwrap();
+            execute_opcode(opcodes::Ordinary::OP_SWAP, &mut stack).unwrap();
+            prop_assert_eq!(orig_stack.0, stack.0);
+        }
 
-		#[test]
-		fn prop_if_then(cond: bool, then_val: i32, else_val: i32) {
-			let script = Builder::new()
-				.push_int(cond as i64)
-				.push_opcode(opcodes::all::OP_IF)
-				.push_int(then_val as i64)
-				.push_opcode(opcodes::all::OP_ELSE)
-				.push_int(else_val as i64)
-				.push_opcode(opcodes::all::OP_ENDIF)
-				.into_script();
+        #[test]
+        fn prop_if_then(cond: bool, then_val: i32, else_val: i32) {
+            let script = Builder::new()
+                .push_int(cond as i64)
+                .push_opcode(opcodes::all::OP_IF)
+                .push_int(then_val as i64)
+                .push_opcode(opcodes::all::OP_ELSE)
+                .push_int(else_val as i64)
+                .push_opcode(opcodes::all::OP_ENDIF)
+                .into_script();
 
-			let stack = Stack::default();
-			let ctx = TestContext::default();
-			let result = run_script(&ctx, &script, stack);
-			prop_assert!(result.is_ok());
+            let stack = Stack::default();
+            let ctx = TestContext::default();
+            let result = run_script(&ctx, &script, stack);
+            prop_assert!(result.is_ok());
 
-			let expected = cond.then(|| then_val).unwrap_or(else_val) as i64;
-			let expected_stack = Stack(vec![script::build_scriptint(expected).into()]);
-			prop_assert_eq!(result.unwrap(), expected_stack);
-		}
+            let expected = cond.then(|| then_val).unwrap_or(else_val) as i64;
+            let expected_stack = Stack(vec![script::build_scriptint(expected).into()]);
+            prop_assert_eq!(result.unwrap(), expected_stack);
+        }
 
-		#[test]
-		fn prop_2rot(orig_stack in gen_stack(gen_item_bytes(0..40), 6..10)) {
-			let mut stack = orig_stack.clone();
-			execute_opcode(opcodes::Ordinary::OP_2ROT, &mut stack).unwrap();
-			prop_assert_eq!(stack.len(), orig_stack.len());
-			prop_assert_eq!(stack.top(0), orig_stack.top(4));
-			prop_assert_eq!(stack.top(1), orig_stack.top(5));
-			prop_assert_eq!(stack.top(2), orig_stack.top(0));
-			prop_assert_eq!(stack.top(3), orig_stack.top(1));
-			prop_assert_eq!(stack.top(4), orig_stack.top(2));
-			prop_assert_eq!(stack.top(5), orig_stack.top(3));
-			prop_assert_eq!(stack.top_slice(6..stack.len()), orig_stack.top_slice(6..stack.len()));
-		}
+        #[test]
+        fn prop_2rot(orig_stack in gen_stack(gen_item_bytes(0..40), 6..10)) {
+            let mut stack = orig_stack.clone();
+            execute_opcode(opcodes::Ordinary::OP_2ROT, &mut stack).unwrap();
+            prop_assert_eq!(stack.len(), orig_stack.len());
+            prop_assert_eq!(stack.top(0), orig_stack.top(4));
+            prop_assert_eq!(stack.top(1), orig_stack.top(5));
+            prop_assert_eq!(stack.top(2), orig_stack.top(0));
+            prop_assert_eq!(stack.top(3), orig_stack.top(1));
+            prop_assert_eq!(stack.top(4), orig_stack.top(2));
+            prop_assert_eq!(stack.top(5), orig_stack.top(3));
+            prop_assert_eq!(stack.top_slice(6..stack.len()), orig_stack.top_slice(6..stack.len()));
+        }
 
-		#[test]
-		fn prop_shuffle(
-			mut orig_stack in gen_stack(gen_item_bytes(0..40), 6..10),
-			opcode in prop::sample::select(&[
-				opcodes::Ordinary::OP_ROT,
-				opcodes::Ordinary::OP_SWAP,
-				opcodes::Ordinary::OP_2ROT,
-				opcodes::Ordinary::OP_2SWAP,
-			][..]),
-		) {
-			let mut stack = orig_stack.clone();
-			execute_opcode(opcode, &mut stack).unwrap();
+        #[test]
+        fn prop_shuffle(
+            mut orig_stack in gen_stack(gen_item_bytes(0..40), 6..10),
+            opcode in prop::sample::select(&[
+                opcodes::Ordinary::OP_ROT,
+                opcodes::Ordinary::OP_SWAP,
+                opcodes::Ordinary::OP_2ROT,
+                opcodes::Ordinary::OP_2SWAP,
+            ][..]),
+        ) {
+            let mut stack = orig_stack.clone();
+            execute_opcode(opcode, &mut stack).unwrap();
 
-			// These opcodes only rearrange items on the stack, they should not duplicate, drop or
-			// create new items. I.e. the before and after stack should be identical after putting
-			// each in the canonical order.
-			stack.0.sort();
-			orig_stack.0.sort();
-			prop_assert_eq!(stack, orig_stack);
-		}
+            // These opcodes only rearrange items on the stack, they should not duplicate, drop or
+            // create new items. I.e. the before and after stack should be identical after putting
+            // each in the canonical order.
+            stack.0.sort();
+            orig_stack.0.sort();
+            prop_assert_eq!(stack, orig_stack);
+        }
 
-		#[test]
-		fn prop_stack_manipulation(
-			orig_stack in gen_stack(gen_item_bytes(0..40), 6..10),
-			opcode in prop::sample::select(&[
-				opcodes::Ordinary::OP_DROP,
-				opcodes::Ordinary::OP_2DROP,
-				opcodes::Ordinary::OP_DUP,
-				opcodes::Ordinary::OP_2DUP,
-				opcodes::Ordinary::OP_3DUP,
-				opcodes::Ordinary::OP_OVER,
-				opcodes::Ordinary::OP_2OVER,
-				opcodes::Ordinary::OP_SWAP,
-				opcodes::Ordinary::OP_2SWAP,
-				opcodes::Ordinary::OP_2ROT,
-				opcodes::Ordinary::OP_NIP,
-				opcodes::Ordinary::OP_ROT,
-				opcodes::Ordinary::OP_TUCK,
-				opcodes::Ordinary::OP_IFDUP,
-			][..]),
-		) {
-			let mut stack = orig_stack.clone();
-			execute_opcode(opcode, &mut stack).unwrap();
-			// These opcodes should not fabricate elements out of thin air.
-			prop_assert!(stack.0.iter().all(|item| orig_stack.0.iter().any(|i| i == item)));
-		}
-	}
+        #[test]
+        fn prop_stack_manipulation(
+            orig_stack in gen_stack(gen_item_bytes(0..40), 6..10),
+            opcode in prop::sample::select(&[
+                opcodes::Ordinary::OP_DROP,
+                opcodes::Ordinary::OP_2DROP,
+                opcodes::Ordinary::OP_DUP,
+                opcodes::Ordinary::OP_2DUP,
+                opcodes::Ordinary::OP_3DUP,
+                opcodes::Ordinary::OP_OVER,
+                opcodes::Ordinary::OP_2OVER,
+                opcodes::Ordinary::OP_SWAP,
+                opcodes::Ordinary::OP_2SWAP,
+                opcodes::Ordinary::OP_2ROT,
+                opcodes::Ordinary::OP_NIP,
+                opcodes::Ordinary::OP_ROT,
+                opcodes::Ordinary::OP_TUCK,
+                opcodes::Ordinary::OP_IFDUP,
+            ][..]),
+        ) {
+            let mut stack = orig_stack.clone();
+            execute_opcode(opcode, &mut stack).unwrap();
+            // These opcodes should not fabricate elements out of thin air.
+            prop_assert!(stack.0.iter().all(|item| orig_stack.0.iter().any(|i| i == item)));
+        }
+    }
 }

--- a/libs/chainscript/src/interpreter.rs
+++ b/libs/chainscript/src/interpreter.rs
@@ -48,6 +48,14 @@ impl<'a> Stack<'a> {
         Some(self.len()).filter(|&l| l >= num).ok_or(Error::NotEnoughElementsOnStack)
     }
 
+    /// Check the stack state represents a successful script verification.
+    pub fn verify(&self) -> crate::Result<()> {
+        match &self.0[..] {
+            [x] => script::read_scriptbool(x).then(|| ()).ok_or(Error::VerifyFail),
+            _ => Err(Error::StackNotClean),
+        }
+    }
+
     /// Pop an item off of the stack.
     fn pop(&mut self) -> crate::Result<Item<'a>> {
         self.0.pop().ok_or(Error::NotEnoughElementsOnStack)

--- a/libs/chainscript/src/interpreter.rs
+++ b/libs/chainscript/src/interpreter.rs
@@ -1,0 +1,482 @@
+use crate::{
+	error::Error,
+	opcodes,
+	script::{self, Instruction, Script},
+	util::{self, check},
+};
+use sp_std::{borrow::Cow, cmp, ops, ops::Range};
+
+/// Item on the data stack.
+///
+/// The [Cow] type is used to avoid copying data when not necessary. That is often the case with
+/// large constants such as public keys and hashes.
+type Item<'a> = Cow<'a, [u8]>;
+
+/// Interpreter data stack.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Stack<'a>(Vec<Item<'a>>);
+
+impl<'a> Stack<'a> {
+	/// Get stack length.
+	fn len(&self) -> usize {
+		self.0.len()
+	}
+
+	/// Check the stack has at least given number of elements and return the length.
+	fn at_least(&self, num: usize) -> crate::Result<usize> {
+		(self.len() >= num).then(|| self.len()).ok_or(Error::NotEnoughElementsOnStack)
+	}
+
+	/// Pop an item off of the stack.
+	fn pop(&mut self) -> crate::Result<Item<'a>> {
+		self.0.pop().ok_or(Error::NotEnoughElementsOnStack)
+	}
+
+	/// Pop an item of the top of the stack and convert it to bool.
+	fn pop_bool(&mut self) -> crate::Result<bool> {
+		self.pop().map(|x| script::read_scriptbool(&x))
+	}
+
+	/// Pop an item off the stack and convert it to int.
+	fn pop_int(&mut self) -> crate::Result<i64> {
+		script::read_scriptint(&self.pop()?)
+	}
+
+	/// Push an item onto the stack.
+	fn push(&mut self, item: Item<'a>) {
+		self.0.push(item)
+	}
+
+	/// Push a boolean item onto the stack.
+	fn push_bool(&mut self, b: bool) {
+		self.push_int(b as i64);
+	}
+
+	/// Push an integer item onto the stack.
+	fn push_int(&mut self, x: i64) {
+		//todo!("Check int in the correct range");
+		self.push(script::build_scriptint(x).into());
+	}
+
+	/// Get an element at given position from the top of the stack.
+	pub fn top(&self, idx: usize) -> crate::Result<&Item<'a>> {
+		self.at_least(idx + 1).map(|len| &self.0[len - idx - 1])
+	}
+
+	/// Map range counting from the top of the stack to the internal vector indexing.
+	fn top_range(&self, r: Range<usize>) -> crate::Result<Range<usize>> {
+		self.at_least(r.start).map(|len| (len - r.start)..(len - r.end))
+	}
+
+	/// Take a mutable slice of the top of the stack.
+	fn top_slice_mut(&mut self, r: Range<usize>) -> crate::Result<&mut [Item<'a>]> {
+		let i = self.top_range(r)?;
+		Ok(&mut self.0[i])
+	}
+
+	/// Drop given number of elements
+	fn drop(&mut self, num_drop: usize) -> crate::Result<()> {
+		let len = self.at_least(num_drop)?;
+		Ok(self.0.truncate(len - num_drop))
+	}
+
+	/// Duplicate slice indexed from the top of the stack. The new items are added to the top of
+	/// the stack.
+	fn dup(&mut self, r: Range<usize>) -> crate::Result<()> {
+		self.top_range(r).map(|i| self.0.extend_from_within(i))
+	}
+
+	/// Swap the top `n` elements with the next `n` elements on the stack.
+	fn swap(&mut self, n: usize) -> crate::Result<()> {
+		let (top, next) = self.top_slice_mut((2 * n)..0)?.split_at_mut(n);
+		Ok(top.swap_with_slice(next))
+	}
+
+	/// Remove `n`-th element, counting from the top of the stack.
+	fn remove(&mut self, n: usize) -> crate::Result<Item<'a>> {
+		let len = self.at_least(n)?;
+		Ok(self.0.remove(len - n - 1))
+	}
+}
+
+/// Execution stack keeps track of masks of IF/ELSE branches being executed.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct ExecStack {
+	stack: Vec<bool>,
+	num_idle: usize,
+}
+
+impl ExecStack {
+	/// Push mask onto the stack. Executing: true, not executing: false.
+	fn push(&mut self, executing: bool) {
+		self.stack.push(executing);
+		self.num_idle += (!executing) as usize;
+	}
+
+	/// Pop the top item off the stack.
+	fn pop(&mut self) -> Option<bool> {
+		let executing = self.stack.pop()?;
+		self.num_idle -= (!executing) as usize;
+		Some(executing)
+	}
+
+	/// Check if we are currently executing, i.e. no branch is masked out.
+	fn executing(&self) -> bool {
+		self.num_idle == 0
+	}
+
+	/// Check the execution stack is empty, i.e. we are not inside of a conditional.
+	fn is_empty(&self) -> bool {
+		self.stack.is_empty()
+	}
+}
+
+pub fn run_interpreter<'a>(script: &'a Script, stack: &mut Stack<'a>) -> crate::Result<bool> {
+	let mut exec_stack = ExecStack::default();
+	let mut alt_stack = Stack::<'a>::default();
+
+	for instr in script.instructions_minimal() {
+		let instr = instr?;
+
+		let executing = exec_stack.executing();
+		match instr {
+			Instruction::PushBytes(data) if executing => stack.push(data.into()),
+			Instruction::PushBytes(_) => (),
+			Instruction::Op(opcode) => match opcode.classify() {
+				opcodes::Class::NoOp => (),
+				opcodes::Class::IllegalOp => return Err(Error::IllegalOp),
+				opcodes::Class::ReturnOp if executing => return Ok(false),
+				opcodes::Class::PushNum(x) if executing => stack.push_int(x as i64),
+				opcodes::Class::PushBytes(_) =>
+					unreachable!("Already handled using Instruction::PushBytes"),
+				opcodes::Class::AltStack(opc) => match opc {
+					opcodes::AltStack::OP_TOALTSTACK => alt_stack.push(stack.pop()?),
+					opcodes::AltStack::OP_FROMALTSTACK => stack.push(alt_stack.pop()?),
+				},
+				opcodes::Class::Signature(_sigop) => todo!("handle signatures"),
+				opcodes::Class::ControlFlow(cf) => match cf {
+					opcodes::ControlFlow::OP_IF | opcodes::ControlFlow::OP_NOTIF => {
+						let cond = executing && {
+                            let enforce_minimal_if = true;
+							let cond = match stack.pop()?.as_ref() {
+                                c if !enforce_minimal_if => script::read_scriptbool(c),
+                                &[] => false,
+                                &[1u8] => true,
+                                _ => return Err(Error::InvalidOperand),
+                            };
+							cond ^ (cf == opcodes::ControlFlow::OP_NOTIF)
+						};
+						exec_stack.push(cond);
+					},
+					opcodes::ControlFlow::OP_ELSE => {
+						let top_executing = exec_stack.pop().ok_or(Error::UnbalancedIfElse)?;
+						exec_stack.push(!top_executing);
+					},
+					opcodes::ControlFlow::OP_ENDIF => {
+						let _ = exec_stack.pop().ok_or(Error::UnbalancedIfElse)?;
+					},
+				},
+				opcodes::Class::Ordinary(opcode) if executing => {
+					if let Some(result) = execute_opcode(opcode, stack)? {
+						return Ok(result)
+					}
+				},
+				_ => (),
+			},
+		}
+	}
+
+	// Check OP_IF/OP_NOTIF has been closed properly wiht OP_ENDIF.
+	if !exec_stack.is_empty() {
+		return Err(Error::UnbalancedIfElse)
+	}
+
+	// TODO inspect stack to determine the result.
+	let success = true;
+	Ok(success)
+}
+
+/// Control flow result of executing an opcode.
+///
+/// * `Ok(None)`: Opcode has executed and the script execution should continue.
+/// * `Ok(Some(e))`: The script should terminate with given validation outcome.
+/// * `Err(e)`: Script execution should terminate with given error.
+type OpcodeResult = Result<Option<bool>, crate::error::Error>;
+
+/// Execute an ["ordinay"](opcode::Ordinary) opcode.
+fn execute_opcode<'a>(opcode: opcodes::Ordinary, stack: &mut Stack<'a>) -> OpcodeResult {
+	use opcodes::Ordinary as Opc;
+
+	match opcode {
+		Opc::OP_PUSHDATA1 | Opc::OP_PUSHDATA2 | Opc::OP_PUSHDATA4 =>
+			unreachable!("OP_PUSHDATA[124] already handled by Instruction::PushBytes"),
+
+		// Verify. Do nothing now, the actual verification is handled below this match statement.
+		Opc::OP_VERIFY => (),
+
+		// Main stack manipulation
+		Opc::OP_DROP => stack.drop(1)?,
+		Opc::OP_2DROP => stack.drop(2)?,
+		Opc::OP_DUP => stack.dup(1..0)?,
+		Opc::OP_2DUP => stack.dup(2..0)?,
+		Opc::OP_3DUP => stack.dup(3..0)?,
+		Opc::OP_OVER => stack.dup(2..1)?,
+		Opc::OP_2OVER => stack.dup(4..2)?,
+		Opc::OP_SWAP => stack.swap(1)?,
+		Opc::OP_2SWAP => stack.swap(2)?,
+		Opc::OP_2ROT => {
+			let top = stack.top_slice_mut(0..6)?;
+			let to_put = [2, 3, 4, 5, 0, 1].map(|i| top[i].clone());
+			top.clone_from_slice(&to_put);
+		},
+		Opc::OP_NIP => {
+			let x = stack.pop()?;
+			let _ = stack.pop()?;
+			stack.push(x);
+		},
+		Opc::OP_PICK => {
+			let i = stack.pop_int()?;
+			check(i >= 0, Error::InvalidOperand)?;
+			stack.push(stack.top(i as usize)?.clone());
+		},
+		Opc::OP_ROLL => {
+			let i = stack.pop_int()?;
+			check(i >= 0, Error::InvalidOperand)?;
+			let x = stack.remove(i as usize)?;
+			stack.push(x);
+		},
+		Opc::OP_ROT => {
+			let x = stack.remove(2)?;
+			stack.push(x);
+		},
+		Opc::OP_TUCK => {
+			let x = stack.top(0)?.clone();
+			stack.swap(1)?;
+			stack.push(x);
+		},
+		Opc::OP_IFDUP => {
+			let item = stack.top(0)?;
+			if script::read_scriptbool(item) {
+				let item_clone = item.clone();
+				stack.push(item_clone);
+			}
+		},
+		Opc::OP_DEPTH => {
+			check(stack.len() < i32::MAX as usize, Error::NumericOverflow)?;
+			stack.push_int(stack.len() as i64);
+		},
+
+		// Stack item queries
+		Opc::OP_SIZE => {
+			let top_len = stack.top(0)?.len();
+			check(top_len < i32::MAX as usize, Error::NumericOverflow)?;
+			stack.push_int(top_len as i64);
+		},
+		Opc::OP_EQUAL | Opc::OP_EQUALVERIFY => {
+			let y = stack.pop()?;
+			let x = stack.pop()?;
+			stack.push_bool(x == y);
+		},
+
+		// Arithmetic
+		Opc::OP_1ADD => op_num1(stack, |x| x + 1)?,
+		Opc::OP_1SUB => op_num1(stack, |x| x - 1)?,
+		Opc::OP_NEGATE => op_num1(stack, ops::Neg::neg)?,
+		Opc::OP_ABS => op_num1(stack, i64::abs)?,
+		Opc::OP_NOT => op_num1(stack, |x| (x == 0) as i64)?,
+		Opc::OP_0NOTEQUAL => op_num1(stack, |x| (x != 0) as i64)?,
+		Opc::OP_ADD => op_num2(stack, ops::Add::add)?,
+		Opc::OP_SUB => op_num2(stack, ops::Sub::sub)?,
+		Opc::OP_BOOLAND => op_num2(stack, |x, y| (x != 0 && y != 0) as i64)?,
+		Opc::OP_BOOLOR => op_num2(stack, |x, y| (x != 0 || y != 0) as i64)?,
+		Opc::OP_NUMEQUAL | Opc::OP_NUMEQUALVERIFY => op_num2(stack, |x, y| (x == y) as i64)?,
+		Opc::OP_NUMNOTEQUAL => op_num2(stack, |x, y| (x != y) as i64)?,
+		Opc::OP_LESSTHAN => op_num2(stack, |x, y| (x < y) as i64)?,
+		Opc::OP_GREATERTHAN => op_num2(stack, |x, y| (x > y) as i64)?,
+		Opc::OP_LESSTHANOREQUAL => op_num2(stack, |x, y| (x <= y) as i64)?,
+		Opc::OP_GREATERTHANOREQUAL => op_num2(stack, |x, y| (x >= y) as i64)?,
+		Opc::OP_MIN => op_num2(stack, cmp::min)?,
+		Opc::OP_MAX => op_num2(stack, cmp::max)?,
+		Opc::OP_WITHIN => {
+			let hi = stack.pop_int()?;
+			let lo = stack.pop_int()?;
+			let x = stack.pop_int()?;
+			stack.push_int((lo <= x && x < hi) as i64);
+		},
+
+		// Hashes
+		Opc::OP_RIPEMD160 => op_hash(stack, util::ripemd160)?,
+		Opc::OP_SHA1 => op_hash(stack, util::sha1)?,
+		Opc::OP_SHA256 => op_hash(stack, util::sha256)?,
+		Opc::OP_HASH160 => op_hash(stack, util::hash160)?,
+		Opc::OP_HASH256 => op_hash(stack, util::hash256)?,
+	}
+
+	if opcode.is_verify() && !stack.pop_bool()? {
+		Ok(Some(false))
+	} else {
+		Ok(None)
+	}
+}
+
+/// Perform an unary arithmetic operation on the top of the stack.
+fn op_num1(stack: &mut Stack, f: impl FnOnce(i64) -> i64) -> crate::Result<()> {
+	let x = stack.pop_int()?;
+	Ok(stack.push_int(f(x)))
+}
+
+/// Perform a binary arithmetic operation on the top of the stack.
+fn op_num2(stack: &mut Stack, f: impl FnOnce(i64, i64) -> i64) -> crate::Result<()> {
+	let y = stack.pop_int()?;
+	let x = stack.pop_int()?;
+	Ok(stack.push_int(f(x, y)))
+}
+
+/// Perform a byte-array based function on the top stack item. Useful for hashes.
+fn op_hash<T: AsRef<[u8]>>(stack: &mut Stack, f: impl FnOnce(&[u8]) -> T) -> crate::Result<()> {
+	let result = f(&stack.pop()?);
+	Ok(stack.push(Cow::Owned(result.as_ref().to_vec())))
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::script::Builder;
+	use proptest::{collection::SizeRange, prelude::*};
+
+	#[test]
+	fn unit_exec_stack() {
+		let mut exec_stack = ExecStack::default();
+		assert!(exec_stack.executing());
+
+		exec_stack.push(true);
+		assert!(exec_stack.executing());
+		exec_stack.push(false);
+		assert!(!exec_stack.executing());
+		exec_stack.push(true);
+		assert!(!exec_stack.executing());
+
+		// [true, false, true]
+		let _ = exec_stack.pop();
+		// [true, false]
+		assert!(!exec_stack.executing());
+		let _ = exec_stack.pop();
+		// [true]
+		assert!(exec_stack.executing());
+		let _ = exec_stack.pop();
+		// []
+		assert!(exec_stack.executing());
+
+		assert!(exec_stack.stack.is_empty());
+	}
+
+	#[test]
+	fn unit_if_then_else_syntax() {
+		let should_fail = |script: Script| {
+			let mut stack = Stack(vec![vec![].into(), vec![].into()]);
+			let result = run_interpreter(&script, &mut stack);
+			assert_eq!(result, Err(Error::UnbalancedIfElse));
+		};
+		use opcodes::all::*;
+		should_fail(Builder::new().push_opcode(OP_IF).into_script());
+		should_fail(Builder::new().push_opcode(OP_IF).push_opcode(OP_ELSE).into_script());
+		should_fail(Builder::new().push_opcode(OP_IF).push_opcode(OP_NOTIF).into_script());
+		should_fail(Builder::new().push_opcode(OP_ELSE).into_script());
+		should_fail(Builder::new().push_opcode(OP_ENDIF).into_script());
+		should_fail(
+			Builder::new()
+				.push_opcode(OP_IF)
+				.push_opcode(OP_IF)
+				.push_opcode(OP_ELSE)
+				.push_opcode(OP_ENDIF)
+				.into_script(),
+		);
+		should_fail(
+			Builder::new()
+				.push_opcode(OP_IF)
+				.push_opcode(OP_ELSE)
+				.push_opcode(OP_ENDIF)
+				.push_opcode(OP_ENDIF)
+				.into_script(),
+		);
+	}
+
+	// Generate stack item as an array of bytes
+	fn gen_item_bytes<'a>(num_bytes: Range<usize>) -> impl Strategy<Value = Item<'a>> {
+		prop::collection::vec(prop::num::u8::ANY, num_bytes).prop_map(|v| v.into())
+	}
+
+	// Generate stack with given item generation strategy.
+	fn gen_stack<'a>(
+		gen_item: impl Strategy<Value = Item<'a>>,
+		size: impl Into<SizeRange>,
+	) -> impl Strategy<Value = Stack<'a>> {
+		prop::collection::vec(gen_item, size).prop_map(Stack)
+	}
+
+	proptest! {
+		#[test]
+		fn prop_exec_stack_push(items in prop::collection::vec(prop::bool::ANY, 0..9)) {
+			let mut exec_stack = ExecStack::default();
+			items.iter().for_each(|i| exec_stack.push(*i));
+
+			// Check the final state of the execution stack
+			assert_eq!(items, exec_stack.stack);
+			// Check number of idle lanes is correct
+			assert_eq!(items.iter().filter(|i| !**i).count(), exec_stack.num_idle);
+			// Check whether executing indicator is correct
+			assert_eq!(items.iter().all(|i| *i), exec_stack.executing());
+		}
+
+		#[test]
+		fn prop_exec_stack_push_pop(items0 in prop::collection::vec(prop::bool::ANY, 0..9),
+									items1 in prop::collection::vec(prop::bool::ANY, 1..9)) {
+			let mut exec_stack = ExecStack::default();
+			items0.iter().for_each(|i| exec_stack.push(*i));
+			let orig_exec_stack = exec_stack.clone();
+
+			// Push a bunch of extra items and pop them again
+			items1.iter().for_each(|i| exec_stack.push(*i));
+			items1.iter().for_each(|_| exec_stack.pop().map(|_| ()).unwrap());
+
+			// Check we got to the original state
+			assert_eq!(orig_exec_stack, exec_stack);
+		}
+
+		#[test]
+		fn prop_2dup(mut stack in gen_stack(gen_item_bytes(0..40), 2..10)) {
+			let res = execute_opcode(opcodes::Ordinary::OP_2DUP, &mut stack);
+			prop_assert!(res.is_ok());
+			prop_assert_eq!(stack.top(0), stack.top(2));
+			prop_assert_eq!(stack.top(1), stack.top(3));
+		}
+
+		#[test]
+		fn prop_swap_swap(orig_stack in gen_stack(gen_item_bytes(0..40), 2..5)) {
+			let mut stack = orig_stack.clone();
+			let _ = execute_opcode(opcodes::Ordinary::OP_SWAP, &mut stack);
+			let _ = execute_opcode(opcodes::Ordinary::OP_SWAP, &mut stack);
+			prop_assert_eq!(orig_stack.0, stack.0);
+		}
+
+		#[test]
+		fn prop_if_then(cond: bool, then_val: i32, else_val: i32) {
+			let script = Builder::new()
+				.push_int(cond as i64)
+				.push_opcode(opcodes::all::OP_IF)
+				.push_int(then_val as i64)
+				.push_opcode(opcodes::all::OP_ELSE)
+				.push_int(else_val as i64)
+				.push_opcode(opcodes::all::OP_ENDIF)
+				.into_script();
+
+			let mut stack = Stack::default();
+			let result = run_interpreter(&script, &mut stack);
+			prop_assert!(result.is_ok());
+
+			let expected = cond.then(|| then_val).unwrap_or(else_val) as i64;
+			let expected_stack = Stack(vec![script::build_scriptint(expected).into()]);
+			prop_assert_eq!(stack, expected_stack);
+		}
+	}
+}

--- a/libs/chainscript/src/lib.rs
+++ b/libs/chainscript/src/lib.rs
@@ -3,5 +3,9 @@
 #[macro_use]
 mod util;
 
+// TODO: hide implementation of most items exported here
+pub mod error;
 pub mod opcodes;
 pub mod script;
+
+pub use error::Result;

--- a/libs/chainscript/src/lib.rs
+++ b/libs/chainscript/src/lib.rs
@@ -1,13 +1,65 @@
+// Copyright (c) 2021 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): L. Kuklinek
+
+//! This library provides scripting capabilities targeting blockchain applications largely
+//! compatible with Bitcoin script. Most opcodes have semantics identical to Bitcoin script,
+//! however the library also provides a number of customization points to allow the user to
+//! deviate from, extend and customize the capabilities of the scripting engine. Most notably,
+//! signatures can be fully customized. For more info, see the [Context] trait.
+//!
+//! ## Example
+//!
+//! Here is how to create a simple script and run it using [TestContext]:
+//!
+//! ```
+//! use chainscript::{Builder, Stack, TestContext, run_script};
+//! use chainscript::opcodes::all as opc;
+//!
+//! // Build a script that calculates 3 + 5.
+//! let script = Builder::new()
+//!         .push_int(3)
+//!         .push_int(5)
+//!         .push_opcode(opc::OP_ADD)
+//!         .into_script();
+//!
+//! // Set up stack and context, run the interpreter.
+//! let stack = Stack::default();
+//! let ctx = TestContext::new("TRANSACTION DATA HERE".as_bytes().to_owned());
+//! let result = run_script(&ctx, &script, stack);
+//!
+//! // Check if the final stack result is [0x08].
+//! let mut expected = Stack::from(vec![vec![0x08].into()]);
+//! assert_eq!(result, Ok(expected));
+//! ```
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[macro_use]
 pub mod util;
 
-// TODO: hide implementation of most items exported here
-pub mod context;
-pub mod error;
-pub mod interpreter;
+mod context;
+mod error;
+mod interpreter;
 pub mod opcodes;
 pub mod script;
 
-pub use error::Result;
+#[cfg(feature = "testcontext")]
+pub use context::testcontext::TestContext;
+pub use context::Context;
+pub use error::{Error, Result};
+pub use interpreter::{run_script, Stack};
+pub use script::{Builder, Script};

--- a/libs/chainscript/src/lib.rs
+++ b/libs/chainscript/src/lib.rs
@@ -61,5 +61,5 @@ pub mod script;
 pub use context::testcontext::TestContext;
 pub use context::Context;
 pub use error::{Error, Result};
-pub use interpreter::{run_script, Stack};
+pub use interpreter::{run_pushdata, run_script, Stack};
 pub use script::{Builder, Script};

--- a/libs/chainscript/src/lib.rs
+++ b/libs/chainscript/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod util;
 
 // TODO: hide implementation of most items exported here
+pub mod context;
 pub mod error;
 pub mod interpreter;
 pub mod opcodes;

--- a/libs/chainscript/src/lib.rs
+++ b/libs/chainscript/src/lib.rs
@@ -1,0 +1,7 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[macro_use]
+mod util;
+
+pub mod opcodes;
+pub mod script;

--- a/libs/chainscript/src/lib.rs
+++ b/libs/chainscript/src/lib.rs
@@ -1,10 +1,11 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[macro_use]
-mod util;
+pub mod util;
 
 // TODO: hide implementation of most items exported here
 pub mod error;
+pub mod interpreter;
 pub mod opcodes;
 pub mod script;
 

--- a/libs/chainscript/src/lib.rs
+++ b/libs/chainscript/src/lib.rs
@@ -49,7 +49,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[macro_use]
-pub mod util;
+mod util;
 
 mod context;
 mod error;

--- a/libs/chainscript/src/opcodes.rs
+++ b/libs/chainscript/src/opcodes.rs
@@ -15,10 +15,10 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-//! Opcodes
+//! Opcode definitions and methods
 //!
 //! Bitcoin's script uses a stack-based assembly language. This module defines
-//! all of the opcodes
+//! all of the opcodes and categorizes them according to semantics.
 
 #![allow(non_camel_case_types)]
 
@@ -883,20 +883,14 @@ impl PushData {
 impl Ordinary {
 	/// Is this OP_*VERIFY?
 	pub fn is_verify(self) -> bool {
-		match self {
-			Self::OP_VERIFY | Self::OP_EQUALVERIFY | Self::OP_NUMEQUALVERIFY => true,
-			_ => false,
-		}
+		matches!(self, Self::OP_VERIFY | Self::OP_EQUALVERIFY | Self::OP_NUMEQUALVERIFY)
 	}
 }
 
 impl Signature {
 	/// Is this OP_*VERIFY?
 	pub fn is_verify(self) -> bool {
-		match self {
-			Self::OP_CHECKSIGVERIFY | Self::OP_CHECKMULTISIGVERIFY => true,
-			_ => false,
-		}
+		matches!(self, Self::OP_CHECKSIGVERIFY | Self::OP_CHECKMULTISIGVERIFY)
 	}
 }
 

--- a/libs/chainscript/src/opcodes.rs
+++ b/libs/chainscript/src/opcodes.rs
@@ -19,15 +19,16 @@
 //!
 //! Bitcoin's script uses a stack-based assembly language. This module defines
 //! all of the opcodes
-//!
 
 #![allow(non_camel_case_types)]
 
-#[cfg(feature = "serde")] use serde;
+#[cfg(feature = "serde")]
+use serde;
 
-#[cfg(feature = "serde")] use prelude::*;
+#[cfg(feature = "serde")]
+use prelude::*;
 
-use core::{fmt, convert::From};
+use core::{convert::From, fmt};
 
 // Note: I am deliberately not implementing PartialOrd or Ord on the
 //       opcode enum. If you want to check ranges of opcodes, etc.,
@@ -36,694 +37,711 @@ use core::{fmt, convert::From};
 /// A script Opcode
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct All {
-    code: u8,
+	code: u8,
 }
 
 pub mod all {
-    //! Constants associated with All type
-    use super::All;
+	//! Constants associated with All type
+	use super::All;
 
-    /// Push an empty array onto the stack
-    pub const OP_PUSHBYTES_0: All = All {code: 0x00};
-    /// Push the next byte as an array onto the stack
-    pub const OP_PUSHBYTES_1: All = All {code: 0x01};
-    /// Push the next 2 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_2: All = All {code: 0x02};
-    /// Push the next 2 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_3: All = All {code: 0x03};
-    /// Push the next 4 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_4: All = All {code: 0x04};
-    /// Push the next 5 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_5: All = All {code: 0x05};
-    /// Push the next 6 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_6: All = All {code: 0x06};
-    /// Push the next 7 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_7: All = All {code: 0x07};
-    /// Push the next 8 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_8: All = All {code: 0x08};
-    /// Push the next 9 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_9: All = All {code: 0x09};
-    /// Push the next 10 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_10: All = All {code: 0x0a};
-    /// Push the next 11 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_11: All = All {code: 0x0b};
-    /// Push the next 12 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_12: All = All {code: 0x0c};
-    /// Push the next 13 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_13: All = All {code: 0x0d};
-    /// Push the next 14 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_14: All = All {code: 0x0e};
-    /// Push the next 15 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_15: All = All {code: 0x0f};
-    /// Push the next 16 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_16: All = All {code: 0x10};
-    /// Push the next 17 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_17: All = All {code: 0x11};
-    /// Push the next 18 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_18: All = All {code: 0x12};
-    /// Push the next 19 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_19: All = All {code: 0x13};
-    /// Push the next 20 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_20: All = All {code: 0x14};
-    /// Push the next 21 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_21: All = All {code: 0x15};
-    /// Push the next 22 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_22: All = All {code: 0x16};
-    /// Push the next 23 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_23: All = All {code: 0x17};
-    /// Push the next 24 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_24: All = All {code: 0x18};
-    /// Push the next 25 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_25: All = All {code: 0x19};
-    /// Push the next 26 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_26: All = All {code: 0x1a};
-    /// Push the next 27 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_27: All = All {code: 0x1b};
-    /// Push the next 28 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_28: All = All {code: 0x1c};
-    /// Push the next 29 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_29: All = All {code: 0x1d};
-    /// Push the next 30 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_30: All = All {code: 0x1e};
-    /// Push the next 31 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_31: All = All {code: 0x1f};
-    /// Push the next 32 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_32: All = All {code: 0x20};
-    /// Push the next 33 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_33: All = All {code: 0x21};
-    /// Push the next 34 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_34: All = All {code: 0x22};
-    /// Push the next 35 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_35: All = All {code: 0x23};
-    /// Push the next 36 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_36: All = All {code: 0x24};
-    /// Push the next 37 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_37: All = All {code: 0x25};
-    /// Push the next 38 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_38: All = All {code: 0x26};
-    /// Push the next 39 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_39: All = All {code: 0x27};
-    /// Push the next 40 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_40: All = All {code: 0x28};
-    /// Push the next 41 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_41: All = All {code: 0x29};
-    /// Push the next 42 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_42: All = All {code: 0x2a};
-    /// Push the next 43 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_43: All = All {code: 0x2b};
-    /// Push the next 44 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_44: All = All {code: 0x2c};
-    /// Push the next 45 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_45: All = All {code: 0x2d};
-    /// Push the next 46 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_46: All = All {code: 0x2e};
-    /// Push the next 47 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_47: All = All {code: 0x2f};
-    /// Push the next 48 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_48: All = All {code: 0x30};
-    /// Push the next 49 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_49: All = All {code: 0x31};
-    /// Push the next 50 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_50: All = All {code: 0x32};
-    /// Push the next 51 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_51: All = All {code: 0x33};
-    /// Push the next 52 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_52: All = All {code: 0x34};
-    /// Push the next 53 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_53: All = All {code: 0x35};
-    /// Push the next 54 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_54: All = All {code: 0x36};
-    /// Push the next 55 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_55: All = All {code: 0x37};
-    /// Push the next 56 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_56: All = All {code: 0x38};
-    /// Push the next 57 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_57: All = All {code: 0x39};
-    /// Push the next 58 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_58: All = All {code: 0x3a};
-    /// Push the next 59 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_59: All = All {code: 0x3b};
-    /// Push the next 60 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_60: All = All {code: 0x3c};
-    /// Push the next 61 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_61: All = All {code: 0x3d};
-    /// Push the next 62 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_62: All = All {code: 0x3e};
-    /// Push the next 63 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_63: All = All {code: 0x3f};
-    /// Push the next 64 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_64: All = All {code: 0x40};
-    /// Push the next 65 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_65: All = All {code: 0x41};
-    /// Push the next 66 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_66: All = All {code: 0x42};
-    /// Push the next 67 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_67: All = All {code: 0x43};
-    /// Push the next 68 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_68: All = All {code: 0x44};
-    /// Push the next 69 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_69: All = All {code: 0x45};
-    /// Push the next 70 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_70: All = All {code: 0x46};
-    /// Push the next 71 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_71: All = All {code: 0x47};
-    /// Push the next 72 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_72: All = All {code: 0x48};
-    /// Push the next 73 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_73: All = All {code: 0x49};
-    /// Push the next 74 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_74: All = All {code: 0x4a};
-    /// Push the next 75 bytes as an array onto the stack
-    pub const OP_PUSHBYTES_75: All = All {code: 0x4b};
-    /// Read the next byte as N; push the next N bytes as an array onto the stack
-    pub const OP_PUSHDATA1: All = All {code: 0x4c};
-    /// Read the next 2 bytes as N; push the next N bytes as an array onto the stack
-    pub const OP_PUSHDATA2: All = All {code: 0x4d};
-    /// Read the next 4 bytes as N; push the next N bytes as an array onto the stack
-    pub const OP_PUSHDATA4: All = All {code: 0x4e};
-    /// Push the array `0x81` onto the stack
-    pub const OP_PUSHNUM_NEG1: All = All {code: 0x4f};
-    /// Synonym for OP_RETURN
-    pub const OP_RESERVED: All = All {code: 0x50};
-    /// Push the array `0x01` onto the stack
-    pub const OP_PUSHNUM_1: All = All {code: 0x51};
-    /// Push the array `0x02` onto the stack
-    pub const OP_PUSHNUM_2: All = All {code: 0x52};
-    /// Push the array `0x03` onto the stack
-    pub const OP_PUSHNUM_3: All = All {code: 0x53};
-    /// Push the array `0x04` onto the stack
-    pub const OP_PUSHNUM_4: All = All {code: 0x54};
-    /// Push the array `0x05` onto the stack
-    pub const OP_PUSHNUM_5: All = All {code: 0x55};
-    /// Push the array `0x06` onto the stack
-    pub const OP_PUSHNUM_6: All = All {code: 0x56};
-    /// Push the array `0x07` onto the stack
-    pub const OP_PUSHNUM_7: All = All {code: 0x57};
-    /// Push the array `0x08` onto the stack
-    pub const OP_PUSHNUM_8: All = All {code: 0x58};
-    /// Push the array `0x09` onto the stack
-    pub const OP_PUSHNUM_9: All = All {code: 0x59};
-    /// Push the array `0x0a` onto the stack
-    pub const OP_PUSHNUM_10: All = All {code: 0x5a};
-    /// Push the array `0x0b` onto the stack
-    pub const OP_PUSHNUM_11: All = All {code: 0x5b};
-    /// Push the array `0x0c` onto the stack
-    pub const OP_PUSHNUM_12: All = All {code: 0x5c};
-    /// Push the array `0x0d` onto the stack
-    pub const OP_PUSHNUM_13: All = All {code: 0x5d};
-    /// Push the array `0x0e` onto the stack
-    pub const OP_PUSHNUM_14: All = All {code: 0x5e};
-    /// Push the array `0x0f` onto the stack
-    pub const OP_PUSHNUM_15: All = All {code: 0x5f};
-    /// Push the array `0x10` onto the stack
-    pub const OP_PUSHNUM_16: All = All {code: 0x60};
-    /// Does nothing
-    pub const OP_NOP: All = All {code: 0x61};
-    /// Synonym for OP_RETURN
-    pub const OP_VER: All = All {code: 0x62};
-    /// Pop and execute the next statements if a nonzero element was popped
-    pub const OP_IF: All = All {code: 0x63};
-    /// Pop and execute the next statements if a zero element was popped
-    pub const OP_NOTIF: All = All {code: 0x64};
-    /// Fail the script unconditionally, does not even need to be executed
-    pub const OP_VERIF: All = All {code: 0x65};
-    /// Fail the script unconditionally, does not even need to be executed
-    pub const OP_VERNOTIF: All = All {code: 0x66};
-    /// Execute statements if those after the previous OP_IF were not, and vice-versa.
-    /// If there is no previous OP_IF, this acts as a RETURN.
-    pub const OP_ELSE: All = All {code: 0x67};
-    /// Pop and execute the next statements if a zero element was popped
-    pub const OP_ENDIF: All = All {code: 0x68};
-    /// If the top value is zero or the stack is empty, fail; otherwise, pop the stack
-    pub const OP_VERIFY: All = All {code: 0x69};
-    /// Fail the script immediately. (Must be executed.)
-    pub const OP_RETURN: All = All {code: 0x6a};
-    /// Pop one element from the main stack onto the alt stack
-    pub const OP_TOALTSTACK: All = All {code: 0x6b};
-    /// Pop one element from the alt stack onto the main stack
-    pub const OP_FROMALTSTACK: All = All {code: 0x6c};
-    /// Drops the top two stack items
-    pub const OP_2DROP: All = All {code: 0x6d};
-    /// Duplicates the top two stack items as AB -> ABAB
-    pub const OP_2DUP: All = All {code: 0x6e};
-    /// Duplicates the two three stack items as ABC -> ABCABC
-    pub const OP_3DUP: All = All {code: 0x6f};
-    /// Copies the two stack items of items two spaces back to
-    /// the front, as xxAB -> ABxxAB
-    pub const OP_2OVER: All = All {code: 0x70};
-    /// Moves the two stack items four spaces back to the front,
-    /// as xxxxAB -> ABxxxx
-    pub const OP_2ROT: All = All {code: 0x71};
-    /// Swaps the top two pairs, as ABCD -> CDAB
-    pub const OP_2SWAP: All = All {code: 0x72};
-    /// Duplicate the top stack element unless it is zero
-    pub const OP_IFDUP: All = All {code: 0x73};
-    /// Push the current number of stack items onto the stack
-    pub const OP_DEPTH: All = All {code: 0x74};
-    /// Drops the top stack item
-    pub const OP_DROP: All = All {code: 0x75};
-    /// Duplicates the top stack item
-    pub const OP_DUP: All = All {code: 0x76};
-    /// Drops the second-to-top stack item
-    pub const OP_NIP: All = All {code: 0x77};
-    /// Copies the second-to-top stack item, as xA -> AxA
-    pub const OP_OVER: All = All {code: 0x78};
-    /// Pop the top stack element as N. Copy the Nth stack element to the top
-    pub const OP_PICK: All = All {code: 0x79};
-    /// Pop the top stack element as N. Move the Nth stack element to the top
-    pub const OP_ROLL: All = All {code: 0x7a};
-    /// Rotate the top three stack items, as [top next1 next2] -> [next2 top next1]
-    pub const OP_ROT: All = All {code: 0x7b};
-    /// Swap the top two stack items
-    pub const OP_SWAP: All = All {code: 0x7c};
-    /// Copy the top stack item to before the second item, as [top next] -> [top next top]
-    pub const OP_TUCK: All = All {code: 0x7d};
-    /// Fail the script unconditionally, does not even need to be executed
-    pub const OP_CAT: All = All {code: 0x7e};
-    /// Fail the script unconditionally, does not even need to be executed
-    pub const OP_SUBSTR: All = All {code: 0x7f};
-    /// Fail the script unconditionally, does not even need to be executed
-    pub const OP_LEFT: All = All {code: 0x80};
-    /// Fail the script unconditionally, does not even need to be executed
-    pub const OP_RIGHT: All = All {code: 0x81};
-    /// Pushes the length of the top stack item onto the stack
-    pub const OP_SIZE: All = All {code: 0x82};
-    /// Fail the script unconditionally, does not even need to be executed
-    pub const OP_INVERT: All = All {code: 0x83};
-    /// Fail the script unconditionally, does not even need to be executed
-    pub const OP_AND: All = All {code: 0x84};
-    /// Fail the script unconditionally, does not even need to be executed
-    pub const OP_OR: All = All {code: 0x85};
-    /// Fail the script unconditionally, does not even need to be executed
-    pub const OP_XOR: All = All {code: 0x86};
-    /// Pushes 1 if the inputs are exactly equal, 0 otherwise
-    pub const OP_EQUAL: All = All {code: 0x87};
-    /// Returns success if the inputs are exactly equal, failure otherwise
-    pub const OP_EQUALVERIFY: All = All {code: 0x88};
-    /// Synonym for OP_RETURN
-    pub const OP_RESERVED1: All = All {code: 0x89};
-    /// Synonym for OP_RETURN
-    pub const OP_RESERVED2: All = All {code: 0x8a};
-    /// Increment the top stack element in place
-    pub const OP_1ADD: All = All {code: 0x8b};
-    /// Decrement the top stack element in place
-    pub const OP_1SUB: All = All {code: 0x8c};
-    /// Fail the script unconditionally, does not even need to be executed
-    pub const OP_2MUL: All = All {code: 0x8d};
-    /// Fail the script unconditionally, does not even need to be executed
-    pub const OP_2DIV: All = All {code: 0x8e};
-    /// Multiply the top stack item by -1 in place
-    pub const OP_NEGATE: All = All {code: 0x8f};
-    /// Absolute value the top stack item in place
-    pub const OP_ABS: All = All {code: 0x90};
-    /// Map 0 to 1 and everything else to 0, in place
-    pub const OP_NOT: All = All {code: 0x91};
-    /// Map 0 to 0 and everything else to 1, in place
-    pub const OP_0NOTEQUAL: All = All {code: 0x92};
-    /// Pop two stack items and push their sum
-    pub const OP_ADD: All = All {code: 0x93};
-    /// Pop two stack items and push the second minus the top
-    pub const OP_SUB: All = All {code: 0x94};
-    /// Fail the script unconditionally, does not even need to be executed
-    pub const OP_MUL: All = All {code: 0x95};
-    /// Fail the script unconditionally, does not even need to be executed
-    pub const OP_DIV: All = All {code: 0x96};
-    /// Fail the script unconditionally, does not even need to be executed
-    pub const OP_MOD: All = All {code: 0x97};
-    /// Fail the script unconditionally, does not even need to be executed
-    pub const OP_LSHIFT: All = All {code: 0x98};
-    /// Fail the script unconditionally, does not even need to be executed
-    pub const OP_RSHIFT: All = All {code: 0x99};
-    /// Pop the top two stack items and push 1 if both are nonzero, else push 0
-    pub const OP_BOOLAND: All = All {code: 0x9a};
-    /// Pop the top two stack items and push 1 if either is nonzero, else push 0
-    pub const OP_BOOLOR: All = All {code: 0x9b};
-    /// Pop the top two stack items and push 1 if both are numerically equal, else push 0
-    pub const OP_NUMEQUAL: All = All {code: 0x9c};
-    /// Pop the top two stack items and return success if both are numerically equal, else return failure
-    pub const OP_NUMEQUALVERIFY: All = All {code: 0x9d};
-    /// Pop the top two stack items and push 0 if both are numerically equal, else push 1
-    pub const OP_NUMNOTEQUAL: All = All {code: 0x9e};
-    /// Pop the top two items; push 1 if the second is less than the top, 0 otherwise
-    pub const OP_LESSTHAN : All = All {code: 0x9f};
-    /// Pop the top two items; push 1 if the second is greater than the top, 0 otherwise
-    pub const OP_GREATERTHAN : All = All {code: 0xa0};
-    /// Pop the top two items; push 1 if the second is <= the top, 0 otherwise
-    pub const OP_LESSTHANOREQUAL : All = All {code: 0xa1};
-    /// Pop the top two items; push 1 if the second is >= the top, 0 otherwise
-    pub const OP_GREATERTHANOREQUAL : All = All {code: 0xa2};
-    /// Pop the top two items; push the smaller
-    pub const OP_MIN: All = All {code: 0xa3};
-    /// Pop the top two items; push the larger
-    pub const OP_MAX: All = All {code: 0xa4};
-    /// Pop the top three items; if the top is >= the second and < the third, push 1, otherwise push 0
-    pub const OP_WITHIN: All = All {code: 0xa5};
-    /// Pop the top stack item and push its RIPEMD160 hash
-    pub const OP_RIPEMD160: All = All {code: 0xa6};
-    /// Pop the top stack item and push its SHA1 hash
-    pub const OP_SHA1: All = All {code: 0xa7};
-    /// Pop the top stack item and push its SHA256 hash
-    pub const OP_SHA256: All = All {code: 0xa8};
-    /// Pop the top stack item and push its RIPEMD(SHA256) hash
-    pub const OP_HASH160: All = All {code: 0xa9};
-    /// Pop the top stack item and push its SHA256(SHA256) hash
-    pub const OP_HASH256: All = All {code: 0xaa};
-    /// Ignore this and everything preceding when deciding what to sign when signature-checking
-    pub const OP_CODESEPARATOR: All = All {code: 0xab};
-    /// <https://en.bitcoin.it/wiki/OP_CHECKSIG> pushing 1/0 for success/failure
-    pub const OP_CHECKSIG: All = All {code: 0xac};
-    /// <https://en.bitcoin.it/wiki/OP_CHECKSIG> returning success/failure
-    pub const OP_CHECKSIGVERIFY: All = All {code: 0xad};
-    /// Pop N, N pubkeys, M, M signatures, a dummy (due to bug in reference code), and verify that all M signatures are valid.
-    /// Push 1 for "all valid", 0 otherwise
-    pub const OP_CHECKMULTISIG: All = All {code: 0xae};
-    /// Like the above but return success/failure
-    pub const OP_CHECKMULTISIGVERIFY: All = All {code: 0xaf};
-    /// Does nothing
-    pub const OP_NOP1: All = All {code: 0xb0};
-    /// <https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki>
-    pub const OP_CLTV: All = All {code: 0xb1};
-    /// <https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki>
-    pub const OP_CSV: All = All {code: 0xb2};
-    /// Does nothing
-    pub const OP_NOP4: All = All {code: 0xb3};
-    /// Does nothing
-    pub const OP_NOP5: All = All {code: 0xb4};
-    /// Does nothing
-    pub const OP_NOP6: All = All {code: 0xb5};
-    /// Does nothing
-    pub const OP_NOP7: All = All {code: 0xb6};
-    /// Does nothing
-    pub const OP_NOP8: All = All {code: 0xb7};
-    /// Does nothing
-    pub const OP_NOP9: All = All {code: 0xb8};
-    /// Does nothing
-    pub const OP_NOP10: All = All {code: 0xb9};
-    // Every other opcode acts as OP_RETURN
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_186: All = All {code: 0xba};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_187: All = All {code: 0xbb};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_188: All = All {code: 0xbc};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_189: All = All {code: 0xbd};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_190: All = All {code: 0xbe};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_191: All = All {code: 0xbf};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_192: All = All {code: 0xc0};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_193: All = All {code: 0xc1};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_194: All = All {code: 0xc2};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_195: All = All {code: 0xc3};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_196: All = All {code: 0xc4};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_197: All = All {code: 0xc5};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_198: All = All {code: 0xc6};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_199: All = All {code: 0xc7};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_200: All = All {code: 0xc8};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_201: All = All {code: 0xc9};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_202: All = All {code: 0xca};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_203: All = All {code: 0xcb};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_204: All = All {code: 0xcc};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_205: All = All {code: 0xcd};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_206: All = All {code: 0xce};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_207: All = All {code: 0xcf};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_208: All = All {code: 0xd0};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_209: All = All {code: 0xd1};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_210: All = All {code: 0xd2};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_211: All = All {code: 0xd3};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_212: All = All {code: 0xd4};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_213: All = All {code: 0xd5};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_214: All = All {code: 0xd6};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_215: All = All {code: 0xd7};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_216: All = All {code: 0xd8};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_217: All = All {code: 0xd9};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_218: All = All {code: 0xda};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_219: All = All {code: 0xdb};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_220: All = All {code: 0xdc};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_221: All = All {code: 0xdd};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_222: All = All {code: 0xde};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_223: All = All {code: 0xdf};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_224: All = All {code: 0xe0};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_225: All = All {code: 0xe1};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_226: All = All {code: 0xe2};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_227: All = All {code: 0xe3};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_228: All = All {code: 0xe4};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_229: All = All {code: 0xe5};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_230: All = All {code: 0xe6};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_231: All = All {code: 0xe7};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_232: All = All {code: 0xe8};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_233: All = All {code: 0xe9};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_234: All = All {code: 0xea};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_235: All = All {code: 0xeb};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_236: All = All {code: 0xec};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_237: All = All {code: 0xed};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_238: All = All {code: 0xee};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_239: All = All {code: 0xef};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_240: All = All {code: 0xf0};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_241: All = All {code: 0xf1};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_242: All = All {code: 0xf2};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_243: All = All {code: 0xf3};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_244: All = All {code: 0xf4};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_245: All = All {code: 0xf5};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_246: All = All {code: 0xf6};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_247: All = All {code: 0xf7};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_248: All = All {code: 0xf8};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_249: All = All {code: 0xf9};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_250: All = All {code: 0xfa};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_251: All = All {code: 0xfb};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_252: All = All {code: 0xfc};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_253: All = All {code: 0xfd};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_254: All = All {code: 0xfe};
-    /// Synonym for OP_RETURN
-    pub const OP_RETURN_255: All = All {code: 0xff};
+	/// Push an empty array onto the stack
+	pub const OP_PUSHBYTES_0: All = All { code: 0x00 };
+	/// Push the next byte as an array onto the stack
+	pub const OP_PUSHBYTES_1: All = All { code: 0x01 };
+	/// Push the next 2 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_2: All = All { code: 0x02 };
+	/// Push the next 2 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_3: All = All { code: 0x03 };
+	/// Push the next 4 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_4: All = All { code: 0x04 };
+	/// Push the next 5 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_5: All = All { code: 0x05 };
+	/// Push the next 6 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_6: All = All { code: 0x06 };
+	/// Push the next 7 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_7: All = All { code: 0x07 };
+	/// Push the next 8 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_8: All = All { code: 0x08 };
+	/// Push the next 9 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_9: All = All { code: 0x09 };
+	/// Push the next 10 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_10: All = All { code: 0x0a };
+	/// Push the next 11 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_11: All = All { code: 0x0b };
+	/// Push the next 12 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_12: All = All { code: 0x0c };
+	/// Push the next 13 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_13: All = All { code: 0x0d };
+	/// Push the next 14 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_14: All = All { code: 0x0e };
+	/// Push the next 15 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_15: All = All { code: 0x0f };
+	/// Push the next 16 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_16: All = All { code: 0x10 };
+	/// Push the next 17 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_17: All = All { code: 0x11 };
+	/// Push the next 18 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_18: All = All { code: 0x12 };
+	/// Push the next 19 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_19: All = All { code: 0x13 };
+	/// Push the next 20 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_20: All = All { code: 0x14 };
+	/// Push the next 21 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_21: All = All { code: 0x15 };
+	/// Push the next 22 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_22: All = All { code: 0x16 };
+	/// Push the next 23 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_23: All = All { code: 0x17 };
+	/// Push the next 24 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_24: All = All { code: 0x18 };
+	/// Push the next 25 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_25: All = All { code: 0x19 };
+	/// Push the next 26 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_26: All = All { code: 0x1a };
+	/// Push the next 27 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_27: All = All { code: 0x1b };
+	/// Push the next 28 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_28: All = All { code: 0x1c };
+	/// Push the next 29 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_29: All = All { code: 0x1d };
+	/// Push the next 30 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_30: All = All { code: 0x1e };
+	/// Push the next 31 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_31: All = All { code: 0x1f };
+	/// Push the next 32 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_32: All = All { code: 0x20 };
+	/// Push the next 33 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_33: All = All { code: 0x21 };
+	/// Push the next 34 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_34: All = All { code: 0x22 };
+	/// Push the next 35 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_35: All = All { code: 0x23 };
+	/// Push the next 36 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_36: All = All { code: 0x24 };
+	/// Push the next 37 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_37: All = All { code: 0x25 };
+	/// Push the next 38 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_38: All = All { code: 0x26 };
+	/// Push the next 39 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_39: All = All { code: 0x27 };
+	/// Push the next 40 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_40: All = All { code: 0x28 };
+	/// Push the next 41 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_41: All = All { code: 0x29 };
+	/// Push the next 42 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_42: All = All { code: 0x2a };
+	/// Push the next 43 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_43: All = All { code: 0x2b };
+	/// Push the next 44 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_44: All = All { code: 0x2c };
+	/// Push the next 45 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_45: All = All { code: 0x2d };
+	/// Push the next 46 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_46: All = All { code: 0x2e };
+	/// Push the next 47 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_47: All = All { code: 0x2f };
+	/// Push the next 48 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_48: All = All { code: 0x30 };
+	/// Push the next 49 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_49: All = All { code: 0x31 };
+	/// Push the next 50 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_50: All = All { code: 0x32 };
+	/// Push the next 51 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_51: All = All { code: 0x33 };
+	/// Push the next 52 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_52: All = All { code: 0x34 };
+	/// Push the next 53 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_53: All = All { code: 0x35 };
+	/// Push the next 54 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_54: All = All { code: 0x36 };
+	/// Push the next 55 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_55: All = All { code: 0x37 };
+	/// Push the next 56 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_56: All = All { code: 0x38 };
+	/// Push the next 57 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_57: All = All { code: 0x39 };
+	/// Push the next 58 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_58: All = All { code: 0x3a };
+	/// Push the next 59 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_59: All = All { code: 0x3b };
+	/// Push the next 60 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_60: All = All { code: 0x3c };
+	/// Push the next 61 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_61: All = All { code: 0x3d };
+	/// Push the next 62 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_62: All = All { code: 0x3e };
+	/// Push the next 63 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_63: All = All { code: 0x3f };
+	/// Push the next 64 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_64: All = All { code: 0x40 };
+	/// Push the next 65 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_65: All = All { code: 0x41 };
+	/// Push the next 66 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_66: All = All { code: 0x42 };
+	/// Push the next 67 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_67: All = All { code: 0x43 };
+	/// Push the next 68 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_68: All = All { code: 0x44 };
+	/// Push the next 69 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_69: All = All { code: 0x45 };
+	/// Push the next 70 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_70: All = All { code: 0x46 };
+	/// Push the next 71 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_71: All = All { code: 0x47 };
+	/// Push the next 72 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_72: All = All { code: 0x48 };
+	/// Push the next 73 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_73: All = All { code: 0x49 };
+	/// Push the next 74 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_74: All = All { code: 0x4a };
+	/// Push the next 75 bytes as an array onto the stack
+	pub const OP_PUSHBYTES_75: All = All { code: 0x4b };
+	/// Read the next byte as N; push the next N bytes as an array onto the stack
+	pub const OP_PUSHDATA1: All = All { code: 0x4c };
+	/// Read the next 2 bytes as N; push the next N bytes as an array onto the stack
+	pub const OP_PUSHDATA2: All = All { code: 0x4d };
+	/// Read the next 4 bytes as N; push the next N bytes as an array onto the stack
+	pub const OP_PUSHDATA4: All = All { code: 0x4e };
+	/// Push the array `0x81` onto the stack
+	pub const OP_PUSHNUM_NEG1: All = All { code: 0x4f };
+	/// Synonym for OP_RETURN
+	pub const OP_RESERVED: All = All { code: 0x50 };
+	/// Push the array `0x01` onto the stack
+	pub const OP_PUSHNUM_1: All = All { code: 0x51 };
+	/// Push the array `0x02` onto the stack
+	pub const OP_PUSHNUM_2: All = All { code: 0x52 };
+	/// Push the array `0x03` onto the stack
+	pub const OP_PUSHNUM_3: All = All { code: 0x53 };
+	/// Push the array `0x04` onto the stack
+	pub const OP_PUSHNUM_4: All = All { code: 0x54 };
+	/// Push the array `0x05` onto the stack
+	pub const OP_PUSHNUM_5: All = All { code: 0x55 };
+	/// Push the array `0x06` onto the stack
+	pub const OP_PUSHNUM_6: All = All { code: 0x56 };
+	/// Push the array `0x07` onto the stack
+	pub const OP_PUSHNUM_7: All = All { code: 0x57 };
+	/// Push the array `0x08` onto the stack
+	pub const OP_PUSHNUM_8: All = All { code: 0x58 };
+	/// Push the array `0x09` onto the stack
+	pub const OP_PUSHNUM_9: All = All { code: 0x59 };
+	/// Push the array `0x0a` onto the stack
+	pub const OP_PUSHNUM_10: All = All { code: 0x5a };
+	/// Push the array `0x0b` onto the stack
+	pub const OP_PUSHNUM_11: All = All { code: 0x5b };
+	/// Push the array `0x0c` onto the stack
+	pub const OP_PUSHNUM_12: All = All { code: 0x5c };
+	/// Push the array `0x0d` onto the stack
+	pub const OP_PUSHNUM_13: All = All { code: 0x5d };
+	/// Push the array `0x0e` onto the stack
+	pub const OP_PUSHNUM_14: All = All { code: 0x5e };
+	/// Push the array `0x0f` onto the stack
+	pub const OP_PUSHNUM_15: All = All { code: 0x5f };
+	/// Push the array `0x10` onto the stack
+	pub const OP_PUSHNUM_16: All = All { code: 0x60 };
+	/// Does nothing
+	pub const OP_NOP: All = All { code: 0x61 };
+	/// Synonym for OP_RETURN
+	pub const OP_VER: All = All { code: 0x62 };
+	/// Pop and execute the next statements if a nonzero element was popped
+	pub const OP_IF: All = All { code: 0x63 };
+	/// Pop and execute the next statements if a zero element was popped
+	pub const OP_NOTIF: All = All { code: 0x64 };
+	/// Fail the script unconditionally, does not even need to be executed
+	pub const OP_VERIF: All = All { code: 0x65 };
+	/// Fail the script unconditionally, does not even need to be executed
+	pub const OP_VERNOTIF: All = All { code: 0x66 };
+	/// Execute statements if those after the previous OP_IF were not, and vice-versa.
+	/// If there is no previous OP_IF, this acts as a RETURN.
+	pub const OP_ELSE: All = All { code: 0x67 };
+	/// Pop and execute the next statements if a zero element was popped
+	pub const OP_ENDIF: All = All { code: 0x68 };
+	/// If the top value is zero or the stack is empty, fail; otherwise, pop the stack
+	pub const OP_VERIFY: All = All { code: 0x69 };
+	/// Fail the script immediately. (Must be executed.)
+	pub const OP_RETURN: All = All { code: 0x6a };
+	/// Pop one element from the main stack onto the alt stack
+	pub const OP_TOALTSTACK: All = All { code: 0x6b };
+	/// Pop one element from the alt stack onto the main stack
+	pub const OP_FROMALTSTACK: All = All { code: 0x6c };
+	/// Drops the top two stack items
+	pub const OP_2DROP: All = All { code: 0x6d };
+	/// Duplicates the top two stack items as AB -> ABAB
+	pub const OP_2DUP: All = All { code: 0x6e };
+	/// Duplicates the two three stack items as ABC -> ABCABC
+	pub const OP_3DUP: All = All { code: 0x6f };
+	/// Copies the two stack items of items two spaces back to
+	/// the front, as xxAB -> ABxxAB
+	pub const OP_2OVER: All = All { code: 0x70 };
+	/// Moves the two stack items four spaces back to the front,
+	/// as xxxxAB -> ABxxxx
+	pub const OP_2ROT: All = All { code: 0x71 };
+	/// Swaps the top two pairs, as ABCD -> CDAB
+	pub const OP_2SWAP: All = All { code: 0x72 };
+	/// Duplicate the top stack element unless it is zero
+	pub const OP_IFDUP: All = All { code: 0x73 };
+	/// Push the current number of stack items onto the stack
+	pub const OP_DEPTH: All = All { code: 0x74 };
+	/// Drops the top stack item
+	pub const OP_DROP: All = All { code: 0x75 };
+	/// Duplicates the top stack item
+	pub const OP_DUP: All = All { code: 0x76 };
+	/// Drops the second-to-top stack item
+	pub const OP_NIP: All = All { code: 0x77 };
+	/// Copies the second-to-top stack item, as xA -> AxA
+	pub const OP_OVER: All = All { code: 0x78 };
+	/// Pop the top stack element as N. Copy the Nth stack element to the top
+	pub const OP_PICK: All = All { code: 0x79 };
+	/// Pop the top stack element as N. Move the Nth stack element to the top
+	pub const OP_ROLL: All = All { code: 0x7a };
+	/// Rotate the top three stack items, as [top next1 next2] -> [next2 top next1]
+	pub const OP_ROT: All = All { code: 0x7b };
+	/// Swap the top two stack items
+	pub const OP_SWAP: All = All { code: 0x7c };
+	/// Copy the top stack item to before the second item, as [top next] -> [top next top]
+	pub const OP_TUCK: All = All { code: 0x7d };
+	/// Fail the script unconditionally, does not even need to be executed
+	pub const OP_CAT: All = All { code: 0x7e };
+	/// Fail the script unconditionally, does not even need to be executed
+	pub const OP_SUBSTR: All = All { code: 0x7f };
+	/// Fail the script unconditionally, does not even need to be executed
+	pub const OP_LEFT: All = All { code: 0x80 };
+	/// Fail the script unconditionally, does not even need to be executed
+	pub const OP_RIGHT: All = All { code: 0x81 };
+	/// Pushes the length of the top stack item onto the stack
+	pub const OP_SIZE: All = All { code: 0x82 };
+	/// Fail the script unconditionally, does not even need to be executed
+	pub const OP_INVERT: All = All { code: 0x83 };
+	/// Fail the script unconditionally, does not even need to be executed
+	pub const OP_AND: All = All { code: 0x84 };
+	/// Fail the script unconditionally, does not even need to be executed
+	pub const OP_OR: All = All { code: 0x85 };
+	/// Fail the script unconditionally, does not even need to be executed
+	pub const OP_XOR: All = All { code: 0x86 };
+	/// Pushes 1 if the inputs are exactly equal, 0 otherwise
+	pub const OP_EQUAL: All = All { code: 0x87 };
+	/// Returns success if the inputs are exactly equal, failure otherwise
+	pub const OP_EQUALVERIFY: All = All { code: 0x88 };
+	/// Synonym for OP_RETURN
+	pub const OP_RESERVED1: All = All { code: 0x89 };
+	/// Synonym for OP_RETURN
+	pub const OP_RESERVED2: All = All { code: 0x8a };
+	/// Increment the top stack element in place
+	pub const OP_1ADD: All = All { code: 0x8b };
+	/// Decrement the top stack element in place
+	pub const OP_1SUB: All = All { code: 0x8c };
+	/// Fail the script unconditionally, does not even need to be executed
+	pub const OP_2MUL: All = All { code: 0x8d };
+	/// Fail the script unconditionally, does not even need to be executed
+	pub const OP_2DIV: All = All { code: 0x8e };
+	/// Multiply the top stack item by -1 in place
+	pub const OP_NEGATE: All = All { code: 0x8f };
+	/// Absolute value the top stack item in place
+	pub const OP_ABS: All = All { code: 0x90 };
+	/// Map 0 to 1 and everything else to 0, in place
+	pub const OP_NOT: All = All { code: 0x91 };
+	/// Map 0 to 0 and everything else to 1, in place
+	pub const OP_0NOTEQUAL: All = All { code: 0x92 };
+	/// Pop two stack items and push their sum
+	pub const OP_ADD: All = All { code: 0x93 };
+	/// Pop two stack items and push the second minus the top
+	pub const OP_SUB: All = All { code: 0x94 };
+	/// Fail the script unconditionally, does not even need to be executed
+	pub const OP_MUL: All = All { code: 0x95 };
+	/// Fail the script unconditionally, does not even need to be executed
+	pub const OP_DIV: All = All { code: 0x96 };
+	/// Fail the script unconditionally, does not even need to be executed
+	pub const OP_MOD: All = All { code: 0x97 };
+	/// Fail the script unconditionally, does not even need to be executed
+	pub const OP_LSHIFT: All = All { code: 0x98 };
+	/// Fail the script unconditionally, does not even need to be executed
+	pub const OP_RSHIFT: All = All { code: 0x99 };
+	/// Pop the top two stack items and push 1 if both are nonzero, else push 0
+	pub const OP_BOOLAND: All = All { code: 0x9a };
+	/// Pop the top two stack items and push 1 if either is nonzero, else push 0
+	pub const OP_BOOLOR: All = All { code: 0x9b };
+	/// Pop the top two stack items and push 1 if both are numerically equal, else push 0
+	pub const OP_NUMEQUAL: All = All { code: 0x9c };
+	/// Pop the top two stack items and return success if both are numerically equal, else return
+	/// failure
+	pub const OP_NUMEQUALVERIFY: All = All { code: 0x9d };
+	/// Pop the top two stack items and push 0 if both are numerically equal, else push 1
+	pub const OP_NUMNOTEQUAL: All = All { code: 0x9e };
+	/// Pop the top two items; push 1 if the second is less than the top, 0 otherwise
+	pub const OP_LESSTHAN: All = All { code: 0x9f };
+	/// Pop the top two items; push 1 if the second is greater than the top, 0 otherwise
+	pub const OP_GREATERTHAN: All = All { code: 0xa0 };
+	/// Pop the top two items; push 1 if the second is <= the top, 0 otherwise
+	pub const OP_LESSTHANOREQUAL: All = All { code: 0xa1 };
+	/// Pop the top two items; push 1 if the second is >= the top, 0 otherwise
+	pub const OP_GREATERTHANOREQUAL: All = All { code: 0xa2 };
+	/// Pop the top two items; push the smaller
+	pub const OP_MIN: All = All { code: 0xa3 };
+	/// Pop the top two items; push the larger
+	pub const OP_MAX: All = All { code: 0xa4 };
+	/// Pop the top three items; if the top is >= the second and < the third, push 1, otherwise push
+	/// 0
+	pub const OP_WITHIN: All = All { code: 0xa5 };
+	/// Pop the top stack item and push its RIPEMD160 hash
+	pub const OP_RIPEMD160: All = All { code: 0xa6 };
+	/// Pop the top stack item and push its SHA1 hash
+	pub const OP_SHA1: All = All { code: 0xa7 };
+	/// Pop the top stack item and push its SHA256 hash
+	pub const OP_SHA256: All = All { code: 0xa8 };
+	/// Pop the top stack item and push its RIPEMD(SHA256) hash
+	pub const OP_HASH160: All = All { code: 0xa9 };
+	/// Pop the top stack item and push its SHA256(SHA256) hash
+	pub const OP_HASH256: All = All { code: 0xaa };
+	/// Ignore this and everything preceding when deciding what to sign when signature-checking
+	pub const OP_CODESEPARATOR: All = All { code: 0xab };
+	/// <https://en.bitcoin.it/wiki/OP_CHECKSIG> pushing 1/0 for success/failure
+	pub const OP_CHECKSIG: All = All { code: 0xac };
+	/// <https://en.bitcoin.it/wiki/OP_CHECKSIG> returning success/failure
+	pub const OP_CHECKSIGVERIFY: All = All { code: 0xad };
+	/// Pop N, N pubkeys, M, M signatures, a dummy (due to bug in reference code), and verify that
+	/// all M signatures are valid. Push 1 for "all valid", 0 otherwise
+	pub const OP_CHECKMULTISIG: All = All { code: 0xae };
+	/// Like the above but return success/failure
+	pub const OP_CHECKMULTISIGVERIFY: All = All { code: 0xaf };
+	/// Does nothing
+	pub const OP_NOP1: All = All { code: 0xb0 };
+	/// <https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki>
+	pub const OP_CLTV: All = All { code: 0xb1 };
+	/// <https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki>
+	pub const OP_CSV: All = All { code: 0xb2 };
+	/// Does nothing
+	pub const OP_NOP4: All = All { code: 0xb3 };
+	/// Does nothing
+	pub const OP_NOP5: All = All { code: 0xb4 };
+	/// Does nothing
+	pub const OP_NOP6: All = All { code: 0xb5 };
+	/// Does nothing
+	pub const OP_NOP7: All = All { code: 0xb6 };
+	/// Does nothing
+	pub const OP_NOP8: All = All { code: 0xb7 };
+	/// Does nothing
+	pub const OP_NOP9: All = All { code: 0xb8 };
+	/// Does nothing
+	pub const OP_NOP10: All = All { code: 0xb9 };
+	// Every other opcode acts as OP_RETURN
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_186: All = All { code: 0xba };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_187: All = All { code: 0xbb };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_188: All = All { code: 0xbc };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_189: All = All { code: 0xbd };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_190: All = All { code: 0xbe };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_191: All = All { code: 0xbf };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_192: All = All { code: 0xc0 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_193: All = All { code: 0xc1 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_194: All = All { code: 0xc2 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_195: All = All { code: 0xc3 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_196: All = All { code: 0xc4 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_197: All = All { code: 0xc5 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_198: All = All { code: 0xc6 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_199: All = All { code: 0xc7 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_200: All = All { code: 0xc8 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_201: All = All { code: 0xc9 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_202: All = All { code: 0xca };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_203: All = All { code: 0xcb };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_204: All = All { code: 0xcc };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_205: All = All { code: 0xcd };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_206: All = All { code: 0xce };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_207: All = All { code: 0xcf };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_208: All = All { code: 0xd0 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_209: All = All { code: 0xd1 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_210: All = All { code: 0xd2 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_211: All = All { code: 0xd3 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_212: All = All { code: 0xd4 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_213: All = All { code: 0xd5 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_214: All = All { code: 0xd6 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_215: All = All { code: 0xd7 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_216: All = All { code: 0xd8 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_217: All = All { code: 0xd9 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_218: All = All { code: 0xda };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_219: All = All { code: 0xdb };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_220: All = All { code: 0xdc };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_221: All = All { code: 0xdd };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_222: All = All { code: 0xde };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_223: All = All { code: 0xdf };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_224: All = All { code: 0xe0 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_225: All = All { code: 0xe1 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_226: All = All { code: 0xe2 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_227: All = All { code: 0xe3 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_228: All = All { code: 0xe4 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_229: All = All { code: 0xe5 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_230: All = All { code: 0xe6 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_231: All = All { code: 0xe7 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_232: All = All { code: 0xe8 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_233: All = All { code: 0xe9 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_234: All = All { code: 0xea };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_235: All = All { code: 0xeb };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_236: All = All { code: 0xec };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_237: All = All { code: 0xed };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_238: All = All { code: 0xee };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_239: All = All { code: 0xef };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_240: All = All { code: 0xf0 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_241: All = All { code: 0xf1 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_242: All = All { code: 0xf2 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_243: All = All { code: 0xf3 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_244: All = All { code: 0xf4 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_245: All = All { code: 0xf5 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_246: All = All { code: 0xf6 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_247: All = All { code: 0xf7 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_248: All = All { code: 0xf8 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_249: All = All { code: 0xf9 };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_250: All = All { code: 0xfa };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_251: All = All { code: 0xfb };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_252: All = All { code: 0xfc };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_253: All = All { code: 0xfd };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_254: All = All { code: 0xfe };
+	/// Synonym for OP_RETURN
+	pub const OP_RETURN_255: All = All { code: 0xff };
 }
 
 impl fmt::Debug for All {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("OP_")?;
-        match *self {
-            All {code: x} if x <= 75 => write!(f, "PUSHBYTES_{}", self.code),
-            all::OP_PUSHDATA1 => write!(f, "PUSHDATA1"),
-            all::OP_PUSHDATA2 => write!(f, "PUSHDATA2"),
-            all::OP_PUSHDATA4 => write!(f, "PUSHDATA4"),
-            all::OP_PUSHNUM_NEG1 => write!(f, "PUSHNUM_NEG1"),
-            all::OP_RESERVED => write!(f, "RESERVED"),
-            All {code: x} if x >= all::OP_PUSHNUM_1.code && x <= all::OP_PUSHNUM_16.code => write!(f, "PUSHNUM_{}", x - all::OP_PUSHNUM_1.code + 1),
-            all::OP_NOP => write!(f, "NOP"),
-            all::OP_VER => write!(f, "VER"),
-            all::OP_IF => write!(f, "IF"),
-            all::OP_NOTIF => write!(f, "NOTIF"),
-            all::OP_VERIF => write!(f, "VERIF"),
-            all::OP_VERNOTIF => write!(f, "VERNOTIF"),
-            all::OP_ELSE => write!(f, "ELSE"),
-            all::OP_ENDIF => write!(f, "ENDIF"),
-            all::OP_VERIFY => write!(f, "VERIFY"),
-            all::OP_RETURN => write!(f, "RETURN"),
-            all::OP_TOALTSTACK => write!(f, "TOALTSTACK"),
-            all::OP_FROMALTSTACK => write!(f, "FROMALTSTACK"),
-            all::OP_2DROP => write!(f, "2DROP"),
-            all::OP_2DUP => write!(f, "2DUP"),
-            all::OP_3DUP => write!(f, "3DUP"),
-            all::OP_2OVER => write!(f, "2OVER"),
-            all::OP_2ROT => write!(f, "2ROT"),
-            all::OP_2SWAP => write!(f, "2SWAP"),
-            all::OP_IFDUP => write!(f, "IFDUP"),
-            all::OP_DEPTH => write!(f, "DEPTH"),
-            all::OP_DROP => write!(f, "DROP"),
-            all::OP_DUP => write!(f, "DUP"),
-            all::OP_NIP => write!(f, "NIP"),
-            all::OP_OVER => write!(f, "OVER"),
-            all::OP_PICK => write!(f, "PICK"),
-            all::OP_ROLL => write!(f, "ROLL"),
-            all::OP_ROT => write!(f, "ROT"),
-            all::OP_SWAP => write!(f, "SWAP"),
-            all::OP_TUCK => write!(f, "TUCK"),
-            all::OP_CAT => write!(f, "CAT"),
-            all::OP_SUBSTR => write!(f, "SUBSTR"),
-            all::OP_LEFT => write!(f, "LEFT"),
-            all::OP_RIGHT => write!(f, "RIGHT"),
-            all::OP_SIZE => write!(f, "SIZE"),
-            all::OP_INVERT => write!(f, "INVERT"),
-            all::OP_AND => write!(f, "AND"),
-            all::OP_OR => write!(f, "OR"),
-            all::OP_XOR => write!(f, "XOR"),
-            all::OP_EQUAL => write!(f, "EQUAL"),
-            all::OP_EQUALVERIFY => write!(f, "EQUALVERIFY"),
-            all::OP_RESERVED1 => write!(f, "RESERVED1"),
-            all::OP_RESERVED2 => write!(f, "RESERVED2"),
-            all::OP_1ADD => write!(f, "1ADD"),
-            all::OP_1SUB => write!(f, "1SUB"),
-            all::OP_2MUL => write!(f, "2MUL"),
-            all::OP_2DIV => write!(f, "2DIV"),
-            all::OP_NEGATE => write!(f, "NEGATE"),
-            all::OP_ABS => write!(f, "ABS"),
-            all::OP_NOT => write!(f, "NOT"),
-            all::OP_0NOTEQUAL => write!(f, "0NOTEQUAL"),
-            all::OP_ADD => write!(f, "ADD"),
-            all::OP_SUB => write!(f, "SUB"),
-            all::OP_MUL => write!(f, "MUL"),
-            all::OP_DIV => write!(f, "DIV"),
-            all::OP_MOD => write!(f, "MOD"),
-            all::OP_LSHIFT => write!(f, "LSHIFT"),
-            all::OP_RSHIFT => write!(f, "RSHIFT"),
-            all::OP_BOOLAND => write!(f, "BOOLAND"),
-            all::OP_BOOLOR => write!(f, "BOOLOR"),
-            all::OP_NUMEQUAL => write!(f, "NUMEQUAL"),
-            all::OP_NUMEQUALVERIFY => write!(f, "NUMEQUALVERIFY"),
-            all::OP_NUMNOTEQUAL => write!(f, "NUMNOTEQUAL"),
-            all::OP_LESSTHAN  => write!(f, "LESSTHAN"),
-            all::OP_GREATERTHAN  => write!(f, "GREATERTHAN"),
-            all::OP_LESSTHANOREQUAL  => write!(f, "LESSTHANOREQUAL"),
-            all::OP_GREATERTHANOREQUAL  => write!(f, "GREATERTHANOREQUAL"),
-            all::OP_MIN => write!(f, "MIN"),
-            all::OP_MAX => write!(f, "MAX"),
-            all::OP_WITHIN => write!(f, "WITHIN"),
-            all::OP_RIPEMD160 => write!(f, "RIPEMD160"),
-            all::OP_SHA1 => write!(f, "SHA1"),
-            all::OP_SHA256 => write!(f, "SHA256"),
-            all::OP_HASH160 => write!(f, "HASH160"),
-            all::OP_HASH256 => write!(f, "HASH256"),
-            all::OP_CODESEPARATOR => write!(f, "CODESEPARATOR"),
-            all::OP_CHECKSIG => write!(f, "CHECKSIG"),
-            all::OP_CHECKSIGVERIFY => write!(f, "CHECKSIGVERIFY"),
-            all::OP_CHECKMULTISIG => write!(f, "CHECKMULTISIG"),
-            all::OP_CHECKMULTISIGVERIFY => write!(f, "CHECKMULTISIGVERIFY"),
-            all::OP_CLTV => write!(f, "CLTV"),
-            all::OP_CSV => write!(f, "CSV"),
-            All {code: x} if x >= all::OP_NOP1.code && x <= all::OP_NOP10.code => write!(f, "NOP{}", x - all::OP_NOP1.code + 1),
-            All {code: x} => write!(f, "RETURN_{}", x),
-        }
-    }
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		f.write_str("OP_")?;
+		match *self {
+			All { code: x } if x <= 75 => write!(f, "PUSHBYTES_{}", self.code),
+			all::OP_PUSHDATA1 => write!(f, "PUSHDATA1"),
+			all::OP_PUSHDATA2 => write!(f, "PUSHDATA2"),
+			all::OP_PUSHDATA4 => write!(f, "PUSHDATA4"),
+			all::OP_PUSHNUM_NEG1 => write!(f, "PUSHNUM_NEG1"),
+			all::OP_RESERVED => write!(f, "RESERVED"),
+			All { code: x } if x >= all::OP_PUSHNUM_1.code && x <= all::OP_PUSHNUM_16.code =>
+				write!(f, "PUSHNUM_{}", x - all::OP_PUSHNUM_1.code + 1),
+			all::OP_NOP => write!(f, "NOP"),
+			all::OP_VER => write!(f, "VER"),
+			all::OP_IF => write!(f, "IF"),
+			all::OP_NOTIF => write!(f, "NOTIF"),
+			all::OP_VERIF => write!(f, "VERIF"),
+			all::OP_VERNOTIF => write!(f, "VERNOTIF"),
+			all::OP_ELSE => write!(f, "ELSE"),
+			all::OP_ENDIF => write!(f, "ENDIF"),
+			all::OP_VERIFY => write!(f, "VERIFY"),
+			all::OP_RETURN => write!(f, "RETURN"),
+			all::OP_TOALTSTACK => write!(f, "TOALTSTACK"),
+			all::OP_FROMALTSTACK => write!(f, "FROMALTSTACK"),
+			all::OP_2DROP => write!(f, "2DROP"),
+			all::OP_2DUP => write!(f, "2DUP"),
+			all::OP_3DUP => write!(f, "3DUP"),
+			all::OP_2OVER => write!(f, "2OVER"),
+			all::OP_2ROT => write!(f, "2ROT"),
+			all::OP_2SWAP => write!(f, "2SWAP"),
+			all::OP_IFDUP => write!(f, "IFDUP"),
+			all::OP_DEPTH => write!(f, "DEPTH"),
+			all::OP_DROP => write!(f, "DROP"),
+			all::OP_DUP => write!(f, "DUP"),
+			all::OP_NIP => write!(f, "NIP"),
+			all::OP_OVER => write!(f, "OVER"),
+			all::OP_PICK => write!(f, "PICK"),
+			all::OP_ROLL => write!(f, "ROLL"),
+			all::OP_ROT => write!(f, "ROT"),
+			all::OP_SWAP => write!(f, "SWAP"),
+			all::OP_TUCK => write!(f, "TUCK"),
+			all::OP_CAT => write!(f, "CAT"),
+			all::OP_SUBSTR => write!(f, "SUBSTR"),
+			all::OP_LEFT => write!(f, "LEFT"),
+			all::OP_RIGHT => write!(f, "RIGHT"),
+			all::OP_SIZE => write!(f, "SIZE"),
+			all::OP_INVERT => write!(f, "INVERT"),
+			all::OP_AND => write!(f, "AND"),
+			all::OP_OR => write!(f, "OR"),
+			all::OP_XOR => write!(f, "XOR"),
+			all::OP_EQUAL => write!(f, "EQUAL"),
+			all::OP_EQUALVERIFY => write!(f, "EQUALVERIFY"),
+			all::OP_RESERVED1 => write!(f, "RESERVED1"),
+			all::OP_RESERVED2 => write!(f, "RESERVED2"),
+			all::OP_1ADD => write!(f, "1ADD"),
+			all::OP_1SUB => write!(f, "1SUB"),
+			all::OP_2MUL => write!(f, "2MUL"),
+			all::OP_2DIV => write!(f, "2DIV"),
+			all::OP_NEGATE => write!(f, "NEGATE"),
+			all::OP_ABS => write!(f, "ABS"),
+			all::OP_NOT => write!(f, "NOT"),
+			all::OP_0NOTEQUAL => write!(f, "0NOTEQUAL"),
+			all::OP_ADD => write!(f, "ADD"),
+			all::OP_SUB => write!(f, "SUB"),
+			all::OP_MUL => write!(f, "MUL"),
+			all::OP_DIV => write!(f, "DIV"),
+			all::OP_MOD => write!(f, "MOD"),
+			all::OP_LSHIFT => write!(f, "LSHIFT"),
+			all::OP_RSHIFT => write!(f, "RSHIFT"),
+			all::OP_BOOLAND => write!(f, "BOOLAND"),
+			all::OP_BOOLOR => write!(f, "BOOLOR"),
+			all::OP_NUMEQUAL => write!(f, "NUMEQUAL"),
+			all::OP_NUMEQUALVERIFY => write!(f, "NUMEQUALVERIFY"),
+			all::OP_NUMNOTEQUAL => write!(f, "NUMNOTEQUAL"),
+			all::OP_LESSTHAN => write!(f, "LESSTHAN"),
+			all::OP_GREATERTHAN => write!(f, "GREATERTHAN"),
+			all::OP_LESSTHANOREQUAL => write!(f, "LESSTHANOREQUAL"),
+			all::OP_GREATERTHANOREQUAL => write!(f, "GREATERTHANOREQUAL"),
+			all::OP_MIN => write!(f, "MIN"),
+			all::OP_MAX => write!(f, "MAX"),
+			all::OP_WITHIN => write!(f, "WITHIN"),
+			all::OP_RIPEMD160 => write!(f, "RIPEMD160"),
+			all::OP_SHA1 => write!(f, "SHA1"),
+			all::OP_SHA256 => write!(f, "SHA256"),
+			all::OP_HASH160 => write!(f, "HASH160"),
+			all::OP_HASH256 => write!(f, "HASH256"),
+			all::OP_CODESEPARATOR => write!(f, "CODESEPARATOR"),
+			all::OP_CHECKSIG => write!(f, "CHECKSIG"),
+			all::OP_CHECKSIGVERIFY => write!(f, "CHECKSIGVERIFY"),
+			all::OP_CHECKMULTISIG => write!(f, "CHECKMULTISIG"),
+			all::OP_CHECKMULTISIGVERIFY => write!(f, "CHECKMULTISIGVERIFY"),
+			all::OP_CLTV => write!(f, "CLTV"),
+			all::OP_CSV => write!(f, "CSV"),
+			All { code: x } if x >= all::OP_NOP1.code && x <= all::OP_NOP10.code =>
+				write!(f, "NOP{}", x - all::OP_NOP1.code + 1),
+			All { code: x } => write!(f, "RETURN_{}", x),
+		}
+	}
 }
 
 impl All {
-    /// Classifies an Opcode into a broad class
-    #[inline]
-    pub fn classify(self) -> Class {
-        // 17 opcodes
-        if self == all::OP_VERIF || self == all::OP_VERNOTIF ||
-           self == all::OP_CAT || self == all::OP_SUBSTR ||
-           self == all::OP_LEFT || self == all::OP_RIGHT ||
-           self == all::OP_INVERT || self == all::OP_AND ||
-           self == all::OP_OR || self == all::OP_XOR ||
-           self == all::OP_2MUL || self == all::OP_2DIV ||
-           self == all::OP_MUL || self == all::OP_DIV || self == all::OP_MOD ||
-           self == all::OP_LSHIFT || self == all::OP_RSHIFT {
-            Class::IllegalOp
-        // 11 opcodes
-        } else if self == all::OP_NOP ||
-                  (all::OP_NOP1.code <= self.code &&
-                   self.code <= all::OP_NOP10.code) {
-            Class::NoOp
-        // 75 opcodes
-        } else if self == all::OP_RESERVED || self == all::OP_VER || self == all::OP_RETURN ||
-                  self == all::OP_RESERVED1 || self == all::OP_RESERVED2 ||
-                  self.code >= all::OP_RETURN_186.code {
-            Class::ReturnOp
-        // 1 opcode
-        } else if self == all::OP_PUSHNUM_NEG1 {
-            Class::PushNum(-1)
-        // 16 opcodes
-        } else if all::OP_PUSHNUM_1.code <= self.code &&
-                  self.code <= all::OP_PUSHNUM_16.code {
-            Class::PushNum(1 + self.code as i32 - all::OP_PUSHNUM_1.code as i32)
-        // 76 opcodes
-        } else if self.code <= all::OP_PUSHBYTES_75.code {
-            Class::PushBytes(self.code as u32)
-        // 60 opcodes
-        } else {
-            Class::Ordinary(Ordinary::try_from_all(self).unwrap())
-        }
-    }
+	/// Classifies an Opcode into a broad class
+	#[inline]
+	pub fn classify(self) -> Class {
+		// 17 opcodes
+		if self == all::OP_VERIF ||
+			self == all::OP_VERNOTIF ||
+			self == all::OP_CAT ||
+			self == all::OP_SUBSTR ||
+			self == all::OP_LEFT ||
+			self == all::OP_RIGHT ||
+			self == all::OP_INVERT ||
+			self == all::OP_AND ||
+			self == all::OP_OR ||
+			self == all::OP_XOR ||
+			self == all::OP_2MUL ||
+			self == all::OP_2DIV ||
+			self == all::OP_MUL ||
+			self == all::OP_DIV ||
+			self == all::OP_MOD ||
+			self == all::OP_LSHIFT ||
+			self == all::OP_RSHIFT
+		{
+			Class::IllegalOp
+		// 11 opcodes
+		} else if self == all::OP_NOP ||
+			(all::OP_NOP1.code <= self.code && self.code <= all::OP_NOP10.code)
+		{
+			Class::NoOp
+		// 75 opcodes
+		} else if self == all::OP_RESERVED ||
+			self == all::OP_VER ||
+			self == all::OP_RETURN ||
+			self == all::OP_RESERVED1 ||
+			self == all::OP_RESERVED2 ||
+			self.code >= all::OP_RETURN_186.code
+		{
+			Class::ReturnOp
+		// 1 opcode
+		} else if self == all::OP_PUSHNUM_NEG1 {
+			Class::PushNum(-1)
+		// 16 opcodes
+		} else if all::OP_PUSHNUM_1.code <= self.code && self.code <= all::OP_PUSHNUM_16.code {
+			Class::PushNum(1 + self.code as i32 - all::OP_PUSHNUM_1.code as i32)
+		// 76 opcodes
+		} else if self.code <= all::OP_PUSHBYTES_75.code {
+			Class::PushBytes(self.code as u32)
+		// 60 opcodes
+		} else {
+			Class::Ordinary(Ordinary::try_from_all(self).unwrap())
+		}
+	}
 
-    /// Encode as a byte
-    #[inline]
-    pub fn into_u8(self) -> u8 {
-        self.code
-    }
+	/// Encode as a byte
+	#[inline]
+	pub fn into_u8(self) -> u8 {
+		self.code
+	}
 }
 
 impl From<u8> for All {
-    #[inline]
-    fn from(b: u8) -> All {
-        All {code: b}
-    }
+	#[inline]
+	fn from(b: u8) -> All {
+		All { code: b }
+	}
 }
 
 display_from_debug!(All);
 
 #[cfg(feature = "serde")]
 impl serde::Serialize for All {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.to_string())
-    }
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		serializer.serialize_str(&self.to_string())
+	}
 }
 
 /// Empty stack is also FALSE
@@ -738,30 +756,30 @@ pub static OP_NOP3: All = all::OP_CSV;
 /// Broad categories of opcodes with similar behavior
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum Class {
-    /// Pushes the given number onto the stack
-    PushNum(i32),
-    /// Pushes the given number of bytes onto the stack
-    PushBytes(u32),
-    /// Fails the script if executed
-    ReturnOp,
-    /// Fails the script even if not executed
-    IllegalOp,
-    /// Does nothing
-    NoOp,
-    /// Any opcode not covered above
-    Ordinary(Ordinary)
+	/// Pushes the given number onto the stack
+	PushNum(i32),
+	/// Pushes the given number of bytes onto the stack
+	PushBytes(u32),
+	/// Fails the script if executed
+	ReturnOp,
+	/// Fails the script even if not executed
+	IllegalOp,
+	/// Does nothing
+	NoOp,
+	/// Any opcode not covered above
+	Ordinary(Ordinary),
 }
 
 display_from_debug!(Class);
 
 #[cfg(feature = "serde")]
 impl serde::Serialize for Class {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.to_string())
-    }
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		serializer.serialize_str(&self.to_string())
+	}
 }
 
 macro_rules! ordinary_opcode {
@@ -787,314 +805,314 @@ macro_rules! ordinary_opcode {
 
 // "Ordinary" opcodes -- should be 60 of these
 ordinary_opcode! {
-    // pushdata
-    OP_PUSHDATA1, OP_PUSHDATA2, OP_PUSHDATA4,
-    // control flow
-    OP_IF, OP_NOTIF, OP_ELSE, OP_ENDIF, OP_VERIFY,
-    // stack
-    OP_TOALTSTACK, OP_FROMALTSTACK,
-    OP_2DROP, OP_2DUP, OP_3DUP, OP_2OVER, OP_2ROT, OP_2SWAP,
-    OP_DROP, OP_DUP, OP_NIP, OP_OVER, OP_PICK, OP_ROLL, OP_ROT, OP_SWAP, OP_TUCK,
-    OP_IFDUP, OP_DEPTH, OP_SIZE,
-    // equality
-    OP_EQUAL, OP_EQUALVERIFY,
-    // arithmetic
-    OP_1ADD, OP_1SUB, OP_NEGATE, OP_ABS, OP_NOT, OP_0NOTEQUAL,
-    OP_ADD, OP_SUB, OP_BOOLAND, OP_BOOLOR,
-    OP_NUMEQUAL, OP_NUMEQUALVERIFY, OP_NUMNOTEQUAL, OP_LESSTHAN,
-    OP_GREATERTHAN, OP_LESSTHANOREQUAL, OP_GREATERTHANOREQUAL,
-    OP_MIN, OP_MAX, OP_WITHIN,
-    // crypto
-    OP_RIPEMD160, OP_SHA1, OP_SHA256, OP_HASH160, OP_HASH256,
-    OP_CODESEPARATOR, OP_CHECKSIG, OP_CHECKSIGVERIFY,
-    OP_CHECKMULTISIG, OP_CHECKMULTISIGVERIFY
+	// pushdata
+	OP_PUSHDATA1, OP_PUSHDATA2, OP_PUSHDATA4,
+	// control flow
+	OP_IF, OP_NOTIF, OP_ELSE, OP_ENDIF, OP_VERIFY,
+	// stack
+	OP_TOALTSTACK, OP_FROMALTSTACK,
+	OP_2DROP, OP_2DUP, OP_3DUP, OP_2OVER, OP_2ROT, OP_2SWAP,
+	OP_DROP, OP_DUP, OP_NIP, OP_OVER, OP_PICK, OP_ROLL, OP_ROT, OP_SWAP, OP_TUCK,
+	OP_IFDUP, OP_DEPTH, OP_SIZE,
+	// equality
+	OP_EQUAL, OP_EQUALVERIFY,
+	// arithmetic
+	OP_1ADD, OP_1SUB, OP_NEGATE, OP_ABS, OP_NOT, OP_0NOTEQUAL,
+	OP_ADD, OP_SUB, OP_BOOLAND, OP_BOOLOR,
+	OP_NUMEQUAL, OP_NUMEQUALVERIFY, OP_NUMNOTEQUAL, OP_LESSTHAN,
+	OP_GREATERTHAN, OP_LESSTHANOREQUAL, OP_GREATERTHANOREQUAL,
+	OP_MIN, OP_MAX, OP_WITHIN,
+	// crypto
+	OP_RIPEMD160, OP_SHA1, OP_SHA256, OP_HASH160, OP_HASH256,
+	OP_CODESEPARATOR, OP_CHECKSIG, OP_CHECKSIGVERIFY,
+	OP_CHECKMULTISIG, OP_CHECKMULTISIGVERIFY
 }
 
 impl Ordinary {
-    /// Encode as a byte
-    #[inline]
-    pub fn into_u8(self) -> u8 {
-      self as u8
-  }
+	/// Encode as a byte
+	#[inline]
+	pub fn into_u8(self) -> u8 {
+		self as u8
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+	use std::collections::HashSet;
 
-    use super::*;
+	use super::*;
 
-    macro_rules! roundtrip {
-        ($unique:expr, $op:ident) => {
-            assert_eq!(all::$op, All::from(all::$op.into_u8()));
+	macro_rules! roundtrip {
+		($unique:expr, $op:ident) => {
+			assert_eq!(all::$op, All::from(all::$op.into_u8()));
 
-            //let s1 = format!("{}", all::$op);
-            let s2 = format!("{:?}", all::$op);
-            //assert_eq!(s1, s2);
-            assert_eq!(s2, stringify!($op));
-            assert!($unique.insert(s2));
-        }
-    }
+			//let s1 = format!("{}", all::$op);
+			let s2 = format!("{:?}", all::$op);
+			//assert_eq!(s1, s2);
+			assert_eq!(s2, stringify!($op));
+			assert!($unique.insert(s2));
+		};
+	}
 
-    #[test]
-    fn str_roundtrip() {
-        let mut unique = HashSet::new();
-        roundtrip!(unique, OP_PUSHBYTES_0);
-        roundtrip!(unique, OP_PUSHBYTES_1);
-        roundtrip!(unique, OP_PUSHBYTES_2);
-        roundtrip!(unique, OP_PUSHBYTES_3);
-        roundtrip!(unique, OP_PUSHBYTES_4);
-        roundtrip!(unique, OP_PUSHBYTES_5);
-        roundtrip!(unique, OP_PUSHBYTES_6);
-        roundtrip!(unique, OP_PUSHBYTES_7);
-        roundtrip!(unique, OP_PUSHBYTES_8);
-        roundtrip!(unique, OP_PUSHBYTES_9);
-        roundtrip!(unique, OP_PUSHBYTES_10);
-        roundtrip!(unique, OP_PUSHBYTES_11);
-        roundtrip!(unique, OP_PUSHBYTES_12);
-        roundtrip!(unique, OP_PUSHBYTES_13);
-        roundtrip!(unique, OP_PUSHBYTES_14);
-        roundtrip!(unique, OP_PUSHBYTES_15);
-        roundtrip!(unique, OP_PUSHBYTES_16);
-        roundtrip!(unique, OP_PUSHBYTES_17);
-        roundtrip!(unique, OP_PUSHBYTES_18);
-        roundtrip!(unique, OP_PUSHBYTES_19);
-        roundtrip!(unique, OP_PUSHBYTES_20);
-        roundtrip!(unique, OP_PUSHBYTES_21);
-        roundtrip!(unique, OP_PUSHBYTES_22);
-        roundtrip!(unique, OP_PUSHBYTES_23);
-        roundtrip!(unique, OP_PUSHBYTES_24);
-        roundtrip!(unique, OP_PUSHBYTES_25);
-        roundtrip!(unique, OP_PUSHBYTES_26);
-        roundtrip!(unique, OP_PUSHBYTES_27);
-        roundtrip!(unique, OP_PUSHBYTES_28);
-        roundtrip!(unique, OP_PUSHBYTES_29);
-        roundtrip!(unique, OP_PUSHBYTES_30);
-        roundtrip!(unique, OP_PUSHBYTES_31);
-        roundtrip!(unique, OP_PUSHBYTES_32);
-        roundtrip!(unique, OP_PUSHBYTES_33);
-        roundtrip!(unique, OP_PUSHBYTES_34);
-        roundtrip!(unique, OP_PUSHBYTES_35);
-        roundtrip!(unique, OP_PUSHBYTES_36);
-        roundtrip!(unique, OP_PUSHBYTES_37);
-        roundtrip!(unique, OP_PUSHBYTES_38);
-        roundtrip!(unique, OP_PUSHBYTES_39);
-        roundtrip!(unique, OP_PUSHBYTES_40);
-        roundtrip!(unique, OP_PUSHBYTES_41);
-        roundtrip!(unique, OP_PUSHBYTES_42);
-        roundtrip!(unique, OP_PUSHBYTES_43);
-        roundtrip!(unique, OP_PUSHBYTES_44);
-        roundtrip!(unique, OP_PUSHBYTES_45);
-        roundtrip!(unique, OP_PUSHBYTES_46);
-        roundtrip!(unique, OP_PUSHBYTES_47);
-        roundtrip!(unique, OP_PUSHBYTES_48);
-        roundtrip!(unique, OP_PUSHBYTES_49);
-        roundtrip!(unique, OP_PUSHBYTES_50);
-        roundtrip!(unique, OP_PUSHBYTES_51);
-        roundtrip!(unique, OP_PUSHBYTES_52);
-        roundtrip!(unique, OP_PUSHBYTES_53);
-        roundtrip!(unique, OP_PUSHBYTES_54);
-        roundtrip!(unique, OP_PUSHBYTES_55);
-        roundtrip!(unique, OP_PUSHBYTES_56);
-        roundtrip!(unique, OP_PUSHBYTES_57);
-        roundtrip!(unique, OP_PUSHBYTES_58);
-        roundtrip!(unique, OP_PUSHBYTES_59);
-        roundtrip!(unique, OP_PUSHBYTES_60);
-        roundtrip!(unique, OP_PUSHBYTES_61);
-        roundtrip!(unique, OP_PUSHBYTES_62);
-        roundtrip!(unique, OP_PUSHBYTES_63);
-        roundtrip!(unique, OP_PUSHBYTES_64);
-        roundtrip!(unique, OP_PUSHBYTES_65);
-        roundtrip!(unique, OP_PUSHBYTES_66);
-        roundtrip!(unique, OP_PUSHBYTES_67);
-        roundtrip!(unique, OP_PUSHBYTES_68);
-        roundtrip!(unique, OP_PUSHBYTES_69);
-        roundtrip!(unique, OP_PUSHBYTES_70);
-        roundtrip!(unique, OP_PUSHBYTES_71);
-        roundtrip!(unique, OP_PUSHBYTES_72);
-        roundtrip!(unique, OP_PUSHBYTES_73);
-        roundtrip!(unique, OP_PUSHBYTES_74);
-        roundtrip!(unique, OP_PUSHBYTES_75);
-        roundtrip!(unique, OP_PUSHDATA1);
-        roundtrip!(unique, OP_PUSHDATA2);
-        roundtrip!(unique, OP_PUSHDATA4);
-        roundtrip!(unique, OP_PUSHNUM_NEG1);
-        roundtrip!(unique, OP_RESERVED);
-        roundtrip!(unique, OP_PUSHNUM_1);
-        roundtrip!(unique, OP_PUSHNUM_2);
-        roundtrip!(unique, OP_PUSHNUM_3);
-        roundtrip!(unique, OP_PUSHNUM_4);
-        roundtrip!(unique, OP_PUSHNUM_5);
-        roundtrip!(unique, OP_PUSHNUM_6);
-        roundtrip!(unique, OP_PUSHNUM_7);
-        roundtrip!(unique, OP_PUSHNUM_8);
-        roundtrip!(unique, OP_PUSHNUM_9);
-        roundtrip!(unique, OP_PUSHNUM_10);
-        roundtrip!(unique, OP_PUSHNUM_11);
-        roundtrip!(unique, OP_PUSHNUM_12);
-        roundtrip!(unique, OP_PUSHNUM_13);
-        roundtrip!(unique, OP_PUSHNUM_14);
-        roundtrip!(unique, OP_PUSHNUM_15);
-        roundtrip!(unique, OP_PUSHNUM_16);
-        roundtrip!(unique, OP_NOP);
-        roundtrip!(unique, OP_VER);
-        roundtrip!(unique, OP_IF);
-        roundtrip!(unique, OP_NOTIF);
-        roundtrip!(unique, OP_VERIF);
-        roundtrip!(unique, OP_VERNOTIF);
-        roundtrip!(unique, OP_ELSE);
-        roundtrip!(unique, OP_ENDIF);
-        roundtrip!(unique, OP_VERIFY);
-        roundtrip!(unique, OP_RETURN);
-        roundtrip!(unique, OP_TOALTSTACK);
-        roundtrip!(unique, OP_FROMALTSTACK);
-        roundtrip!(unique, OP_2DROP);
-        roundtrip!(unique, OP_2DUP);
-        roundtrip!(unique, OP_3DUP);
-        roundtrip!(unique, OP_2OVER);
-        roundtrip!(unique, OP_2ROT);
-        roundtrip!(unique, OP_2SWAP);
-        roundtrip!(unique, OP_IFDUP);
-        roundtrip!(unique, OP_DEPTH);
-        roundtrip!(unique, OP_DROP);
-        roundtrip!(unique, OP_DUP);
-        roundtrip!(unique, OP_NIP);
-        roundtrip!(unique, OP_OVER);
-        roundtrip!(unique, OP_PICK);
-        roundtrip!(unique, OP_ROLL);
-        roundtrip!(unique, OP_ROT);
-        roundtrip!(unique, OP_SWAP);
-        roundtrip!(unique, OP_TUCK);
-        roundtrip!(unique, OP_CAT);
-        roundtrip!(unique, OP_SUBSTR);
-        roundtrip!(unique, OP_LEFT);
-        roundtrip!(unique, OP_RIGHT);
-        roundtrip!(unique, OP_SIZE);
-        roundtrip!(unique, OP_INVERT);
-        roundtrip!(unique, OP_AND);
-        roundtrip!(unique, OP_OR);
-        roundtrip!(unique, OP_XOR);
-        roundtrip!(unique, OP_EQUAL);
-        roundtrip!(unique, OP_EQUALVERIFY);
-        roundtrip!(unique, OP_RESERVED1);
-        roundtrip!(unique, OP_RESERVED2);
-        roundtrip!(unique, OP_1ADD);
-        roundtrip!(unique, OP_1SUB);
-        roundtrip!(unique, OP_2MUL);
-        roundtrip!(unique, OP_2DIV);
-        roundtrip!(unique, OP_NEGATE);
-        roundtrip!(unique, OP_ABS);
-        roundtrip!(unique, OP_NOT);
-        roundtrip!(unique, OP_0NOTEQUAL);
-        roundtrip!(unique, OP_ADD);
-        roundtrip!(unique, OP_SUB);
-        roundtrip!(unique, OP_MUL);
-        roundtrip!(unique, OP_DIV);
-        roundtrip!(unique, OP_MOD);
-        roundtrip!(unique, OP_LSHIFT);
-        roundtrip!(unique, OP_RSHIFT);
-        roundtrip!(unique, OP_BOOLAND);
-        roundtrip!(unique, OP_BOOLOR);
-        roundtrip!(unique, OP_NUMEQUAL);
-        roundtrip!(unique, OP_NUMEQUALVERIFY);
-        roundtrip!(unique, OP_NUMNOTEQUAL);
-        roundtrip!(unique, OP_LESSTHAN );
-        roundtrip!(unique, OP_GREATERTHAN );
-        roundtrip!(unique, OP_LESSTHANOREQUAL );
-        roundtrip!(unique, OP_GREATERTHANOREQUAL );
-        roundtrip!(unique, OP_MIN);
-        roundtrip!(unique, OP_MAX);
-        roundtrip!(unique, OP_WITHIN);
-        roundtrip!(unique, OP_RIPEMD160);
-        roundtrip!(unique, OP_SHA1);
-        roundtrip!(unique, OP_SHA256);
-        roundtrip!(unique, OP_HASH160);
-        roundtrip!(unique, OP_HASH256);
-        roundtrip!(unique, OP_CODESEPARATOR);
-        roundtrip!(unique, OP_CHECKSIG);
-        roundtrip!(unique, OP_CHECKSIGVERIFY);
-        roundtrip!(unique, OP_CHECKMULTISIG);
-        roundtrip!(unique, OP_CHECKMULTISIGVERIFY);
-        roundtrip!(unique, OP_NOP1);
-        roundtrip!(unique, OP_CLTV);
-        roundtrip!(unique, OP_CSV);
-        roundtrip!(unique, OP_NOP4);
-        roundtrip!(unique, OP_NOP5);
-        roundtrip!(unique, OP_NOP6);
-        roundtrip!(unique, OP_NOP7);
-        roundtrip!(unique, OP_NOP8);
-        roundtrip!(unique, OP_NOP9);
-        roundtrip!(unique, OP_NOP10);
-        roundtrip!(unique, OP_RETURN_186);
-        roundtrip!(unique, OP_RETURN_187);
-        roundtrip!(unique, OP_RETURN_188);
-        roundtrip!(unique, OP_RETURN_189);
-        roundtrip!(unique, OP_RETURN_190);
-        roundtrip!(unique, OP_RETURN_191);
-        roundtrip!(unique, OP_RETURN_192);
-        roundtrip!(unique, OP_RETURN_193);
-        roundtrip!(unique, OP_RETURN_194);
-        roundtrip!(unique, OP_RETURN_195);
-        roundtrip!(unique, OP_RETURN_196);
-        roundtrip!(unique, OP_RETURN_197);
-        roundtrip!(unique, OP_RETURN_198);
-        roundtrip!(unique, OP_RETURN_199);
-        roundtrip!(unique, OP_RETURN_200);
-        roundtrip!(unique, OP_RETURN_201);
-        roundtrip!(unique, OP_RETURN_202);
-        roundtrip!(unique, OP_RETURN_203);
-        roundtrip!(unique, OP_RETURN_204);
-        roundtrip!(unique, OP_RETURN_205);
-        roundtrip!(unique, OP_RETURN_206);
-        roundtrip!(unique, OP_RETURN_207);
-        roundtrip!(unique, OP_RETURN_208);
-        roundtrip!(unique, OP_RETURN_209);
-        roundtrip!(unique, OP_RETURN_210);
-        roundtrip!(unique, OP_RETURN_211);
-        roundtrip!(unique, OP_RETURN_212);
-        roundtrip!(unique, OP_RETURN_213);
-        roundtrip!(unique, OP_RETURN_214);
-        roundtrip!(unique, OP_RETURN_215);
-        roundtrip!(unique, OP_RETURN_216);
-        roundtrip!(unique, OP_RETURN_217);
-        roundtrip!(unique, OP_RETURN_218);
-        roundtrip!(unique, OP_RETURN_219);
-        roundtrip!(unique, OP_RETURN_220);
-        roundtrip!(unique, OP_RETURN_221);
-        roundtrip!(unique, OP_RETURN_222);
-        roundtrip!(unique, OP_RETURN_223);
-        roundtrip!(unique, OP_RETURN_224);
-        roundtrip!(unique, OP_RETURN_225);
-        roundtrip!(unique, OP_RETURN_226);
-        roundtrip!(unique, OP_RETURN_227);
-        roundtrip!(unique, OP_RETURN_228);
-        roundtrip!(unique, OP_RETURN_229);
-        roundtrip!(unique, OP_RETURN_230);
-        roundtrip!(unique, OP_RETURN_231);
-        roundtrip!(unique, OP_RETURN_232);
-        roundtrip!(unique, OP_RETURN_233);
-        roundtrip!(unique, OP_RETURN_234);
-        roundtrip!(unique, OP_RETURN_235);
-        roundtrip!(unique, OP_RETURN_236);
-        roundtrip!(unique, OP_RETURN_237);
-        roundtrip!(unique, OP_RETURN_238);
-        roundtrip!(unique, OP_RETURN_239);
-        roundtrip!(unique, OP_RETURN_240);
-        roundtrip!(unique, OP_RETURN_241);
-        roundtrip!(unique, OP_RETURN_242);
-        roundtrip!(unique, OP_RETURN_243);
-        roundtrip!(unique, OP_RETURN_244);
-        roundtrip!(unique, OP_RETURN_245);
-        roundtrip!(unique, OP_RETURN_246);
-        roundtrip!(unique, OP_RETURN_247);
-        roundtrip!(unique, OP_RETURN_248);
-        roundtrip!(unique, OP_RETURN_249);
-        roundtrip!(unique, OP_RETURN_250);
-        roundtrip!(unique, OP_RETURN_251);
-        roundtrip!(unique, OP_RETURN_252);
-        roundtrip!(unique, OP_RETURN_253);
-        roundtrip!(unique, OP_RETURN_254);
-        roundtrip!(unique, OP_RETURN_255);
-        assert_eq!(unique.len(), 256);
-    }
+	#[test]
+	fn str_roundtrip() {
+		let mut unique = HashSet::new();
+		roundtrip!(unique, OP_PUSHBYTES_0);
+		roundtrip!(unique, OP_PUSHBYTES_1);
+		roundtrip!(unique, OP_PUSHBYTES_2);
+		roundtrip!(unique, OP_PUSHBYTES_3);
+		roundtrip!(unique, OP_PUSHBYTES_4);
+		roundtrip!(unique, OP_PUSHBYTES_5);
+		roundtrip!(unique, OP_PUSHBYTES_6);
+		roundtrip!(unique, OP_PUSHBYTES_7);
+		roundtrip!(unique, OP_PUSHBYTES_8);
+		roundtrip!(unique, OP_PUSHBYTES_9);
+		roundtrip!(unique, OP_PUSHBYTES_10);
+		roundtrip!(unique, OP_PUSHBYTES_11);
+		roundtrip!(unique, OP_PUSHBYTES_12);
+		roundtrip!(unique, OP_PUSHBYTES_13);
+		roundtrip!(unique, OP_PUSHBYTES_14);
+		roundtrip!(unique, OP_PUSHBYTES_15);
+		roundtrip!(unique, OP_PUSHBYTES_16);
+		roundtrip!(unique, OP_PUSHBYTES_17);
+		roundtrip!(unique, OP_PUSHBYTES_18);
+		roundtrip!(unique, OP_PUSHBYTES_19);
+		roundtrip!(unique, OP_PUSHBYTES_20);
+		roundtrip!(unique, OP_PUSHBYTES_21);
+		roundtrip!(unique, OP_PUSHBYTES_22);
+		roundtrip!(unique, OP_PUSHBYTES_23);
+		roundtrip!(unique, OP_PUSHBYTES_24);
+		roundtrip!(unique, OP_PUSHBYTES_25);
+		roundtrip!(unique, OP_PUSHBYTES_26);
+		roundtrip!(unique, OP_PUSHBYTES_27);
+		roundtrip!(unique, OP_PUSHBYTES_28);
+		roundtrip!(unique, OP_PUSHBYTES_29);
+		roundtrip!(unique, OP_PUSHBYTES_30);
+		roundtrip!(unique, OP_PUSHBYTES_31);
+		roundtrip!(unique, OP_PUSHBYTES_32);
+		roundtrip!(unique, OP_PUSHBYTES_33);
+		roundtrip!(unique, OP_PUSHBYTES_34);
+		roundtrip!(unique, OP_PUSHBYTES_35);
+		roundtrip!(unique, OP_PUSHBYTES_36);
+		roundtrip!(unique, OP_PUSHBYTES_37);
+		roundtrip!(unique, OP_PUSHBYTES_38);
+		roundtrip!(unique, OP_PUSHBYTES_39);
+		roundtrip!(unique, OP_PUSHBYTES_40);
+		roundtrip!(unique, OP_PUSHBYTES_41);
+		roundtrip!(unique, OP_PUSHBYTES_42);
+		roundtrip!(unique, OP_PUSHBYTES_43);
+		roundtrip!(unique, OP_PUSHBYTES_44);
+		roundtrip!(unique, OP_PUSHBYTES_45);
+		roundtrip!(unique, OP_PUSHBYTES_46);
+		roundtrip!(unique, OP_PUSHBYTES_47);
+		roundtrip!(unique, OP_PUSHBYTES_48);
+		roundtrip!(unique, OP_PUSHBYTES_49);
+		roundtrip!(unique, OP_PUSHBYTES_50);
+		roundtrip!(unique, OP_PUSHBYTES_51);
+		roundtrip!(unique, OP_PUSHBYTES_52);
+		roundtrip!(unique, OP_PUSHBYTES_53);
+		roundtrip!(unique, OP_PUSHBYTES_54);
+		roundtrip!(unique, OP_PUSHBYTES_55);
+		roundtrip!(unique, OP_PUSHBYTES_56);
+		roundtrip!(unique, OP_PUSHBYTES_57);
+		roundtrip!(unique, OP_PUSHBYTES_58);
+		roundtrip!(unique, OP_PUSHBYTES_59);
+		roundtrip!(unique, OP_PUSHBYTES_60);
+		roundtrip!(unique, OP_PUSHBYTES_61);
+		roundtrip!(unique, OP_PUSHBYTES_62);
+		roundtrip!(unique, OP_PUSHBYTES_63);
+		roundtrip!(unique, OP_PUSHBYTES_64);
+		roundtrip!(unique, OP_PUSHBYTES_65);
+		roundtrip!(unique, OP_PUSHBYTES_66);
+		roundtrip!(unique, OP_PUSHBYTES_67);
+		roundtrip!(unique, OP_PUSHBYTES_68);
+		roundtrip!(unique, OP_PUSHBYTES_69);
+		roundtrip!(unique, OP_PUSHBYTES_70);
+		roundtrip!(unique, OP_PUSHBYTES_71);
+		roundtrip!(unique, OP_PUSHBYTES_72);
+		roundtrip!(unique, OP_PUSHBYTES_73);
+		roundtrip!(unique, OP_PUSHBYTES_74);
+		roundtrip!(unique, OP_PUSHBYTES_75);
+		roundtrip!(unique, OP_PUSHDATA1);
+		roundtrip!(unique, OP_PUSHDATA2);
+		roundtrip!(unique, OP_PUSHDATA4);
+		roundtrip!(unique, OP_PUSHNUM_NEG1);
+		roundtrip!(unique, OP_RESERVED);
+		roundtrip!(unique, OP_PUSHNUM_1);
+		roundtrip!(unique, OP_PUSHNUM_2);
+		roundtrip!(unique, OP_PUSHNUM_3);
+		roundtrip!(unique, OP_PUSHNUM_4);
+		roundtrip!(unique, OP_PUSHNUM_5);
+		roundtrip!(unique, OP_PUSHNUM_6);
+		roundtrip!(unique, OP_PUSHNUM_7);
+		roundtrip!(unique, OP_PUSHNUM_8);
+		roundtrip!(unique, OP_PUSHNUM_9);
+		roundtrip!(unique, OP_PUSHNUM_10);
+		roundtrip!(unique, OP_PUSHNUM_11);
+		roundtrip!(unique, OP_PUSHNUM_12);
+		roundtrip!(unique, OP_PUSHNUM_13);
+		roundtrip!(unique, OP_PUSHNUM_14);
+		roundtrip!(unique, OP_PUSHNUM_15);
+		roundtrip!(unique, OP_PUSHNUM_16);
+		roundtrip!(unique, OP_NOP);
+		roundtrip!(unique, OP_VER);
+		roundtrip!(unique, OP_IF);
+		roundtrip!(unique, OP_NOTIF);
+		roundtrip!(unique, OP_VERIF);
+		roundtrip!(unique, OP_VERNOTIF);
+		roundtrip!(unique, OP_ELSE);
+		roundtrip!(unique, OP_ENDIF);
+		roundtrip!(unique, OP_VERIFY);
+		roundtrip!(unique, OP_RETURN);
+		roundtrip!(unique, OP_TOALTSTACK);
+		roundtrip!(unique, OP_FROMALTSTACK);
+		roundtrip!(unique, OP_2DROP);
+		roundtrip!(unique, OP_2DUP);
+		roundtrip!(unique, OP_3DUP);
+		roundtrip!(unique, OP_2OVER);
+		roundtrip!(unique, OP_2ROT);
+		roundtrip!(unique, OP_2SWAP);
+		roundtrip!(unique, OP_IFDUP);
+		roundtrip!(unique, OP_DEPTH);
+		roundtrip!(unique, OP_DROP);
+		roundtrip!(unique, OP_DUP);
+		roundtrip!(unique, OP_NIP);
+		roundtrip!(unique, OP_OVER);
+		roundtrip!(unique, OP_PICK);
+		roundtrip!(unique, OP_ROLL);
+		roundtrip!(unique, OP_ROT);
+		roundtrip!(unique, OP_SWAP);
+		roundtrip!(unique, OP_TUCK);
+		roundtrip!(unique, OP_CAT);
+		roundtrip!(unique, OP_SUBSTR);
+		roundtrip!(unique, OP_LEFT);
+		roundtrip!(unique, OP_RIGHT);
+		roundtrip!(unique, OP_SIZE);
+		roundtrip!(unique, OP_INVERT);
+		roundtrip!(unique, OP_AND);
+		roundtrip!(unique, OP_OR);
+		roundtrip!(unique, OP_XOR);
+		roundtrip!(unique, OP_EQUAL);
+		roundtrip!(unique, OP_EQUALVERIFY);
+		roundtrip!(unique, OP_RESERVED1);
+		roundtrip!(unique, OP_RESERVED2);
+		roundtrip!(unique, OP_1ADD);
+		roundtrip!(unique, OP_1SUB);
+		roundtrip!(unique, OP_2MUL);
+		roundtrip!(unique, OP_2DIV);
+		roundtrip!(unique, OP_NEGATE);
+		roundtrip!(unique, OP_ABS);
+		roundtrip!(unique, OP_NOT);
+		roundtrip!(unique, OP_0NOTEQUAL);
+		roundtrip!(unique, OP_ADD);
+		roundtrip!(unique, OP_SUB);
+		roundtrip!(unique, OP_MUL);
+		roundtrip!(unique, OP_DIV);
+		roundtrip!(unique, OP_MOD);
+		roundtrip!(unique, OP_LSHIFT);
+		roundtrip!(unique, OP_RSHIFT);
+		roundtrip!(unique, OP_BOOLAND);
+		roundtrip!(unique, OP_BOOLOR);
+		roundtrip!(unique, OP_NUMEQUAL);
+		roundtrip!(unique, OP_NUMEQUALVERIFY);
+		roundtrip!(unique, OP_NUMNOTEQUAL);
+		roundtrip!(unique, OP_LESSTHAN);
+		roundtrip!(unique, OP_GREATERTHAN);
+		roundtrip!(unique, OP_LESSTHANOREQUAL);
+		roundtrip!(unique, OP_GREATERTHANOREQUAL);
+		roundtrip!(unique, OP_MIN);
+		roundtrip!(unique, OP_MAX);
+		roundtrip!(unique, OP_WITHIN);
+		roundtrip!(unique, OP_RIPEMD160);
+		roundtrip!(unique, OP_SHA1);
+		roundtrip!(unique, OP_SHA256);
+		roundtrip!(unique, OP_HASH160);
+		roundtrip!(unique, OP_HASH256);
+		roundtrip!(unique, OP_CODESEPARATOR);
+		roundtrip!(unique, OP_CHECKSIG);
+		roundtrip!(unique, OP_CHECKSIGVERIFY);
+		roundtrip!(unique, OP_CHECKMULTISIG);
+		roundtrip!(unique, OP_CHECKMULTISIGVERIFY);
+		roundtrip!(unique, OP_NOP1);
+		roundtrip!(unique, OP_CLTV);
+		roundtrip!(unique, OP_CSV);
+		roundtrip!(unique, OP_NOP4);
+		roundtrip!(unique, OP_NOP5);
+		roundtrip!(unique, OP_NOP6);
+		roundtrip!(unique, OP_NOP7);
+		roundtrip!(unique, OP_NOP8);
+		roundtrip!(unique, OP_NOP9);
+		roundtrip!(unique, OP_NOP10);
+		roundtrip!(unique, OP_RETURN_186);
+		roundtrip!(unique, OP_RETURN_187);
+		roundtrip!(unique, OP_RETURN_188);
+		roundtrip!(unique, OP_RETURN_189);
+		roundtrip!(unique, OP_RETURN_190);
+		roundtrip!(unique, OP_RETURN_191);
+		roundtrip!(unique, OP_RETURN_192);
+		roundtrip!(unique, OP_RETURN_193);
+		roundtrip!(unique, OP_RETURN_194);
+		roundtrip!(unique, OP_RETURN_195);
+		roundtrip!(unique, OP_RETURN_196);
+		roundtrip!(unique, OP_RETURN_197);
+		roundtrip!(unique, OP_RETURN_198);
+		roundtrip!(unique, OP_RETURN_199);
+		roundtrip!(unique, OP_RETURN_200);
+		roundtrip!(unique, OP_RETURN_201);
+		roundtrip!(unique, OP_RETURN_202);
+		roundtrip!(unique, OP_RETURN_203);
+		roundtrip!(unique, OP_RETURN_204);
+		roundtrip!(unique, OP_RETURN_205);
+		roundtrip!(unique, OP_RETURN_206);
+		roundtrip!(unique, OP_RETURN_207);
+		roundtrip!(unique, OP_RETURN_208);
+		roundtrip!(unique, OP_RETURN_209);
+		roundtrip!(unique, OP_RETURN_210);
+		roundtrip!(unique, OP_RETURN_211);
+		roundtrip!(unique, OP_RETURN_212);
+		roundtrip!(unique, OP_RETURN_213);
+		roundtrip!(unique, OP_RETURN_214);
+		roundtrip!(unique, OP_RETURN_215);
+		roundtrip!(unique, OP_RETURN_216);
+		roundtrip!(unique, OP_RETURN_217);
+		roundtrip!(unique, OP_RETURN_218);
+		roundtrip!(unique, OP_RETURN_219);
+		roundtrip!(unique, OP_RETURN_220);
+		roundtrip!(unique, OP_RETURN_221);
+		roundtrip!(unique, OP_RETURN_222);
+		roundtrip!(unique, OP_RETURN_223);
+		roundtrip!(unique, OP_RETURN_224);
+		roundtrip!(unique, OP_RETURN_225);
+		roundtrip!(unique, OP_RETURN_226);
+		roundtrip!(unique, OP_RETURN_227);
+		roundtrip!(unique, OP_RETURN_228);
+		roundtrip!(unique, OP_RETURN_229);
+		roundtrip!(unique, OP_RETURN_230);
+		roundtrip!(unique, OP_RETURN_231);
+		roundtrip!(unique, OP_RETURN_232);
+		roundtrip!(unique, OP_RETURN_233);
+		roundtrip!(unique, OP_RETURN_234);
+		roundtrip!(unique, OP_RETURN_235);
+		roundtrip!(unique, OP_RETURN_236);
+		roundtrip!(unique, OP_RETURN_237);
+		roundtrip!(unique, OP_RETURN_238);
+		roundtrip!(unique, OP_RETURN_239);
+		roundtrip!(unique, OP_RETURN_240);
+		roundtrip!(unique, OP_RETURN_241);
+		roundtrip!(unique, OP_RETURN_242);
+		roundtrip!(unique, OP_RETURN_243);
+		roundtrip!(unique, OP_RETURN_244);
+		roundtrip!(unique, OP_RETURN_245);
+		roundtrip!(unique, OP_RETURN_246);
+		roundtrip!(unique, OP_RETURN_247);
+		roundtrip!(unique, OP_RETURN_248);
+		roundtrip!(unique, OP_RETURN_249);
+		roundtrip!(unique, OP_RETURN_250);
+		roundtrip!(unique, OP_RETURN_251);
+		roundtrip!(unique, OP_RETURN_252);
+		roundtrip!(unique, OP_RETURN_253);
+		roundtrip!(unique, OP_RETURN_254);
+		roundtrip!(unique, OP_RETURN_255);
+		assert_eq!(unique.len(), 256);
+	}
 }

--- a/libs/chainscript/src/opcodes.rs
+++ b/libs/chainscript/src/opcodes.rs
@@ -37,719 +37,719 @@ use core::{convert::From, fmt};
 /// A script Opcode
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct All {
-	code: u8,
+    code: u8,
 }
 
 pub mod all {
-	//! Constants associated with All type
-	use super::All;
+    //! Constants associated with All type
+    use super::All;
 
-	/// Push an empty array onto the stack
-	pub const OP_PUSHBYTES_0: All = All { code: 0x00 };
-	/// Push the next byte as an array onto the stack
-	pub const OP_PUSHBYTES_1: All = All { code: 0x01 };
-	/// Push the next 2 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_2: All = All { code: 0x02 };
-	/// Push the next 2 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_3: All = All { code: 0x03 };
-	/// Push the next 4 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_4: All = All { code: 0x04 };
-	/// Push the next 5 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_5: All = All { code: 0x05 };
-	/// Push the next 6 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_6: All = All { code: 0x06 };
-	/// Push the next 7 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_7: All = All { code: 0x07 };
-	/// Push the next 8 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_8: All = All { code: 0x08 };
-	/// Push the next 9 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_9: All = All { code: 0x09 };
-	/// Push the next 10 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_10: All = All { code: 0x0a };
-	/// Push the next 11 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_11: All = All { code: 0x0b };
-	/// Push the next 12 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_12: All = All { code: 0x0c };
-	/// Push the next 13 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_13: All = All { code: 0x0d };
-	/// Push the next 14 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_14: All = All { code: 0x0e };
-	/// Push the next 15 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_15: All = All { code: 0x0f };
-	/// Push the next 16 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_16: All = All { code: 0x10 };
-	/// Push the next 17 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_17: All = All { code: 0x11 };
-	/// Push the next 18 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_18: All = All { code: 0x12 };
-	/// Push the next 19 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_19: All = All { code: 0x13 };
-	/// Push the next 20 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_20: All = All { code: 0x14 };
-	/// Push the next 21 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_21: All = All { code: 0x15 };
-	/// Push the next 22 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_22: All = All { code: 0x16 };
-	/// Push the next 23 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_23: All = All { code: 0x17 };
-	/// Push the next 24 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_24: All = All { code: 0x18 };
-	/// Push the next 25 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_25: All = All { code: 0x19 };
-	/// Push the next 26 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_26: All = All { code: 0x1a };
-	/// Push the next 27 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_27: All = All { code: 0x1b };
-	/// Push the next 28 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_28: All = All { code: 0x1c };
-	/// Push the next 29 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_29: All = All { code: 0x1d };
-	/// Push the next 30 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_30: All = All { code: 0x1e };
-	/// Push the next 31 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_31: All = All { code: 0x1f };
-	/// Push the next 32 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_32: All = All { code: 0x20 };
-	/// Push the next 33 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_33: All = All { code: 0x21 };
-	/// Push the next 34 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_34: All = All { code: 0x22 };
-	/// Push the next 35 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_35: All = All { code: 0x23 };
-	/// Push the next 36 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_36: All = All { code: 0x24 };
-	/// Push the next 37 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_37: All = All { code: 0x25 };
-	/// Push the next 38 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_38: All = All { code: 0x26 };
-	/// Push the next 39 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_39: All = All { code: 0x27 };
-	/// Push the next 40 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_40: All = All { code: 0x28 };
-	/// Push the next 41 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_41: All = All { code: 0x29 };
-	/// Push the next 42 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_42: All = All { code: 0x2a };
-	/// Push the next 43 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_43: All = All { code: 0x2b };
-	/// Push the next 44 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_44: All = All { code: 0x2c };
-	/// Push the next 45 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_45: All = All { code: 0x2d };
-	/// Push the next 46 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_46: All = All { code: 0x2e };
-	/// Push the next 47 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_47: All = All { code: 0x2f };
-	/// Push the next 48 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_48: All = All { code: 0x30 };
-	/// Push the next 49 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_49: All = All { code: 0x31 };
-	/// Push the next 50 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_50: All = All { code: 0x32 };
-	/// Push the next 51 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_51: All = All { code: 0x33 };
-	/// Push the next 52 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_52: All = All { code: 0x34 };
-	/// Push the next 53 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_53: All = All { code: 0x35 };
-	/// Push the next 54 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_54: All = All { code: 0x36 };
-	/// Push the next 55 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_55: All = All { code: 0x37 };
-	/// Push the next 56 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_56: All = All { code: 0x38 };
-	/// Push the next 57 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_57: All = All { code: 0x39 };
-	/// Push the next 58 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_58: All = All { code: 0x3a };
-	/// Push the next 59 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_59: All = All { code: 0x3b };
-	/// Push the next 60 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_60: All = All { code: 0x3c };
-	/// Push the next 61 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_61: All = All { code: 0x3d };
-	/// Push the next 62 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_62: All = All { code: 0x3e };
-	/// Push the next 63 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_63: All = All { code: 0x3f };
-	/// Push the next 64 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_64: All = All { code: 0x40 };
-	/// Push the next 65 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_65: All = All { code: 0x41 };
-	/// Push the next 66 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_66: All = All { code: 0x42 };
-	/// Push the next 67 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_67: All = All { code: 0x43 };
-	/// Push the next 68 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_68: All = All { code: 0x44 };
-	/// Push the next 69 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_69: All = All { code: 0x45 };
-	/// Push the next 70 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_70: All = All { code: 0x46 };
-	/// Push the next 71 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_71: All = All { code: 0x47 };
-	/// Push the next 72 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_72: All = All { code: 0x48 };
-	/// Push the next 73 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_73: All = All { code: 0x49 };
-	/// Push the next 74 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_74: All = All { code: 0x4a };
-	/// Push the next 75 bytes as an array onto the stack
-	pub const OP_PUSHBYTES_75: All = All { code: 0x4b };
-	/// Read the next byte as N; push the next N bytes as an array onto the stack
-	pub const OP_PUSHDATA1: All = All { code: 0x4c };
-	/// Read the next 2 bytes as N; push the next N bytes as an array onto the stack
-	pub const OP_PUSHDATA2: All = All { code: 0x4d };
-	/// Read the next 4 bytes as N; push the next N bytes as an array onto the stack
-	pub const OP_PUSHDATA4: All = All { code: 0x4e };
-	/// Push the array `0x81` onto the stack
-	pub const OP_PUSHNUM_NEG1: All = All { code: 0x4f };
-	/// Synonym for OP_RETURN
-	pub const OP_RESERVED: All = All { code: 0x50 };
-	/// Push the array `0x01` onto the stack
-	pub const OP_PUSHNUM_1: All = All { code: 0x51 };
-	/// Push the array `0x02` onto the stack
-	pub const OP_PUSHNUM_2: All = All { code: 0x52 };
-	/// Push the array `0x03` onto the stack
-	pub const OP_PUSHNUM_3: All = All { code: 0x53 };
-	/// Push the array `0x04` onto the stack
-	pub const OP_PUSHNUM_4: All = All { code: 0x54 };
-	/// Push the array `0x05` onto the stack
-	pub const OP_PUSHNUM_5: All = All { code: 0x55 };
-	/// Push the array `0x06` onto the stack
-	pub const OP_PUSHNUM_6: All = All { code: 0x56 };
-	/// Push the array `0x07` onto the stack
-	pub const OP_PUSHNUM_7: All = All { code: 0x57 };
-	/// Push the array `0x08` onto the stack
-	pub const OP_PUSHNUM_8: All = All { code: 0x58 };
-	/// Push the array `0x09` onto the stack
-	pub const OP_PUSHNUM_9: All = All { code: 0x59 };
-	/// Push the array `0x0a` onto the stack
-	pub const OP_PUSHNUM_10: All = All { code: 0x5a };
-	/// Push the array `0x0b` onto the stack
-	pub const OP_PUSHNUM_11: All = All { code: 0x5b };
-	/// Push the array `0x0c` onto the stack
-	pub const OP_PUSHNUM_12: All = All { code: 0x5c };
-	/// Push the array `0x0d` onto the stack
-	pub const OP_PUSHNUM_13: All = All { code: 0x5d };
-	/// Push the array `0x0e` onto the stack
-	pub const OP_PUSHNUM_14: All = All { code: 0x5e };
-	/// Push the array `0x0f` onto the stack
-	pub const OP_PUSHNUM_15: All = All { code: 0x5f };
-	/// Push the array `0x10` onto the stack
-	pub const OP_PUSHNUM_16: All = All { code: 0x60 };
-	/// Does nothing
-	pub const OP_NOP: All = All { code: 0x61 };
-	/// Synonym for OP_RETURN
-	pub const OP_VER: All = All { code: 0x62 };
-	/// Pop and execute the next statements if a nonzero element was popped
-	pub const OP_IF: All = All { code: 0x63 };
-	/// Pop and execute the next statements if a zero element was popped
-	pub const OP_NOTIF: All = All { code: 0x64 };
-	/// Fail the script unconditionally, does not even need to be executed
-	pub const OP_VERIF: All = All { code: 0x65 };
-	/// Fail the script unconditionally, does not even need to be executed
-	pub const OP_VERNOTIF: All = All { code: 0x66 };
-	/// Execute statements if those after the previous OP_IF were not, and vice-versa.
-	/// If there is no previous OP_IF, this acts as a RETURN.
-	pub const OP_ELSE: All = All { code: 0x67 };
-	/// Pop and execute the next statements if a zero element was popped
-	pub const OP_ENDIF: All = All { code: 0x68 };
-	/// If the top value is zero or the stack is empty, fail; otherwise, pop the stack
-	pub const OP_VERIFY: All = All { code: 0x69 };
-	/// Fail the script immediately. (Must be executed.)
-	pub const OP_RETURN: All = All { code: 0x6a };
-	/// Pop one element from the main stack onto the alt stack
-	pub const OP_TOALTSTACK: All = All { code: 0x6b };
-	/// Pop one element from the alt stack onto the main stack
-	pub const OP_FROMALTSTACK: All = All { code: 0x6c };
-	/// Drops the top two stack items
-	pub const OP_2DROP: All = All { code: 0x6d };
-	/// Duplicates the top two stack items as AB -> ABAB
-	pub const OP_2DUP: All = All { code: 0x6e };
-	/// Duplicates the two three stack items as ABC -> ABCABC
-	pub const OP_3DUP: All = All { code: 0x6f };
-	/// Copies the two stack items of items two spaces back to
-	/// the front, as xxAB -> ABxxAB
-	pub const OP_2OVER: All = All { code: 0x70 };
-	/// Moves the two stack items four spaces back to the front,
-	/// as xxxxAB -> ABxxxx
-	pub const OP_2ROT: All = All { code: 0x71 };
-	/// Swaps the top two pairs, as ABCD -> CDAB
-	pub const OP_2SWAP: All = All { code: 0x72 };
-	/// Duplicate the top stack element unless it is zero
-	pub const OP_IFDUP: All = All { code: 0x73 };
-	/// Push the current number of stack items onto the stack
-	pub const OP_DEPTH: All = All { code: 0x74 };
-	/// Drops the top stack item
-	pub const OP_DROP: All = All { code: 0x75 };
-	/// Duplicates the top stack item
-	pub const OP_DUP: All = All { code: 0x76 };
-	/// Drops the second-to-top stack item
-	pub const OP_NIP: All = All { code: 0x77 };
-	/// Copies the second-to-top stack item, as xA -> AxA
-	pub const OP_OVER: All = All { code: 0x78 };
-	/// Pop the top stack element as N. Copy the Nth stack element to the top
-	pub const OP_PICK: All = All { code: 0x79 };
-	/// Pop the top stack element as N. Move the Nth stack element to the top
-	pub const OP_ROLL: All = All { code: 0x7a };
-	/// Rotate the top three stack items, as [top next1 next2] -> [next2 top next1]
-	pub const OP_ROT: All = All { code: 0x7b };
-	/// Swap the top two stack items
-	pub const OP_SWAP: All = All { code: 0x7c };
-	/// Copy the top stack item to before the second item, as [top next] -> [top next top]
-	pub const OP_TUCK: All = All { code: 0x7d };
-	/// Fail the script unconditionally, does not even need to be executed
-	pub const OP_CAT: All = All { code: 0x7e };
-	/// Fail the script unconditionally, does not even need to be executed
-	pub const OP_SUBSTR: All = All { code: 0x7f };
-	/// Fail the script unconditionally, does not even need to be executed
-	pub const OP_LEFT: All = All { code: 0x80 };
-	/// Fail the script unconditionally, does not even need to be executed
-	pub const OP_RIGHT: All = All { code: 0x81 };
-	/// Pushes the length of the top stack item onto the stack
-	pub const OP_SIZE: All = All { code: 0x82 };
-	/// Fail the script unconditionally, does not even need to be executed
-	pub const OP_INVERT: All = All { code: 0x83 };
-	/// Fail the script unconditionally, does not even need to be executed
-	pub const OP_AND: All = All { code: 0x84 };
-	/// Fail the script unconditionally, does not even need to be executed
-	pub const OP_OR: All = All { code: 0x85 };
-	/// Fail the script unconditionally, does not even need to be executed
-	pub const OP_XOR: All = All { code: 0x86 };
-	/// Pushes 1 if the inputs are exactly equal, 0 otherwise
-	pub const OP_EQUAL: All = All { code: 0x87 };
-	/// Returns success if the inputs are exactly equal, failure otherwise
-	pub const OP_EQUALVERIFY: All = All { code: 0x88 };
-	/// Synonym for OP_RETURN
-	pub const OP_RESERVED1: All = All { code: 0x89 };
-	/// Synonym for OP_RETURN
-	pub const OP_RESERVED2: All = All { code: 0x8a };
-	/// Increment the top stack element in place
-	pub const OP_1ADD: All = All { code: 0x8b };
-	/// Decrement the top stack element in place
-	pub const OP_1SUB: All = All { code: 0x8c };
-	/// Fail the script unconditionally, does not even need to be executed
-	pub const OP_2MUL: All = All { code: 0x8d };
-	/// Fail the script unconditionally, does not even need to be executed
-	pub const OP_2DIV: All = All { code: 0x8e };
-	/// Multiply the top stack item by -1 in place
-	pub const OP_NEGATE: All = All { code: 0x8f };
-	/// Absolute value the top stack item in place
-	pub const OP_ABS: All = All { code: 0x90 };
-	/// Map 0 to 1 and everything else to 0, in place
-	pub const OP_NOT: All = All { code: 0x91 };
-	/// Map 0 to 0 and everything else to 1, in place
-	pub const OP_0NOTEQUAL: All = All { code: 0x92 };
-	/// Pop two stack items and push their sum
-	pub const OP_ADD: All = All { code: 0x93 };
-	/// Pop two stack items and push the second minus the top
-	pub const OP_SUB: All = All { code: 0x94 };
-	/// Fail the script unconditionally, does not even need to be executed
-	pub const OP_MUL: All = All { code: 0x95 };
-	/// Fail the script unconditionally, does not even need to be executed
-	pub const OP_DIV: All = All { code: 0x96 };
-	/// Fail the script unconditionally, does not even need to be executed
-	pub const OP_MOD: All = All { code: 0x97 };
-	/// Fail the script unconditionally, does not even need to be executed
-	pub const OP_LSHIFT: All = All { code: 0x98 };
-	/// Fail the script unconditionally, does not even need to be executed
-	pub const OP_RSHIFT: All = All { code: 0x99 };
-	/// Pop the top two stack items and push 1 if both are nonzero, else push 0
-	pub const OP_BOOLAND: All = All { code: 0x9a };
-	/// Pop the top two stack items and push 1 if either is nonzero, else push 0
-	pub const OP_BOOLOR: All = All { code: 0x9b };
-	/// Pop the top two stack items and push 1 if both are numerically equal, else push 0
-	pub const OP_NUMEQUAL: All = All { code: 0x9c };
-	/// Pop the top two stack items and return success if both are numerically equal, else return
-	/// failure
-	pub const OP_NUMEQUALVERIFY: All = All { code: 0x9d };
-	/// Pop the top two stack items and push 0 if both are numerically equal, else push 1
-	pub const OP_NUMNOTEQUAL: All = All { code: 0x9e };
-	/// Pop the top two items; push 1 if the second is less than the top, 0 otherwise
-	pub const OP_LESSTHAN: All = All { code: 0x9f };
-	/// Pop the top two items; push 1 if the second is greater than the top, 0 otherwise
-	pub const OP_GREATERTHAN: All = All { code: 0xa0 };
-	/// Pop the top two items; push 1 if the second is <= the top, 0 otherwise
-	pub const OP_LESSTHANOREQUAL: All = All { code: 0xa1 };
-	/// Pop the top two items; push 1 if the second is >= the top, 0 otherwise
-	pub const OP_GREATERTHANOREQUAL: All = All { code: 0xa2 };
-	/// Pop the top two items; push the smaller
-	pub const OP_MIN: All = All { code: 0xa3 };
-	/// Pop the top two items; push the larger
-	pub const OP_MAX: All = All { code: 0xa4 };
-	/// Pop the top three items; if the top is >= the second and < the third, push 1, otherwise push
-	/// 0
-	pub const OP_WITHIN: All = All { code: 0xa5 };
-	/// Pop the top stack item and push its RIPEMD160 hash
-	pub const OP_RIPEMD160: All = All { code: 0xa6 };
-	/// Pop the top stack item and push its SHA1 hash
-	pub const OP_SHA1: All = All { code: 0xa7 };
-	/// Pop the top stack item and push its SHA256 hash
-	pub const OP_SHA256: All = All { code: 0xa8 };
-	/// Pop the top stack item and push its RIPEMD(SHA256) hash
-	pub const OP_HASH160: All = All { code: 0xa9 };
-	/// Pop the top stack item and push its SHA256(SHA256) hash
-	pub const OP_HASH256: All = All { code: 0xaa };
-	/// Ignore this and everything preceding when deciding what to sign when signature-checking
-	pub const OP_CODESEPARATOR: All = All { code: 0xab };
-	/// <https://en.bitcoin.it/wiki/OP_CHECKSIG> pushing 1/0 for success/failure
-	pub const OP_CHECKSIG: All = All { code: 0xac };
-	/// <https://en.bitcoin.it/wiki/OP_CHECKSIG> returning success/failure
-	pub const OP_CHECKSIGVERIFY: All = All { code: 0xad };
-	/// Pop N, N pubkeys, M, M signatures, a dummy (due to bug in reference code), and verify that
-	/// all M signatures are valid. Push 1 for "all valid", 0 otherwise
-	pub const OP_CHECKMULTISIG: All = All { code: 0xae };
-	/// Like the above but return success/failure
-	pub const OP_CHECKMULTISIGVERIFY: All = All { code: 0xaf };
-	/// Does nothing
-	pub const OP_NOP1: All = All { code: 0xb0 };
-	/// <https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki>
-	pub const OP_CLTV: All = All { code: 0xb1 };
-	/// <https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki>
-	pub const OP_CSV: All = All { code: 0xb2 };
-	/// Does nothing
-	pub const OP_NOP4: All = All { code: 0xb3 };
-	/// Does nothing
-	pub const OP_NOP5: All = All { code: 0xb4 };
-	/// Does nothing
-	pub const OP_NOP6: All = All { code: 0xb5 };
-	/// Does nothing
-	pub const OP_NOP7: All = All { code: 0xb6 };
-	/// Does nothing
-	pub const OP_NOP8: All = All { code: 0xb7 };
-	/// Does nothing
-	pub const OP_NOP9: All = All { code: 0xb8 };
-	/// Does nothing
-	pub const OP_NOP10: All = All { code: 0xb9 };
-	// Every other opcode acts as OP_RETURN
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_186: All = All { code: 0xba };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_187: All = All { code: 0xbb };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_188: All = All { code: 0xbc };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_189: All = All { code: 0xbd };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_190: All = All { code: 0xbe };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_191: All = All { code: 0xbf };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_192: All = All { code: 0xc0 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_193: All = All { code: 0xc1 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_194: All = All { code: 0xc2 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_195: All = All { code: 0xc3 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_196: All = All { code: 0xc4 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_197: All = All { code: 0xc5 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_198: All = All { code: 0xc6 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_199: All = All { code: 0xc7 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_200: All = All { code: 0xc8 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_201: All = All { code: 0xc9 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_202: All = All { code: 0xca };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_203: All = All { code: 0xcb };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_204: All = All { code: 0xcc };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_205: All = All { code: 0xcd };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_206: All = All { code: 0xce };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_207: All = All { code: 0xcf };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_208: All = All { code: 0xd0 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_209: All = All { code: 0xd1 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_210: All = All { code: 0xd2 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_211: All = All { code: 0xd3 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_212: All = All { code: 0xd4 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_213: All = All { code: 0xd5 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_214: All = All { code: 0xd6 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_215: All = All { code: 0xd7 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_216: All = All { code: 0xd8 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_217: All = All { code: 0xd9 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_218: All = All { code: 0xda };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_219: All = All { code: 0xdb };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_220: All = All { code: 0xdc };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_221: All = All { code: 0xdd };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_222: All = All { code: 0xde };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_223: All = All { code: 0xdf };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_224: All = All { code: 0xe0 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_225: All = All { code: 0xe1 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_226: All = All { code: 0xe2 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_227: All = All { code: 0xe3 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_228: All = All { code: 0xe4 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_229: All = All { code: 0xe5 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_230: All = All { code: 0xe6 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_231: All = All { code: 0xe7 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_232: All = All { code: 0xe8 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_233: All = All { code: 0xe9 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_234: All = All { code: 0xea };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_235: All = All { code: 0xeb };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_236: All = All { code: 0xec };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_237: All = All { code: 0xed };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_238: All = All { code: 0xee };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_239: All = All { code: 0xef };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_240: All = All { code: 0xf0 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_241: All = All { code: 0xf1 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_242: All = All { code: 0xf2 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_243: All = All { code: 0xf3 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_244: All = All { code: 0xf4 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_245: All = All { code: 0xf5 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_246: All = All { code: 0xf6 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_247: All = All { code: 0xf7 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_248: All = All { code: 0xf8 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_249: All = All { code: 0xf9 };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_250: All = All { code: 0xfa };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_251: All = All { code: 0xfb };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_252: All = All { code: 0xfc };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_253: All = All { code: 0xfd };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_254: All = All { code: 0xfe };
-	/// Synonym for OP_RETURN
-	pub const OP_RETURN_255: All = All { code: 0xff };
+    /// Push an empty array onto the stack
+    pub const OP_PUSHBYTES_0: All = All { code: 0x00 };
+    /// Push the next byte as an array onto the stack
+    pub const OP_PUSHBYTES_1: All = All { code: 0x01 };
+    /// Push the next 2 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_2: All = All { code: 0x02 };
+    /// Push the next 2 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_3: All = All { code: 0x03 };
+    /// Push the next 4 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_4: All = All { code: 0x04 };
+    /// Push the next 5 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_5: All = All { code: 0x05 };
+    /// Push the next 6 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_6: All = All { code: 0x06 };
+    /// Push the next 7 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_7: All = All { code: 0x07 };
+    /// Push the next 8 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_8: All = All { code: 0x08 };
+    /// Push the next 9 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_9: All = All { code: 0x09 };
+    /// Push the next 10 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_10: All = All { code: 0x0a };
+    /// Push the next 11 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_11: All = All { code: 0x0b };
+    /// Push the next 12 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_12: All = All { code: 0x0c };
+    /// Push the next 13 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_13: All = All { code: 0x0d };
+    /// Push the next 14 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_14: All = All { code: 0x0e };
+    /// Push the next 15 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_15: All = All { code: 0x0f };
+    /// Push the next 16 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_16: All = All { code: 0x10 };
+    /// Push the next 17 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_17: All = All { code: 0x11 };
+    /// Push the next 18 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_18: All = All { code: 0x12 };
+    /// Push the next 19 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_19: All = All { code: 0x13 };
+    /// Push the next 20 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_20: All = All { code: 0x14 };
+    /// Push the next 21 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_21: All = All { code: 0x15 };
+    /// Push the next 22 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_22: All = All { code: 0x16 };
+    /// Push the next 23 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_23: All = All { code: 0x17 };
+    /// Push the next 24 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_24: All = All { code: 0x18 };
+    /// Push the next 25 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_25: All = All { code: 0x19 };
+    /// Push the next 26 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_26: All = All { code: 0x1a };
+    /// Push the next 27 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_27: All = All { code: 0x1b };
+    /// Push the next 28 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_28: All = All { code: 0x1c };
+    /// Push the next 29 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_29: All = All { code: 0x1d };
+    /// Push the next 30 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_30: All = All { code: 0x1e };
+    /// Push the next 31 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_31: All = All { code: 0x1f };
+    /// Push the next 32 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_32: All = All { code: 0x20 };
+    /// Push the next 33 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_33: All = All { code: 0x21 };
+    /// Push the next 34 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_34: All = All { code: 0x22 };
+    /// Push the next 35 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_35: All = All { code: 0x23 };
+    /// Push the next 36 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_36: All = All { code: 0x24 };
+    /// Push the next 37 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_37: All = All { code: 0x25 };
+    /// Push the next 38 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_38: All = All { code: 0x26 };
+    /// Push the next 39 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_39: All = All { code: 0x27 };
+    /// Push the next 40 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_40: All = All { code: 0x28 };
+    /// Push the next 41 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_41: All = All { code: 0x29 };
+    /// Push the next 42 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_42: All = All { code: 0x2a };
+    /// Push the next 43 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_43: All = All { code: 0x2b };
+    /// Push the next 44 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_44: All = All { code: 0x2c };
+    /// Push the next 45 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_45: All = All { code: 0x2d };
+    /// Push the next 46 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_46: All = All { code: 0x2e };
+    /// Push the next 47 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_47: All = All { code: 0x2f };
+    /// Push the next 48 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_48: All = All { code: 0x30 };
+    /// Push the next 49 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_49: All = All { code: 0x31 };
+    /// Push the next 50 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_50: All = All { code: 0x32 };
+    /// Push the next 51 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_51: All = All { code: 0x33 };
+    /// Push the next 52 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_52: All = All { code: 0x34 };
+    /// Push the next 53 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_53: All = All { code: 0x35 };
+    /// Push the next 54 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_54: All = All { code: 0x36 };
+    /// Push the next 55 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_55: All = All { code: 0x37 };
+    /// Push the next 56 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_56: All = All { code: 0x38 };
+    /// Push the next 57 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_57: All = All { code: 0x39 };
+    /// Push the next 58 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_58: All = All { code: 0x3a };
+    /// Push the next 59 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_59: All = All { code: 0x3b };
+    /// Push the next 60 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_60: All = All { code: 0x3c };
+    /// Push the next 61 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_61: All = All { code: 0x3d };
+    /// Push the next 62 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_62: All = All { code: 0x3e };
+    /// Push the next 63 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_63: All = All { code: 0x3f };
+    /// Push the next 64 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_64: All = All { code: 0x40 };
+    /// Push the next 65 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_65: All = All { code: 0x41 };
+    /// Push the next 66 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_66: All = All { code: 0x42 };
+    /// Push the next 67 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_67: All = All { code: 0x43 };
+    /// Push the next 68 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_68: All = All { code: 0x44 };
+    /// Push the next 69 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_69: All = All { code: 0x45 };
+    /// Push the next 70 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_70: All = All { code: 0x46 };
+    /// Push the next 71 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_71: All = All { code: 0x47 };
+    /// Push the next 72 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_72: All = All { code: 0x48 };
+    /// Push the next 73 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_73: All = All { code: 0x49 };
+    /// Push the next 74 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_74: All = All { code: 0x4a };
+    /// Push the next 75 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_75: All = All { code: 0x4b };
+    /// Read the next byte as N; push the next N bytes as an array onto the stack
+    pub const OP_PUSHDATA1: All = All { code: 0x4c };
+    /// Read the next 2 bytes as N; push the next N bytes as an array onto the stack
+    pub const OP_PUSHDATA2: All = All { code: 0x4d };
+    /// Read the next 4 bytes as N; push the next N bytes as an array onto the stack
+    pub const OP_PUSHDATA4: All = All { code: 0x4e };
+    /// Push the array `0x81` onto the stack
+    pub const OP_PUSHNUM_NEG1: All = All { code: 0x4f };
+    /// Synonym for OP_RETURN
+    pub const OP_RESERVED: All = All { code: 0x50 };
+    /// Push the array `0x01` onto the stack
+    pub const OP_PUSHNUM_1: All = All { code: 0x51 };
+    /// Push the array `0x02` onto the stack
+    pub const OP_PUSHNUM_2: All = All { code: 0x52 };
+    /// Push the array `0x03` onto the stack
+    pub const OP_PUSHNUM_3: All = All { code: 0x53 };
+    /// Push the array `0x04` onto the stack
+    pub const OP_PUSHNUM_4: All = All { code: 0x54 };
+    /// Push the array `0x05` onto the stack
+    pub const OP_PUSHNUM_5: All = All { code: 0x55 };
+    /// Push the array `0x06` onto the stack
+    pub const OP_PUSHNUM_6: All = All { code: 0x56 };
+    /// Push the array `0x07` onto the stack
+    pub const OP_PUSHNUM_7: All = All { code: 0x57 };
+    /// Push the array `0x08` onto the stack
+    pub const OP_PUSHNUM_8: All = All { code: 0x58 };
+    /// Push the array `0x09` onto the stack
+    pub const OP_PUSHNUM_9: All = All { code: 0x59 };
+    /// Push the array `0x0a` onto the stack
+    pub const OP_PUSHNUM_10: All = All { code: 0x5a };
+    /// Push the array `0x0b` onto the stack
+    pub const OP_PUSHNUM_11: All = All { code: 0x5b };
+    /// Push the array `0x0c` onto the stack
+    pub const OP_PUSHNUM_12: All = All { code: 0x5c };
+    /// Push the array `0x0d` onto the stack
+    pub const OP_PUSHNUM_13: All = All { code: 0x5d };
+    /// Push the array `0x0e` onto the stack
+    pub const OP_PUSHNUM_14: All = All { code: 0x5e };
+    /// Push the array `0x0f` onto the stack
+    pub const OP_PUSHNUM_15: All = All { code: 0x5f };
+    /// Push the array `0x10` onto the stack
+    pub const OP_PUSHNUM_16: All = All { code: 0x60 };
+    /// Does nothing
+    pub const OP_NOP: All = All { code: 0x61 };
+    /// Synonym for OP_RETURN
+    pub const OP_VER: All = All { code: 0x62 };
+    /// Pop and execute the next statements if a nonzero element was popped
+    pub const OP_IF: All = All { code: 0x63 };
+    /// Pop and execute the next statements if a zero element was popped
+    pub const OP_NOTIF: All = All { code: 0x64 };
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_VERIF: All = All { code: 0x65 };
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_VERNOTIF: All = All { code: 0x66 };
+    /// Execute statements if those after the previous OP_IF were not, and vice-versa.
+    /// If there is no previous OP_IF, this acts as a RETURN.
+    pub const OP_ELSE: All = All { code: 0x67 };
+    /// Pop and execute the next statements if a zero element was popped
+    pub const OP_ENDIF: All = All { code: 0x68 };
+    /// If the top value is zero or the stack is empty, fail; otherwise, pop the stack
+    pub const OP_VERIFY: All = All { code: 0x69 };
+    /// Fail the script immediately. (Must be executed.)
+    pub const OP_RETURN: All = All { code: 0x6a };
+    /// Pop one element from the main stack onto the alt stack
+    pub const OP_TOALTSTACK: All = All { code: 0x6b };
+    /// Pop one element from the alt stack onto the main stack
+    pub const OP_FROMALTSTACK: All = All { code: 0x6c };
+    /// Drops the top two stack items
+    pub const OP_2DROP: All = All { code: 0x6d };
+    /// Duplicates the top two stack items as AB -> ABAB
+    pub const OP_2DUP: All = All { code: 0x6e };
+    /// Duplicates the two three stack items as ABC -> ABCABC
+    pub const OP_3DUP: All = All { code: 0x6f };
+    /// Copies the two stack items of items two spaces back to
+    /// the front, as xxAB -> ABxxAB
+    pub const OP_2OVER: All = All { code: 0x70 };
+    /// Moves the two stack items four spaces back to the front,
+    /// as xxxxAB -> ABxxxx
+    pub const OP_2ROT: All = All { code: 0x71 };
+    /// Swaps the top two pairs, as ABCD -> CDAB
+    pub const OP_2SWAP: All = All { code: 0x72 };
+    /// Duplicate the top stack element unless it is zero
+    pub const OP_IFDUP: All = All { code: 0x73 };
+    /// Push the current number of stack items onto the stack
+    pub const OP_DEPTH: All = All { code: 0x74 };
+    /// Drops the top stack item
+    pub const OP_DROP: All = All { code: 0x75 };
+    /// Duplicates the top stack item
+    pub const OP_DUP: All = All { code: 0x76 };
+    /// Drops the second-to-top stack item
+    pub const OP_NIP: All = All { code: 0x77 };
+    /// Copies the second-to-top stack item, as xA -> AxA
+    pub const OP_OVER: All = All { code: 0x78 };
+    /// Pop the top stack element as N. Copy the Nth stack element to the top
+    pub const OP_PICK: All = All { code: 0x79 };
+    /// Pop the top stack element as N. Move the Nth stack element to the top
+    pub const OP_ROLL: All = All { code: 0x7a };
+    /// Rotate the top three stack items, as [top next1 next2] -> [next2 top next1]
+    pub const OP_ROT: All = All { code: 0x7b };
+    /// Swap the top two stack items
+    pub const OP_SWAP: All = All { code: 0x7c };
+    /// Copy the top stack item to before the second item, as [top next] -> [top next top]
+    pub const OP_TUCK: All = All { code: 0x7d };
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_CAT: All = All { code: 0x7e };
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_SUBSTR: All = All { code: 0x7f };
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_LEFT: All = All { code: 0x80 };
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_RIGHT: All = All { code: 0x81 };
+    /// Pushes the length of the top stack item onto the stack
+    pub const OP_SIZE: All = All { code: 0x82 };
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_INVERT: All = All { code: 0x83 };
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_AND: All = All { code: 0x84 };
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_OR: All = All { code: 0x85 };
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_XOR: All = All { code: 0x86 };
+    /// Pushes 1 if the inputs are exactly equal, 0 otherwise
+    pub const OP_EQUAL: All = All { code: 0x87 };
+    /// Returns success if the inputs are exactly equal, failure otherwise
+    pub const OP_EQUALVERIFY: All = All { code: 0x88 };
+    /// Synonym for OP_RETURN
+    pub const OP_RESERVED1: All = All { code: 0x89 };
+    /// Synonym for OP_RETURN
+    pub const OP_RESERVED2: All = All { code: 0x8a };
+    /// Increment the top stack element in place
+    pub const OP_1ADD: All = All { code: 0x8b };
+    /// Decrement the top stack element in place
+    pub const OP_1SUB: All = All { code: 0x8c };
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_2MUL: All = All { code: 0x8d };
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_2DIV: All = All { code: 0x8e };
+    /// Multiply the top stack item by -1 in place
+    pub const OP_NEGATE: All = All { code: 0x8f };
+    /// Absolute value the top stack item in place
+    pub const OP_ABS: All = All { code: 0x90 };
+    /// Map 0 to 1 and everything else to 0, in place
+    pub const OP_NOT: All = All { code: 0x91 };
+    /// Map 0 to 0 and everything else to 1, in place
+    pub const OP_0NOTEQUAL: All = All { code: 0x92 };
+    /// Pop two stack items and push their sum
+    pub const OP_ADD: All = All { code: 0x93 };
+    /// Pop two stack items and push the second minus the top
+    pub const OP_SUB: All = All { code: 0x94 };
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_MUL: All = All { code: 0x95 };
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_DIV: All = All { code: 0x96 };
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_MOD: All = All { code: 0x97 };
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_LSHIFT: All = All { code: 0x98 };
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_RSHIFT: All = All { code: 0x99 };
+    /// Pop the top two stack items and push 1 if both are nonzero, else push 0
+    pub const OP_BOOLAND: All = All { code: 0x9a };
+    /// Pop the top two stack items and push 1 if either is nonzero, else push 0
+    pub const OP_BOOLOR: All = All { code: 0x9b };
+    /// Pop the top two stack items and push 1 if both are numerically equal, else push 0
+    pub const OP_NUMEQUAL: All = All { code: 0x9c };
+    /// Pop the top two stack items and return success if both are numerically equal, else return
+    /// failure
+    pub const OP_NUMEQUALVERIFY: All = All { code: 0x9d };
+    /// Pop the top two stack items and push 0 if both are numerically equal, else push 1
+    pub const OP_NUMNOTEQUAL: All = All { code: 0x9e };
+    /// Pop the top two items; push 1 if the second is less than the top, 0 otherwise
+    pub const OP_LESSTHAN: All = All { code: 0x9f };
+    /// Pop the top two items; push 1 if the second is greater than the top, 0 otherwise
+    pub const OP_GREATERTHAN: All = All { code: 0xa0 };
+    /// Pop the top two items; push 1 if the second is <= the top, 0 otherwise
+    pub const OP_LESSTHANOREQUAL: All = All { code: 0xa1 };
+    /// Pop the top two items; push 1 if the second is >= the top, 0 otherwise
+    pub const OP_GREATERTHANOREQUAL: All = All { code: 0xa2 };
+    /// Pop the top two items; push the smaller
+    pub const OP_MIN: All = All { code: 0xa3 };
+    /// Pop the top two items; push the larger
+    pub const OP_MAX: All = All { code: 0xa4 };
+    /// Pop the top three items; if the top is >= the second and < the third, push 1, otherwise push
+    /// 0
+    pub const OP_WITHIN: All = All { code: 0xa5 };
+    /// Pop the top stack item and push its RIPEMD160 hash
+    pub const OP_RIPEMD160: All = All { code: 0xa6 };
+    /// Pop the top stack item and push its SHA1 hash
+    pub const OP_SHA1: All = All { code: 0xa7 };
+    /// Pop the top stack item and push its SHA256 hash
+    pub const OP_SHA256: All = All { code: 0xa8 };
+    /// Pop the top stack item and push its RIPEMD(SHA256) hash
+    pub const OP_HASH160: All = All { code: 0xa9 };
+    /// Pop the top stack item and push its SHA256(SHA256) hash
+    pub const OP_HASH256: All = All { code: 0xaa };
+    /// Ignore this and everything preceding when deciding what to sign when signature-checking
+    pub const OP_CODESEPARATOR: All = All { code: 0xab };
+    /// <https://en.bitcoin.it/wiki/OP_CHECKSIG> pushing 1/0 for success/failure
+    pub const OP_CHECKSIG: All = All { code: 0xac };
+    /// <https://en.bitcoin.it/wiki/OP_CHECKSIG> returning success/failure
+    pub const OP_CHECKSIGVERIFY: All = All { code: 0xad };
+    /// Pop N, N pubkeys, M, M signatures, a dummy (due to bug in reference code), and verify that
+    /// all M signatures are valid. Push 1 for "all valid", 0 otherwise
+    pub const OP_CHECKMULTISIG: All = All { code: 0xae };
+    /// Like the above but return success/failure
+    pub const OP_CHECKMULTISIGVERIFY: All = All { code: 0xaf };
+    /// Does nothing
+    pub const OP_NOP1: All = All { code: 0xb0 };
+    /// <https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki>
+    pub const OP_CLTV: All = All { code: 0xb1 };
+    /// <https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki>
+    pub const OP_CSV: All = All { code: 0xb2 };
+    /// Does nothing
+    pub const OP_NOP4: All = All { code: 0xb3 };
+    /// Does nothing
+    pub const OP_NOP5: All = All { code: 0xb4 };
+    /// Does nothing
+    pub const OP_NOP6: All = All { code: 0xb5 };
+    /// Does nothing
+    pub const OP_NOP7: All = All { code: 0xb6 };
+    /// Does nothing
+    pub const OP_NOP8: All = All { code: 0xb7 };
+    /// Does nothing
+    pub const OP_NOP9: All = All { code: 0xb8 };
+    /// Does nothing
+    pub const OP_NOP10: All = All { code: 0xb9 };
+    // Every other opcode acts as OP_RETURN
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_186: All = All { code: 0xba };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_187: All = All { code: 0xbb };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_188: All = All { code: 0xbc };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_189: All = All { code: 0xbd };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_190: All = All { code: 0xbe };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_191: All = All { code: 0xbf };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_192: All = All { code: 0xc0 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_193: All = All { code: 0xc1 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_194: All = All { code: 0xc2 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_195: All = All { code: 0xc3 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_196: All = All { code: 0xc4 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_197: All = All { code: 0xc5 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_198: All = All { code: 0xc6 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_199: All = All { code: 0xc7 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_200: All = All { code: 0xc8 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_201: All = All { code: 0xc9 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_202: All = All { code: 0xca };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_203: All = All { code: 0xcb };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_204: All = All { code: 0xcc };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_205: All = All { code: 0xcd };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_206: All = All { code: 0xce };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_207: All = All { code: 0xcf };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_208: All = All { code: 0xd0 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_209: All = All { code: 0xd1 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_210: All = All { code: 0xd2 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_211: All = All { code: 0xd3 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_212: All = All { code: 0xd4 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_213: All = All { code: 0xd5 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_214: All = All { code: 0xd6 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_215: All = All { code: 0xd7 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_216: All = All { code: 0xd8 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_217: All = All { code: 0xd9 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_218: All = All { code: 0xda };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_219: All = All { code: 0xdb };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_220: All = All { code: 0xdc };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_221: All = All { code: 0xdd };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_222: All = All { code: 0xde };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_223: All = All { code: 0xdf };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_224: All = All { code: 0xe0 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_225: All = All { code: 0xe1 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_226: All = All { code: 0xe2 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_227: All = All { code: 0xe3 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_228: All = All { code: 0xe4 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_229: All = All { code: 0xe5 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_230: All = All { code: 0xe6 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_231: All = All { code: 0xe7 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_232: All = All { code: 0xe8 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_233: All = All { code: 0xe9 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_234: All = All { code: 0xea };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_235: All = All { code: 0xeb };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_236: All = All { code: 0xec };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_237: All = All { code: 0xed };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_238: All = All { code: 0xee };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_239: All = All { code: 0xef };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_240: All = All { code: 0xf0 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_241: All = All { code: 0xf1 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_242: All = All { code: 0xf2 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_243: All = All { code: 0xf3 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_244: All = All { code: 0xf4 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_245: All = All { code: 0xf5 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_246: All = All { code: 0xf6 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_247: All = All { code: 0xf7 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_248: All = All { code: 0xf8 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_249: All = All { code: 0xf9 };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_250: All = All { code: 0xfa };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_251: All = All { code: 0xfb };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_252: All = All { code: 0xfc };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_253: All = All { code: 0xfd };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_254: All = All { code: 0xfe };
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_255: All = All { code: 0xff };
 }
 
 impl fmt::Debug for All {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		f.write_str("OP_")?;
-		match *self {
-			All { code: x } if x <= 75 => write!(f, "PUSHBYTES_{}", self.code),
-			all::OP_PUSHDATA1 => write!(f, "PUSHDATA1"),
-			all::OP_PUSHDATA2 => write!(f, "PUSHDATA2"),
-			all::OP_PUSHDATA4 => write!(f, "PUSHDATA4"),
-			all::OP_PUSHNUM_NEG1 => write!(f, "PUSHNUM_NEG1"),
-			all::OP_RESERVED => write!(f, "RESERVED"),
-			All { code: x } if x >= all::OP_PUSHNUM_1.code && x <= all::OP_PUSHNUM_16.code => {
-				write!(f, "PUSHNUM_{}", x - all::OP_PUSHNUM_1.code + 1)
-			},
-			all::OP_NOP => write!(f, "NOP"),
-			all::OP_VER => write!(f, "VER"),
-			all::OP_IF => write!(f, "IF"),
-			all::OP_NOTIF => write!(f, "NOTIF"),
-			all::OP_VERIF => write!(f, "VERIF"),
-			all::OP_VERNOTIF => write!(f, "VERNOTIF"),
-			all::OP_ELSE => write!(f, "ELSE"),
-			all::OP_ENDIF => write!(f, "ENDIF"),
-			all::OP_VERIFY => write!(f, "VERIFY"),
-			all::OP_RETURN => write!(f, "RETURN"),
-			all::OP_TOALTSTACK => write!(f, "TOALTSTACK"),
-			all::OP_FROMALTSTACK => write!(f, "FROMALTSTACK"),
-			all::OP_2DROP => write!(f, "2DROP"),
-			all::OP_2DUP => write!(f, "2DUP"),
-			all::OP_3DUP => write!(f, "3DUP"),
-			all::OP_2OVER => write!(f, "2OVER"),
-			all::OP_2ROT => write!(f, "2ROT"),
-			all::OP_2SWAP => write!(f, "2SWAP"),
-			all::OP_IFDUP => write!(f, "IFDUP"),
-			all::OP_DEPTH => write!(f, "DEPTH"),
-			all::OP_DROP => write!(f, "DROP"),
-			all::OP_DUP => write!(f, "DUP"),
-			all::OP_NIP => write!(f, "NIP"),
-			all::OP_OVER => write!(f, "OVER"),
-			all::OP_PICK => write!(f, "PICK"),
-			all::OP_ROLL => write!(f, "ROLL"),
-			all::OP_ROT => write!(f, "ROT"),
-			all::OP_SWAP => write!(f, "SWAP"),
-			all::OP_TUCK => write!(f, "TUCK"),
-			all::OP_CAT => write!(f, "CAT"),
-			all::OP_SUBSTR => write!(f, "SUBSTR"),
-			all::OP_LEFT => write!(f, "LEFT"),
-			all::OP_RIGHT => write!(f, "RIGHT"),
-			all::OP_SIZE => write!(f, "SIZE"),
-			all::OP_INVERT => write!(f, "INVERT"),
-			all::OP_AND => write!(f, "AND"),
-			all::OP_OR => write!(f, "OR"),
-			all::OP_XOR => write!(f, "XOR"),
-			all::OP_EQUAL => write!(f, "EQUAL"),
-			all::OP_EQUALVERIFY => write!(f, "EQUALVERIFY"),
-			all::OP_RESERVED1 => write!(f, "RESERVED1"),
-			all::OP_RESERVED2 => write!(f, "RESERVED2"),
-			all::OP_1ADD => write!(f, "1ADD"),
-			all::OP_1SUB => write!(f, "1SUB"),
-			all::OP_2MUL => write!(f, "2MUL"),
-			all::OP_2DIV => write!(f, "2DIV"),
-			all::OP_NEGATE => write!(f, "NEGATE"),
-			all::OP_ABS => write!(f, "ABS"),
-			all::OP_NOT => write!(f, "NOT"),
-			all::OP_0NOTEQUAL => write!(f, "0NOTEQUAL"),
-			all::OP_ADD => write!(f, "ADD"),
-			all::OP_SUB => write!(f, "SUB"),
-			all::OP_MUL => write!(f, "MUL"),
-			all::OP_DIV => write!(f, "DIV"),
-			all::OP_MOD => write!(f, "MOD"),
-			all::OP_LSHIFT => write!(f, "LSHIFT"),
-			all::OP_RSHIFT => write!(f, "RSHIFT"),
-			all::OP_BOOLAND => write!(f, "BOOLAND"),
-			all::OP_BOOLOR => write!(f, "BOOLOR"),
-			all::OP_NUMEQUAL => write!(f, "NUMEQUAL"),
-			all::OP_NUMEQUALVERIFY => write!(f, "NUMEQUALVERIFY"),
-			all::OP_NUMNOTEQUAL => write!(f, "NUMNOTEQUAL"),
-			all::OP_LESSTHAN => write!(f, "LESSTHAN"),
-			all::OP_GREATERTHAN => write!(f, "GREATERTHAN"),
-			all::OP_LESSTHANOREQUAL => write!(f, "LESSTHANOREQUAL"),
-			all::OP_GREATERTHANOREQUAL => write!(f, "GREATERTHANOREQUAL"),
-			all::OP_MIN => write!(f, "MIN"),
-			all::OP_MAX => write!(f, "MAX"),
-			all::OP_WITHIN => write!(f, "WITHIN"),
-			all::OP_RIPEMD160 => write!(f, "RIPEMD160"),
-			all::OP_SHA1 => write!(f, "SHA1"),
-			all::OP_SHA256 => write!(f, "SHA256"),
-			all::OP_HASH160 => write!(f, "HASH160"),
-			all::OP_HASH256 => write!(f, "HASH256"),
-			all::OP_CODESEPARATOR => write!(f, "CODESEPARATOR"),
-			all::OP_CHECKSIG => write!(f, "CHECKSIG"),
-			all::OP_CHECKSIGVERIFY => write!(f, "CHECKSIGVERIFY"),
-			all::OP_CHECKMULTISIG => write!(f, "CHECKMULTISIG"),
-			all::OP_CHECKMULTISIGVERIFY => write!(f, "CHECKMULTISIGVERIFY"),
-			all::OP_CLTV => write!(f, "CLTV"),
-			all::OP_CSV => write!(f, "CSV"),
-			All { code: x } if x >= all::OP_NOP1.code && x <= all::OP_NOP10.code => {
-				write!(f, "NOP{}", x - all::OP_NOP1.code + 1)
-			},
-			All { code: x } => write!(f, "RETURN_{}", x),
-		}
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("OP_")?;
+        match *self {
+            All { code: x } if x <= 75 => write!(f, "PUSHBYTES_{}", self.code),
+            all::OP_PUSHDATA1 => write!(f, "PUSHDATA1"),
+            all::OP_PUSHDATA2 => write!(f, "PUSHDATA2"),
+            all::OP_PUSHDATA4 => write!(f, "PUSHDATA4"),
+            all::OP_PUSHNUM_NEG1 => write!(f, "PUSHNUM_NEG1"),
+            all::OP_RESERVED => write!(f, "RESERVED"),
+            All { code: x } if x >= all::OP_PUSHNUM_1.code && x <= all::OP_PUSHNUM_16.code => {
+                write!(f, "PUSHNUM_{}", x - all::OP_PUSHNUM_1.code + 1)
+            }
+            all::OP_NOP => write!(f, "NOP"),
+            all::OP_VER => write!(f, "VER"),
+            all::OP_IF => write!(f, "IF"),
+            all::OP_NOTIF => write!(f, "NOTIF"),
+            all::OP_VERIF => write!(f, "VERIF"),
+            all::OP_VERNOTIF => write!(f, "VERNOTIF"),
+            all::OP_ELSE => write!(f, "ELSE"),
+            all::OP_ENDIF => write!(f, "ENDIF"),
+            all::OP_VERIFY => write!(f, "VERIFY"),
+            all::OP_RETURN => write!(f, "RETURN"),
+            all::OP_TOALTSTACK => write!(f, "TOALTSTACK"),
+            all::OP_FROMALTSTACK => write!(f, "FROMALTSTACK"),
+            all::OP_2DROP => write!(f, "2DROP"),
+            all::OP_2DUP => write!(f, "2DUP"),
+            all::OP_3DUP => write!(f, "3DUP"),
+            all::OP_2OVER => write!(f, "2OVER"),
+            all::OP_2ROT => write!(f, "2ROT"),
+            all::OP_2SWAP => write!(f, "2SWAP"),
+            all::OP_IFDUP => write!(f, "IFDUP"),
+            all::OP_DEPTH => write!(f, "DEPTH"),
+            all::OP_DROP => write!(f, "DROP"),
+            all::OP_DUP => write!(f, "DUP"),
+            all::OP_NIP => write!(f, "NIP"),
+            all::OP_OVER => write!(f, "OVER"),
+            all::OP_PICK => write!(f, "PICK"),
+            all::OP_ROLL => write!(f, "ROLL"),
+            all::OP_ROT => write!(f, "ROT"),
+            all::OP_SWAP => write!(f, "SWAP"),
+            all::OP_TUCK => write!(f, "TUCK"),
+            all::OP_CAT => write!(f, "CAT"),
+            all::OP_SUBSTR => write!(f, "SUBSTR"),
+            all::OP_LEFT => write!(f, "LEFT"),
+            all::OP_RIGHT => write!(f, "RIGHT"),
+            all::OP_SIZE => write!(f, "SIZE"),
+            all::OP_INVERT => write!(f, "INVERT"),
+            all::OP_AND => write!(f, "AND"),
+            all::OP_OR => write!(f, "OR"),
+            all::OP_XOR => write!(f, "XOR"),
+            all::OP_EQUAL => write!(f, "EQUAL"),
+            all::OP_EQUALVERIFY => write!(f, "EQUALVERIFY"),
+            all::OP_RESERVED1 => write!(f, "RESERVED1"),
+            all::OP_RESERVED2 => write!(f, "RESERVED2"),
+            all::OP_1ADD => write!(f, "1ADD"),
+            all::OP_1SUB => write!(f, "1SUB"),
+            all::OP_2MUL => write!(f, "2MUL"),
+            all::OP_2DIV => write!(f, "2DIV"),
+            all::OP_NEGATE => write!(f, "NEGATE"),
+            all::OP_ABS => write!(f, "ABS"),
+            all::OP_NOT => write!(f, "NOT"),
+            all::OP_0NOTEQUAL => write!(f, "0NOTEQUAL"),
+            all::OP_ADD => write!(f, "ADD"),
+            all::OP_SUB => write!(f, "SUB"),
+            all::OP_MUL => write!(f, "MUL"),
+            all::OP_DIV => write!(f, "DIV"),
+            all::OP_MOD => write!(f, "MOD"),
+            all::OP_LSHIFT => write!(f, "LSHIFT"),
+            all::OP_RSHIFT => write!(f, "RSHIFT"),
+            all::OP_BOOLAND => write!(f, "BOOLAND"),
+            all::OP_BOOLOR => write!(f, "BOOLOR"),
+            all::OP_NUMEQUAL => write!(f, "NUMEQUAL"),
+            all::OP_NUMEQUALVERIFY => write!(f, "NUMEQUALVERIFY"),
+            all::OP_NUMNOTEQUAL => write!(f, "NUMNOTEQUAL"),
+            all::OP_LESSTHAN => write!(f, "LESSTHAN"),
+            all::OP_GREATERTHAN => write!(f, "GREATERTHAN"),
+            all::OP_LESSTHANOREQUAL => write!(f, "LESSTHANOREQUAL"),
+            all::OP_GREATERTHANOREQUAL => write!(f, "GREATERTHANOREQUAL"),
+            all::OP_MIN => write!(f, "MIN"),
+            all::OP_MAX => write!(f, "MAX"),
+            all::OP_WITHIN => write!(f, "WITHIN"),
+            all::OP_RIPEMD160 => write!(f, "RIPEMD160"),
+            all::OP_SHA1 => write!(f, "SHA1"),
+            all::OP_SHA256 => write!(f, "SHA256"),
+            all::OP_HASH160 => write!(f, "HASH160"),
+            all::OP_HASH256 => write!(f, "HASH256"),
+            all::OP_CODESEPARATOR => write!(f, "CODESEPARATOR"),
+            all::OP_CHECKSIG => write!(f, "CHECKSIG"),
+            all::OP_CHECKSIGVERIFY => write!(f, "CHECKSIGVERIFY"),
+            all::OP_CHECKMULTISIG => write!(f, "CHECKMULTISIG"),
+            all::OP_CHECKMULTISIGVERIFY => write!(f, "CHECKMULTISIGVERIFY"),
+            all::OP_CLTV => write!(f, "CLTV"),
+            all::OP_CSV => write!(f, "CSV"),
+            All { code: x } if x >= all::OP_NOP1.code && x <= all::OP_NOP10.code => {
+                write!(f, "NOP{}", x - all::OP_NOP1.code + 1)
+            }
+            All { code: x } => write!(f, "RETURN_{}", x),
+        }
+    }
 }
 
 impl All {
-	/// Classifies an Opcode into a broad class
-	#[inline]
-	pub fn classify(self) -> Class {
-		// 17 opcodes
-		if self == all::OP_VERIF ||
-			self == all::OP_VERNOTIF ||
-			self == all::OP_CAT ||
-			self == all::OP_SUBSTR ||
-			self == all::OP_LEFT ||
-			self == all::OP_RIGHT ||
-			self == all::OP_INVERT ||
-			self == all::OP_AND ||
-			self == all::OP_OR ||
-			self == all::OP_XOR ||
-			self == all::OP_2MUL ||
-			self == all::OP_2DIV ||
-			self == all::OP_MUL ||
-			self == all::OP_DIV ||
-			self == all::OP_MOD ||
-			self == all::OP_LSHIFT ||
-			self == all::OP_RSHIFT
-		{
-			Class::IllegalOp
-		// 11 opcodes
-		} else if self == all::OP_NOP ||
-			(all::OP_NOP1.code <= self.code && self.code <= all::OP_NOP10.code)
-		{
-			Class::NoOp
-		// 75 opcodes
-		} else if self == all::OP_RESERVED ||
-			self == all::OP_VER ||
-			self == all::OP_RETURN ||
-			self == all::OP_RESERVED1 ||
-			self == all::OP_RESERVED2 ||
-			self.code >= all::OP_RETURN_186.code
-		{
-			Class::ReturnOp
-		// 1 opcode
-		} else if self == all::OP_PUSHNUM_NEG1 {
-			Class::PushNum(-1)
-		// 16 opcodes
-		} else if all::OP_PUSHNUM_1.code <= self.code && self.code <= all::OP_PUSHNUM_16.code {
-			Class::PushNum(1 + self.code as i32 - all::OP_PUSHNUM_1.code as i32)
-		// 76 opcodes
-		} else if self.code <= all::OP_PUSHBYTES_75.code {
-			Class::PushBytes(self.code as u32)
-		// 60 opcodes
-		} else {
-			Ordinary::try_from_all(self)
-				.map(Class::Ordinary)
-				.or_else(|| ControlFlow::try_from_all(self).map(Class::ControlFlow))
-				.or_else(|| PushData::try_from_all(self).map(Class::PushData))
-				.or_else(|| Signature::try_from_all(self).map(Class::Signature))
-				.or_else(|| AltStack::try_from_all(self).map(Class::AltStack))
-				.expect("opcode categories not covered")
-		}
-	}
+    /// Classifies an Opcode into a broad class
+    #[inline]
+    pub fn classify(self) -> Class {
+        // 17 opcodes
+        if self == all::OP_VERIF
+            || self == all::OP_VERNOTIF
+            || self == all::OP_CAT
+            || self == all::OP_SUBSTR
+            || self == all::OP_LEFT
+            || self == all::OP_RIGHT
+            || self == all::OP_INVERT
+            || self == all::OP_AND
+            || self == all::OP_OR
+            || self == all::OP_XOR
+            || self == all::OP_2MUL
+            || self == all::OP_2DIV
+            || self == all::OP_MUL
+            || self == all::OP_DIV
+            || self == all::OP_MOD
+            || self == all::OP_LSHIFT
+            || self == all::OP_RSHIFT
+        {
+            Class::IllegalOp
+        // 11 opcodes
+        } else if self == all::OP_NOP
+            || (all::OP_NOP1.code <= self.code && self.code <= all::OP_NOP10.code)
+        {
+            Class::NoOp
+        // 75 opcodes
+        } else if self == all::OP_RESERVED
+            || self == all::OP_VER
+            || self == all::OP_RETURN
+            || self == all::OP_RESERVED1
+            || self == all::OP_RESERVED2
+            || self.code >= all::OP_RETURN_186.code
+        {
+            Class::ReturnOp
+        // 1 opcode
+        } else if self == all::OP_PUSHNUM_NEG1 {
+            Class::PushNum(-1)
+        // 16 opcodes
+        } else if all::OP_PUSHNUM_1.code <= self.code && self.code <= all::OP_PUSHNUM_16.code {
+            Class::PushNum(1 + self.code as i32 - all::OP_PUSHNUM_1.code as i32)
+        // 76 opcodes
+        } else if self.code <= all::OP_PUSHBYTES_75.code {
+            Class::PushBytes(self.code as u32)
+        // 60 opcodes
+        } else {
+            Ordinary::try_from_all(self)
+                .map(Class::Ordinary)
+                .or_else(|| ControlFlow::try_from_all(self).map(Class::ControlFlow))
+                .or_else(|| PushData::try_from_all(self).map(Class::PushData))
+                .or_else(|| Signature::try_from_all(self).map(Class::Signature))
+                .or_else(|| AltStack::try_from_all(self).map(Class::AltStack))
+                .expect("opcode categories not covered")
+        }
+    }
 
-	/// Encode as a byte
-	#[inline]
-	pub fn into_u8(self) -> u8 {
-		self.code
-	}
+    /// Encode as a byte
+    #[inline]
+    pub fn into_u8(self) -> u8 {
+        self.code
+    }
 }
 
 impl From<u8> for All {
-	#[inline]
-	fn from(b: u8) -> All {
-		All { code: b }
-	}
+    #[inline]
+    fn from(b: u8) -> All {
+        All { code: b }
+    }
 }
 
 display_from_debug!(All);
 
 #[cfg(feature = "serde")]
 impl serde::Serialize for All {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		serializer.serialize_str(&self.to_string())
-	}
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
 }
 
 /// Empty stack is also FALSE
@@ -764,38 +764,38 @@ pub static OP_NOP3: All = all::OP_CSV;
 /// Broad categories of opcodes with similar behavior
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum Class {
-	/// Pushes the given number onto the stack
-	PushNum(i32),
-	/// Pushes the given number of bytes onto the stack
-	PushBytes(u32),
-	/// Pushes the number of bytes determined by size following the opcode.
-	PushData(PushData),
-	/// Fails the script if executed
-	ReturnOp,
-	/// Fails the script even if not executed
-	IllegalOp,
-	/// Does nothing
-	NoOp,
-	/// Control flow opcodes
-	ControlFlow(ControlFlow),
-	/// Opcodes manipulating alt stack
-	AltStack(AltStack),
-	/// Opcodes to do with verifying signatures
-	Signature(Signature),
-	/// Any opcode not covered above
-	Ordinary(Ordinary),
+    /// Pushes the given number onto the stack
+    PushNum(i32),
+    /// Pushes the given number of bytes onto the stack
+    PushBytes(u32),
+    /// Pushes the number of bytes determined by size following the opcode.
+    PushData(PushData),
+    /// Fails the script if executed
+    ReturnOp,
+    /// Fails the script even if not executed
+    IllegalOp,
+    /// Does nothing
+    NoOp,
+    /// Control flow opcodes
+    ControlFlow(ControlFlow),
+    /// Opcodes manipulating alt stack
+    AltStack(AltStack),
+    /// Opcodes to do with verifying signatures
+    Signature(Signature),
+    /// Any opcode not covered above
+    Ordinary(Ordinary),
 }
 
 display_from_debug!(Class);
 
 #[cfg(feature = "serde")]
 impl serde::Serialize for Class {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		serializer.serialize_str(&self.to_string())
-	}
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
 }
 
 macro_rules! opcode_category {
@@ -821,358 +821,361 @@ macro_rules! opcode_category {
 
 // Control flow opcodes
 opcode_category! {
-	ControlFlow -> OP_IF, OP_NOTIF, OP_ELSE, OP_ENDIF
+    ControlFlow -> OP_IF, OP_NOTIF, OP_ELSE, OP_ENDIF
 }
 
 // Alt stack manipulation opcodes
 opcode_category! {
-	AltStack -> OP_TOALTSTACK, OP_FROMALTSTACK
+    AltStack -> OP_TOALTSTACK, OP_FROMALTSTACK
 }
 
 // Signature verification opcodes
 opcode_category! {
-	Signature ->
-		OP_CHECKSIG, OP_CHECKSIGVERIFY, OP_CHECKMULTISIG, OP_CHECKMULTISIGVERIFY,
-		OP_CODESEPARATOR
+    Signature ->
+        OP_CHECKSIG, OP_CHECKSIGVERIFY, OP_CHECKMULTISIG, OP_CHECKMULTISIGVERIFY,
+        OP_CODESEPARATOR
 }
 
 // Pushdata opcodes
 opcode_category! {
-	PushData -> OP_PUSHDATA1, OP_PUSHDATA2, OP_PUSHDATA4
+    PushData -> OP_PUSHDATA1, OP_PUSHDATA2, OP_PUSHDATA4
 }
 
 // "Ordinary" opcodes
 opcode_category! {
-	Ordinary ->
-		// verify
-		OP_VERIFY,
-		// stack
-		OP_2DROP, OP_2DUP, OP_3DUP, OP_2OVER, OP_2ROT, OP_2SWAP,
-		OP_DROP, OP_DUP, OP_NIP, OP_OVER, OP_PICK, OP_ROLL, OP_ROT, OP_SWAP, OP_TUCK,
-		OP_IFDUP, OP_DEPTH, OP_SIZE,
-		// equality
-		OP_EQUAL, OP_EQUALVERIFY,
-		// arithmetic
-		OP_1ADD, OP_1SUB, OP_NEGATE, OP_ABS, OP_NOT, OP_0NOTEQUAL,
-		OP_ADD, OP_SUB, OP_BOOLAND, OP_BOOLOR,
-		OP_NUMEQUAL, OP_NUMEQUALVERIFY, OP_NUMNOTEQUAL, OP_LESSTHAN,
-		OP_GREATERTHAN, OP_LESSTHANOREQUAL, OP_GREATERTHANOREQUAL,
-		OP_MIN, OP_MAX, OP_WITHIN,
-		// hashes
-		OP_RIPEMD160, OP_SHA1, OP_SHA256, OP_HASH160, OP_HASH256
+    Ordinary ->
+        // verify
+        OP_VERIFY,
+        // stack
+        OP_2DROP, OP_2DUP, OP_3DUP, OP_2OVER, OP_2ROT, OP_2SWAP,
+        OP_DROP, OP_DUP, OP_NIP, OP_OVER, OP_PICK, OP_ROLL, OP_ROT, OP_SWAP, OP_TUCK,
+        OP_IFDUP, OP_DEPTH, OP_SIZE,
+        // equality
+        OP_EQUAL, OP_EQUALVERIFY,
+        // arithmetic
+        OP_1ADD, OP_1SUB, OP_NEGATE, OP_ABS, OP_NOT, OP_0NOTEQUAL,
+        OP_ADD, OP_SUB, OP_BOOLAND, OP_BOOLOR,
+        OP_NUMEQUAL, OP_NUMEQUALVERIFY, OP_NUMNOTEQUAL, OP_LESSTHAN,
+        OP_GREATERTHAN, OP_LESSTHANOREQUAL, OP_GREATERTHANOREQUAL,
+        OP_MIN, OP_MAX, OP_WITHIN,
+        // hashes
+        OP_RIPEMD160, OP_SHA1, OP_SHA256, OP_HASH160, OP_HASH256
 }
 
 impl PushData {
-	/// Get number of bytes reserved to specify push length.
-	pub fn data_size_bytes(self) -> usize {
-		match self {
-			Self::OP_PUSHDATA1 => 1,
-			Self::OP_PUSHDATA2 => 2,
-			Self::OP_PUSHDATA4 => 4,
-		}
-	}
+    /// Get number of bytes reserved to specify push length.
+    pub fn data_size_bytes(self) -> usize {
+        match self {
+            Self::OP_PUSHDATA1 => 1,
+            Self::OP_PUSHDATA2 => 2,
+            Self::OP_PUSHDATA4 => 4,
+        }
+    }
 
-	/// Minimum value to be pushed by this for it to be a minimal push.
-	pub fn data_size_min(self) -> usize {
-		match self {
-			Self::OP_PUSHDATA1 => 76,
-			Self::OP_PUSHDATA2 => 0x100,
-			Self::OP_PUSHDATA4 => 0x10000,
-		}
-	}
+    /// Minimum value to be pushed by this for it to be a minimal push.
+    pub fn data_size_min(self) -> usize {
+        match self {
+            Self::OP_PUSHDATA1 => 76,
+            Self::OP_PUSHDATA2 => 0x100,
+            Self::OP_PUSHDATA4 => 0x10000,
+        }
+    }
 }
 
 impl Ordinary {
-	/// Is this OP_*VERIFY?
-	pub fn is_verify(self) -> bool {
-		matches!(self, Self::OP_VERIFY | Self::OP_EQUALVERIFY | Self::OP_NUMEQUALVERIFY)
-	}
+    /// Is this OP_*VERIFY?
+    pub fn is_verify(self) -> bool {
+        matches!(
+            self,
+            Self::OP_VERIFY | Self::OP_EQUALVERIFY | Self::OP_NUMEQUALVERIFY
+        )
+    }
 }
 
 impl Signature {
-	/// Is this OP_*VERIFY?
-	pub fn is_verify(self) -> bool {
-		matches!(self, Self::OP_CHECKSIGVERIFY | Self::OP_CHECKMULTISIGVERIFY)
-	}
+    /// Is this OP_*VERIFY?
+    pub fn is_verify(self) -> bool {
+        matches!(self, Self::OP_CHECKSIGVERIFY | Self::OP_CHECKMULTISIGVERIFY)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use std::collections::HashSet;
+    use std::collections::HashSet;
 
-	use super::*;
+    use super::*;
 
-	macro_rules! roundtrip {
-		($unique:expr, $op:ident) => {
-			assert_eq!(all::$op, All::from(all::$op.into_u8()));
+    macro_rules! roundtrip {
+        ($unique:expr, $op:ident) => {
+            assert_eq!(all::$op, All::from(all::$op.into_u8()));
 
-			let s1 = format!("{}", all::$op);
-			let s2 = format!("{:?}", all::$op);
-			assert_eq!(s1, s2);
-			assert_eq!(s2, stringify!($op));
-			assert!($unique.insert(s2));
-		};
-	}
+            let s1 = format!("{}", all::$op);
+            let s2 = format!("{:?}", all::$op);
+            assert_eq!(s1, s2);
+            assert_eq!(s2, stringify!($op));
+            assert!($unique.insert(s2));
+        };
+    }
 
-	#[test]
-	fn str_roundtrip() {
-		let mut unique = HashSet::new();
-		roundtrip!(unique, OP_PUSHBYTES_0);
-		roundtrip!(unique, OP_PUSHBYTES_1);
-		roundtrip!(unique, OP_PUSHBYTES_2);
-		roundtrip!(unique, OP_PUSHBYTES_3);
-		roundtrip!(unique, OP_PUSHBYTES_4);
-		roundtrip!(unique, OP_PUSHBYTES_5);
-		roundtrip!(unique, OP_PUSHBYTES_6);
-		roundtrip!(unique, OP_PUSHBYTES_7);
-		roundtrip!(unique, OP_PUSHBYTES_8);
-		roundtrip!(unique, OP_PUSHBYTES_9);
-		roundtrip!(unique, OP_PUSHBYTES_10);
-		roundtrip!(unique, OP_PUSHBYTES_11);
-		roundtrip!(unique, OP_PUSHBYTES_12);
-		roundtrip!(unique, OP_PUSHBYTES_13);
-		roundtrip!(unique, OP_PUSHBYTES_14);
-		roundtrip!(unique, OP_PUSHBYTES_15);
-		roundtrip!(unique, OP_PUSHBYTES_16);
-		roundtrip!(unique, OP_PUSHBYTES_17);
-		roundtrip!(unique, OP_PUSHBYTES_18);
-		roundtrip!(unique, OP_PUSHBYTES_19);
-		roundtrip!(unique, OP_PUSHBYTES_20);
-		roundtrip!(unique, OP_PUSHBYTES_21);
-		roundtrip!(unique, OP_PUSHBYTES_22);
-		roundtrip!(unique, OP_PUSHBYTES_23);
-		roundtrip!(unique, OP_PUSHBYTES_24);
-		roundtrip!(unique, OP_PUSHBYTES_25);
-		roundtrip!(unique, OP_PUSHBYTES_26);
-		roundtrip!(unique, OP_PUSHBYTES_27);
-		roundtrip!(unique, OP_PUSHBYTES_28);
-		roundtrip!(unique, OP_PUSHBYTES_29);
-		roundtrip!(unique, OP_PUSHBYTES_30);
-		roundtrip!(unique, OP_PUSHBYTES_31);
-		roundtrip!(unique, OP_PUSHBYTES_32);
-		roundtrip!(unique, OP_PUSHBYTES_33);
-		roundtrip!(unique, OP_PUSHBYTES_34);
-		roundtrip!(unique, OP_PUSHBYTES_35);
-		roundtrip!(unique, OP_PUSHBYTES_36);
-		roundtrip!(unique, OP_PUSHBYTES_37);
-		roundtrip!(unique, OP_PUSHBYTES_38);
-		roundtrip!(unique, OP_PUSHBYTES_39);
-		roundtrip!(unique, OP_PUSHBYTES_40);
-		roundtrip!(unique, OP_PUSHBYTES_41);
-		roundtrip!(unique, OP_PUSHBYTES_42);
-		roundtrip!(unique, OP_PUSHBYTES_43);
-		roundtrip!(unique, OP_PUSHBYTES_44);
-		roundtrip!(unique, OP_PUSHBYTES_45);
-		roundtrip!(unique, OP_PUSHBYTES_46);
-		roundtrip!(unique, OP_PUSHBYTES_47);
-		roundtrip!(unique, OP_PUSHBYTES_48);
-		roundtrip!(unique, OP_PUSHBYTES_49);
-		roundtrip!(unique, OP_PUSHBYTES_50);
-		roundtrip!(unique, OP_PUSHBYTES_51);
-		roundtrip!(unique, OP_PUSHBYTES_52);
-		roundtrip!(unique, OP_PUSHBYTES_53);
-		roundtrip!(unique, OP_PUSHBYTES_54);
-		roundtrip!(unique, OP_PUSHBYTES_55);
-		roundtrip!(unique, OP_PUSHBYTES_56);
-		roundtrip!(unique, OP_PUSHBYTES_57);
-		roundtrip!(unique, OP_PUSHBYTES_58);
-		roundtrip!(unique, OP_PUSHBYTES_59);
-		roundtrip!(unique, OP_PUSHBYTES_60);
-		roundtrip!(unique, OP_PUSHBYTES_61);
-		roundtrip!(unique, OP_PUSHBYTES_62);
-		roundtrip!(unique, OP_PUSHBYTES_63);
-		roundtrip!(unique, OP_PUSHBYTES_64);
-		roundtrip!(unique, OP_PUSHBYTES_65);
-		roundtrip!(unique, OP_PUSHBYTES_66);
-		roundtrip!(unique, OP_PUSHBYTES_67);
-		roundtrip!(unique, OP_PUSHBYTES_68);
-		roundtrip!(unique, OP_PUSHBYTES_69);
-		roundtrip!(unique, OP_PUSHBYTES_70);
-		roundtrip!(unique, OP_PUSHBYTES_71);
-		roundtrip!(unique, OP_PUSHBYTES_72);
-		roundtrip!(unique, OP_PUSHBYTES_73);
-		roundtrip!(unique, OP_PUSHBYTES_74);
-		roundtrip!(unique, OP_PUSHBYTES_75);
-		roundtrip!(unique, OP_PUSHDATA1);
-		roundtrip!(unique, OP_PUSHDATA2);
-		roundtrip!(unique, OP_PUSHDATA4);
-		roundtrip!(unique, OP_PUSHNUM_NEG1);
-		roundtrip!(unique, OP_RESERVED);
-		roundtrip!(unique, OP_PUSHNUM_1);
-		roundtrip!(unique, OP_PUSHNUM_2);
-		roundtrip!(unique, OP_PUSHNUM_3);
-		roundtrip!(unique, OP_PUSHNUM_4);
-		roundtrip!(unique, OP_PUSHNUM_5);
-		roundtrip!(unique, OP_PUSHNUM_6);
-		roundtrip!(unique, OP_PUSHNUM_7);
-		roundtrip!(unique, OP_PUSHNUM_8);
-		roundtrip!(unique, OP_PUSHNUM_9);
-		roundtrip!(unique, OP_PUSHNUM_10);
-		roundtrip!(unique, OP_PUSHNUM_11);
-		roundtrip!(unique, OP_PUSHNUM_12);
-		roundtrip!(unique, OP_PUSHNUM_13);
-		roundtrip!(unique, OP_PUSHNUM_14);
-		roundtrip!(unique, OP_PUSHNUM_15);
-		roundtrip!(unique, OP_PUSHNUM_16);
-		roundtrip!(unique, OP_NOP);
-		roundtrip!(unique, OP_VER);
-		roundtrip!(unique, OP_IF);
-		roundtrip!(unique, OP_NOTIF);
-		roundtrip!(unique, OP_VERIF);
-		roundtrip!(unique, OP_VERNOTIF);
-		roundtrip!(unique, OP_ELSE);
-		roundtrip!(unique, OP_ENDIF);
-		roundtrip!(unique, OP_VERIFY);
-		roundtrip!(unique, OP_RETURN);
-		roundtrip!(unique, OP_TOALTSTACK);
-		roundtrip!(unique, OP_FROMALTSTACK);
-		roundtrip!(unique, OP_2DROP);
-		roundtrip!(unique, OP_2DUP);
-		roundtrip!(unique, OP_3DUP);
-		roundtrip!(unique, OP_2OVER);
-		roundtrip!(unique, OP_2ROT);
-		roundtrip!(unique, OP_2SWAP);
-		roundtrip!(unique, OP_IFDUP);
-		roundtrip!(unique, OP_DEPTH);
-		roundtrip!(unique, OP_DROP);
-		roundtrip!(unique, OP_DUP);
-		roundtrip!(unique, OP_NIP);
-		roundtrip!(unique, OP_OVER);
-		roundtrip!(unique, OP_PICK);
-		roundtrip!(unique, OP_ROLL);
-		roundtrip!(unique, OP_ROT);
-		roundtrip!(unique, OP_SWAP);
-		roundtrip!(unique, OP_TUCK);
-		roundtrip!(unique, OP_CAT);
-		roundtrip!(unique, OP_SUBSTR);
-		roundtrip!(unique, OP_LEFT);
-		roundtrip!(unique, OP_RIGHT);
-		roundtrip!(unique, OP_SIZE);
-		roundtrip!(unique, OP_INVERT);
-		roundtrip!(unique, OP_AND);
-		roundtrip!(unique, OP_OR);
-		roundtrip!(unique, OP_XOR);
-		roundtrip!(unique, OP_EQUAL);
-		roundtrip!(unique, OP_EQUALVERIFY);
-		roundtrip!(unique, OP_RESERVED1);
-		roundtrip!(unique, OP_RESERVED2);
-		roundtrip!(unique, OP_1ADD);
-		roundtrip!(unique, OP_1SUB);
-		roundtrip!(unique, OP_2MUL);
-		roundtrip!(unique, OP_2DIV);
-		roundtrip!(unique, OP_NEGATE);
-		roundtrip!(unique, OP_ABS);
-		roundtrip!(unique, OP_NOT);
-		roundtrip!(unique, OP_0NOTEQUAL);
-		roundtrip!(unique, OP_ADD);
-		roundtrip!(unique, OP_SUB);
-		roundtrip!(unique, OP_MUL);
-		roundtrip!(unique, OP_DIV);
-		roundtrip!(unique, OP_MOD);
-		roundtrip!(unique, OP_LSHIFT);
-		roundtrip!(unique, OP_RSHIFT);
-		roundtrip!(unique, OP_BOOLAND);
-		roundtrip!(unique, OP_BOOLOR);
-		roundtrip!(unique, OP_NUMEQUAL);
-		roundtrip!(unique, OP_NUMEQUALVERIFY);
-		roundtrip!(unique, OP_NUMNOTEQUAL);
-		roundtrip!(unique, OP_LESSTHAN);
-		roundtrip!(unique, OP_GREATERTHAN);
-		roundtrip!(unique, OP_LESSTHANOREQUAL);
-		roundtrip!(unique, OP_GREATERTHANOREQUAL);
-		roundtrip!(unique, OP_MIN);
-		roundtrip!(unique, OP_MAX);
-		roundtrip!(unique, OP_WITHIN);
-		roundtrip!(unique, OP_RIPEMD160);
-		roundtrip!(unique, OP_SHA1);
-		roundtrip!(unique, OP_SHA256);
-		roundtrip!(unique, OP_HASH160);
-		roundtrip!(unique, OP_HASH256);
-		roundtrip!(unique, OP_CODESEPARATOR);
-		roundtrip!(unique, OP_CHECKSIG);
-		roundtrip!(unique, OP_CHECKSIGVERIFY);
-		roundtrip!(unique, OP_CHECKMULTISIG);
-		roundtrip!(unique, OP_CHECKMULTISIGVERIFY);
-		roundtrip!(unique, OP_NOP1);
-		roundtrip!(unique, OP_CLTV);
-		roundtrip!(unique, OP_CSV);
-		roundtrip!(unique, OP_NOP4);
-		roundtrip!(unique, OP_NOP5);
-		roundtrip!(unique, OP_NOP6);
-		roundtrip!(unique, OP_NOP7);
-		roundtrip!(unique, OP_NOP8);
-		roundtrip!(unique, OP_NOP9);
-		roundtrip!(unique, OP_NOP10);
-		roundtrip!(unique, OP_RETURN_186);
-		roundtrip!(unique, OP_RETURN_187);
-		roundtrip!(unique, OP_RETURN_188);
-		roundtrip!(unique, OP_RETURN_189);
-		roundtrip!(unique, OP_RETURN_190);
-		roundtrip!(unique, OP_RETURN_191);
-		roundtrip!(unique, OP_RETURN_192);
-		roundtrip!(unique, OP_RETURN_193);
-		roundtrip!(unique, OP_RETURN_194);
-		roundtrip!(unique, OP_RETURN_195);
-		roundtrip!(unique, OP_RETURN_196);
-		roundtrip!(unique, OP_RETURN_197);
-		roundtrip!(unique, OP_RETURN_198);
-		roundtrip!(unique, OP_RETURN_199);
-		roundtrip!(unique, OP_RETURN_200);
-		roundtrip!(unique, OP_RETURN_201);
-		roundtrip!(unique, OP_RETURN_202);
-		roundtrip!(unique, OP_RETURN_203);
-		roundtrip!(unique, OP_RETURN_204);
-		roundtrip!(unique, OP_RETURN_205);
-		roundtrip!(unique, OP_RETURN_206);
-		roundtrip!(unique, OP_RETURN_207);
-		roundtrip!(unique, OP_RETURN_208);
-		roundtrip!(unique, OP_RETURN_209);
-		roundtrip!(unique, OP_RETURN_210);
-		roundtrip!(unique, OP_RETURN_211);
-		roundtrip!(unique, OP_RETURN_212);
-		roundtrip!(unique, OP_RETURN_213);
-		roundtrip!(unique, OP_RETURN_214);
-		roundtrip!(unique, OP_RETURN_215);
-		roundtrip!(unique, OP_RETURN_216);
-		roundtrip!(unique, OP_RETURN_217);
-		roundtrip!(unique, OP_RETURN_218);
-		roundtrip!(unique, OP_RETURN_219);
-		roundtrip!(unique, OP_RETURN_220);
-		roundtrip!(unique, OP_RETURN_221);
-		roundtrip!(unique, OP_RETURN_222);
-		roundtrip!(unique, OP_RETURN_223);
-		roundtrip!(unique, OP_RETURN_224);
-		roundtrip!(unique, OP_RETURN_225);
-		roundtrip!(unique, OP_RETURN_226);
-		roundtrip!(unique, OP_RETURN_227);
-		roundtrip!(unique, OP_RETURN_228);
-		roundtrip!(unique, OP_RETURN_229);
-		roundtrip!(unique, OP_RETURN_230);
-		roundtrip!(unique, OP_RETURN_231);
-		roundtrip!(unique, OP_RETURN_232);
-		roundtrip!(unique, OP_RETURN_233);
-		roundtrip!(unique, OP_RETURN_234);
-		roundtrip!(unique, OP_RETURN_235);
-		roundtrip!(unique, OP_RETURN_236);
-		roundtrip!(unique, OP_RETURN_237);
-		roundtrip!(unique, OP_RETURN_238);
-		roundtrip!(unique, OP_RETURN_239);
-		roundtrip!(unique, OP_RETURN_240);
-		roundtrip!(unique, OP_RETURN_241);
-		roundtrip!(unique, OP_RETURN_242);
-		roundtrip!(unique, OP_RETURN_243);
-		roundtrip!(unique, OP_RETURN_244);
-		roundtrip!(unique, OP_RETURN_245);
-		roundtrip!(unique, OP_RETURN_246);
-		roundtrip!(unique, OP_RETURN_247);
-		roundtrip!(unique, OP_RETURN_248);
-		roundtrip!(unique, OP_RETURN_249);
-		roundtrip!(unique, OP_RETURN_250);
-		roundtrip!(unique, OP_RETURN_251);
-		roundtrip!(unique, OP_RETURN_252);
-		roundtrip!(unique, OP_RETURN_253);
-		roundtrip!(unique, OP_RETURN_254);
-		roundtrip!(unique, OP_RETURN_255);
-		assert_eq!(unique.len(), 256);
-	}
+    #[test]
+    fn str_roundtrip() {
+        let mut unique = HashSet::new();
+        roundtrip!(unique, OP_PUSHBYTES_0);
+        roundtrip!(unique, OP_PUSHBYTES_1);
+        roundtrip!(unique, OP_PUSHBYTES_2);
+        roundtrip!(unique, OP_PUSHBYTES_3);
+        roundtrip!(unique, OP_PUSHBYTES_4);
+        roundtrip!(unique, OP_PUSHBYTES_5);
+        roundtrip!(unique, OP_PUSHBYTES_6);
+        roundtrip!(unique, OP_PUSHBYTES_7);
+        roundtrip!(unique, OP_PUSHBYTES_8);
+        roundtrip!(unique, OP_PUSHBYTES_9);
+        roundtrip!(unique, OP_PUSHBYTES_10);
+        roundtrip!(unique, OP_PUSHBYTES_11);
+        roundtrip!(unique, OP_PUSHBYTES_12);
+        roundtrip!(unique, OP_PUSHBYTES_13);
+        roundtrip!(unique, OP_PUSHBYTES_14);
+        roundtrip!(unique, OP_PUSHBYTES_15);
+        roundtrip!(unique, OP_PUSHBYTES_16);
+        roundtrip!(unique, OP_PUSHBYTES_17);
+        roundtrip!(unique, OP_PUSHBYTES_18);
+        roundtrip!(unique, OP_PUSHBYTES_19);
+        roundtrip!(unique, OP_PUSHBYTES_20);
+        roundtrip!(unique, OP_PUSHBYTES_21);
+        roundtrip!(unique, OP_PUSHBYTES_22);
+        roundtrip!(unique, OP_PUSHBYTES_23);
+        roundtrip!(unique, OP_PUSHBYTES_24);
+        roundtrip!(unique, OP_PUSHBYTES_25);
+        roundtrip!(unique, OP_PUSHBYTES_26);
+        roundtrip!(unique, OP_PUSHBYTES_27);
+        roundtrip!(unique, OP_PUSHBYTES_28);
+        roundtrip!(unique, OP_PUSHBYTES_29);
+        roundtrip!(unique, OP_PUSHBYTES_30);
+        roundtrip!(unique, OP_PUSHBYTES_31);
+        roundtrip!(unique, OP_PUSHBYTES_32);
+        roundtrip!(unique, OP_PUSHBYTES_33);
+        roundtrip!(unique, OP_PUSHBYTES_34);
+        roundtrip!(unique, OP_PUSHBYTES_35);
+        roundtrip!(unique, OP_PUSHBYTES_36);
+        roundtrip!(unique, OP_PUSHBYTES_37);
+        roundtrip!(unique, OP_PUSHBYTES_38);
+        roundtrip!(unique, OP_PUSHBYTES_39);
+        roundtrip!(unique, OP_PUSHBYTES_40);
+        roundtrip!(unique, OP_PUSHBYTES_41);
+        roundtrip!(unique, OP_PUSHBYTES_42);
+        roundtrip!(unique, OP_PUSHBYTES_43);
+        roundtrip!(unique, OP_PUSHBYTES_44);
+        roundtrip!(unique, OP_PUSHBYTES_45);
+        roundtrip!(unique, OP_PUSHBYTES_46);
+        roundtrip!(unique, OP_PUSHBYTES_47);
+        roundtrip!(unique, OP_PUSHBYTES_48);
+        roundtrip!(unique, OP_PUSHBYTES_49);
+        roundtrip!(unique, OP_PUSHBYTES_50);
+        roundtrip!(unique, OP_PUSHBYTES_51);
+        roundtrip!(unique, OP_PUSHBYTES_52);
+        roundtrip!(unique, OP_PUSHBYTES_53);
+        roundtrip!(unique, OP_PUSHBYTES_54);
+        roundtrip!(unique, OP_PUSHBYTES_55);
+        roundtrip!(unique, OP_PUSHBYTES_56);
+        roundtrip!(unique, OP_PUSHBYTES_57);
+        roundtrip!(unique, OP_PUSHBYTES_58);
+        roundtrip!(unique, OP_PUSHBYTES_59);
+        roundtrip!(unique, OP_PUSHBYTES_60);
+        roundtrip!(unique, OP_PUSHBYTES_61);
+        roundtrip!(unique, OP_PUSHBYTES_62);
+        roundtrip!(unique, OP_PUSHBYTES_63);
+        roundtrip!(unique, OP_PUSHBYTES_64);
+        roundtrip!(unique, OP_PUSHBYTES_65);
+        roundtrip!(unique, OP_PUSHBYTES_66);
+        roundtrip!(unique, OP_PUSHBYTES_67);
+        roundtrip!(unique, OP_PUSHBYTES_68);
+        roundtrip!(unique, OP_PUSHBYTES_69);
+        roundtrip!(unique, OP_PUSHBYTES_70);
+        roundtrip!(unique, OP_PUSHBYTES_71);
+        roundtrip!(unique, OP_PUSHBYTES_72);
+        roundtrip!(unique, OP_PUSHBYTES_73);
+        roundtrip!(unique, OP_PUSHBYTES_74);
+        roundtrip!(unique, OP_PUSHBYTES_75);
+        roundtrip!(unique, OP_PUSHDATA1);
+        roundtrip!(unique, OP_PUSHDATA2);
+        roundtrip!(unique, OP_PUSHDATA4);
+        roundtrip!(unique, OP_PUSHNUM_NEG1);
+        roundtrip!(unique, OP_RESERVED);
+        roundtrip!(unique, OP_PUSHNUM_1);
+        roundtrip!(unique, OP_PUSHNUM_2);
+        roundtrip!(unique, OP_PUSHNUM_3);
+        roundtrip!(unique, OP_PUSHNUM_4);
+        roundtrip!(unique, OP_PUSHNUM_5);
+        roundtrip!(unique, OP_PUSHNUM_6);
+        roundtrip!(unique, OP_PUSHNUM_7);
+        roundtrip!(unique, OP_PUSHNUM_8);
+        roundtrip!(unique, OP_PUSHNUM_9);
+        roundtrip!(unique, OP_PUSHNUM_10);
+        roundtrip!(unique, OP_PUSHNUM_11);
+        roundtrip!(unique, OP_PUSHNUM_12);
+        roundtrip!(unique, OP_PUSHNUM_13);
+        roundtrip!(unique, OP_PUSHNUM_14);
+        roundtrip!(unique, OP_PUSHNUM_15);
+        roundtrip!(unique, OP_PUSHNUM_16);
+        roundtrip!(unique, OP_NOP);
+        roundtrip!(unique, OP_VER);
+        roundtrip!(unique, OP_IF);
+        roundtrip!(unique, OP_NOTIF);
+        roundtrip!(unique, OP_VERIF);
+        roundtrip!(unique, OP_VERNOTIF);
+        roundtrip!(unique, OP_ELSE);
+        roundtrip!(unique, OP_ENDIF);
+        roundtrip!(unique, OP_VERIFY);
+        roundtrip!(unique, OP_RETURN);
+        roundtrip!(unique, OP_TOALTSTACK);
+        roundtrip!(unique, OP_FROMALTSTACK);
+        roundtrip!(unique, OP_2DROP);
+        roundtrip!(unique, OP_2DUP);
+        roundtrip!(unique, OP_3DUP);
+        roundtrip!(unique, OP_2OVER);
+        roundtrip!(unique, OP_2ROT);
+        roundtrip!(unique, OP_2SWAP);
+        roundtrip!(unique, OP_IFDUP);
+        roundtrip!(unique, OP_DEPTH);
+        roundtrip!(unique, OP_DROP);
+        roundtrip!(unique, OP_DUP);
+        roundtrip!(unique, OP_NIP);
+        roundtrip!(unique, OP_OVER);
+        roundtrip!(unique, OP_PICK);
+        roundtrip!(unique, OP_ROLL);
+        roundtrip!(unique, OP_ROT);
+        roundtrip!(unique, OP_SWAP);
+        roundtrip!(unique, OP_TUCK);
+        roundtrip!(unique, OP_CAT);
+        roundtrip!(unique, OP_SUBSTR);
+        roundtrip!(unique, OP_LEFT);
+        roundtrip!(unique, OP_RIGHT);
+        roundtrip!(unique, OP_SIZE);
+        roundtrip!(unique, OP_INVERT);
+        roundtrip!(unique, OP_AND);
+        roundtrip!(unique, OP_OR);
+        roundtrip!(unique, OP_XOR);
+        roundtrip!(unique, OP_EQUAL);
+        roundtrip!(unique, OP_EQUALVERIFY);
+        roundtrip!(unique, OP_RESERVED1);
+        roundtrip!(unique, OP_RESERVED2);
+        roundtrip!(unique, OP_1ADD);
+        roundtrip!(unique, OP_1SUB);
+        roundtrip!(unique, OP_2MUL);
+        roundtrip!(unique, OP_2DIV);
+        roundtrip!(unique, OP_NEGATE);
+        roundtrip!(unique, OP_ABS);
+        roundtrip!(unique, OP_NOT);
+        roundtrip!(unique, OP_0NOTEQUAL);
+        roundtrip!(unique, OP_ADD);
+        roundtrip!(unique, OP_SUB);
+        roundtrip!(unique, OP_MUL);
+        roundtrip!(unique, OP_DIV);
+        roundtrip!(unique, OP_MOD);
+        roundtrip!(unique, OP_LSHIFT);
+        roundtrip!(unique, OP_RSHIFT);
+        roundtrip!(unique, OP_BOOLAND);
+        roundtrip!(unique, OP_BOOLOR);
+        roundtrip!(unique, OP_NUMEQUAL);
+        roundtrip!(unique, OP_NUMEQUALVERIFY);
+        roundtrip!(unique, OP_NUMNOTEQUAL);
+        roundtrip!(unique, OP_LESSTHAN);
+        roundtrip!(unique, OP_GREATERTHAN);
+        roundtrip!(unique, OP_LESSTHANOREQUAL);
+        roundtrip!(unique, OP_GREATERTHANOREQUAL);
+        roundtrip!(unique, OP_MIN);
+        roundtrip!(unique, OP_MAX);
+        roundtrip!(unique, OP_WITHIN);
+        roundtrip!(unique, OP_RIPEMD160);
+        roundtrip!(unique, OP_SHA1);
+        roundtrip!(unique, OP_SHA256);
+        roundtrip!(unique, OP_HASH160);
+        roundtrip!(unique, OP_HASH256);
+        roundtrip!(unique, OP_CODESEPARATOR);
+        roundtrip!(unique, OP_CHECKSIG);
+        roundtrip!(unique, OP_CHECKSIGVERIFY);
+        roundtrip!(unique, OP_CHECKMULTISIG);
+        roundtrip!(unique, OP_CHECKMULTISIGVERIFY);
+        roundtrip!(unique, OP_NOP1);
+        roundtrip!(unique, OP_CLTV);
+        roundtrip!(unique, OP_CSV);
+        roundtrip!(unique, OP_NOP4);
+        roundtrip!(unique, OP_NOP5);
+        roundtrip!(unique, OP_NOP6);
+        roundtrip!(unique, OP_NOP7);
+        roundtrip!(unique, OP_NOP8);
+        roundtrip!(unique, OP_NOP9);
+        roundtrip!(unique, OP_NOP10);
+        roundtrip!(unique, OP_RETURN_186);
+        roundtrip!(unique, OP_RETURN_187);
+        roundtrip!(unique, OP_RETURN_188);
+        roundtrip!(unique, OP_RETURN_189);
+        roundtrip!(unique, OP_RETURN_190);
+        roundtrip!(unique, OP_RETURN_191);
+        roundtrip!(unique, OP_RETURN_192);
+        roundtrip!(unique, OP_RETURN_193);
+        roundtrip!(unique, OP_RETURN_194);
+        roundtrip!(unique, OP_RETURN_195);
+        roundtrip!(unique, OP_RETURN_196);
+        roundtrip!(unique, OP_RETURN_197);
+        roundtrip!(unique, OP_RETURN_198);
+        roundtrip!(unique, OP_RETURN_199);
+        roundtrip!(unique, OP_RETURN_200);
+        roundtrip!(unique, OP_RETURN_201);
+        roundtrip!(unique, OP_RETURN_202);
+        roundtrip!(unique, OP_RETURN_203);
+        roundtrip!(unique, OP_RETURN_204);
+        roundtrip!(unique, OP_RETURN_205);
+        roundtrip!(unique, OP_RETURN_206);
+        roundtrip!(unique, OP_RETURN_207);
+        roundtrip!(unique, OP_RETURN_208);
+        roundtrip!(unique, OP_RETURN_209);
+        roundtrip!(unique, OP_RETURN_210);
+        roundtrip!(unique, OP_RETURN_211);
+        roundtrip!(unique, OP_RETURN_212);
+        roundtrip!(unique, OP_RETURN_213);
+        roundtrip!(unique, OP_RETURN_214);
+        roundtrip!(unique, OP_RETURN_215);
+        roundtrip!(unique, OP_RETURN_216);
+        roundtrip!(unique, OP_RETURN_217);
+        roundtrip!(unique, OP_RETURN_218);
+        roundtrip!(unique, OP_RETURN_219);
+        roundtrip!(unique, OP_RETURN_220);
+        roundtrip!(unique, OP_RETURN_221);
+        roundtrip!(unique, OP_RETURN_222);
+        roundtrip!(unique, OP_RETURN_223);
+        roundtrip!(unique, OP_RETURN_224);
+        roundtrip!(unique, OP_RETURN_225);
+        roundtrip!(unique, OP_RETURN_226);
+        roundtrip!(unique, OP_RETURN_227);
+        roundtrip!(unique, OP_RETURN_228);
+        roundtrip!(unique, OP_RETURN_229);
+        roundtrip!(unique, OP_RETURN_230);
+        roundtrip!(unique, OP_RETURN_231);
+        roundtrip!(unique, OP_RETURN_232);
+        roundtrip!(unique, OP_RETURN_233);
+        roundtrip!(unique, OP_RETURN_234);
+        roundtrip!(unique, OP_RETURN_235);
+        roundtrip!(unique, OP_RETURN_236);
+        roundtrip!(unique, OP_RETURN_237);
+        roundtrip!(unique, OP_RETURN_238);
+        roundtrip!(unique, OP_RETURN_239);
+        roundtrip!(unique, OP_RETURN_240);
+        roundtrip!(unique, OP_RETURN_241);
+        roundtrip!(unique, OP_RETURN_242);
+        roundtrip!(unique, OP_RETURN_243);
+        roundtrip!(unique, OP_RETURN_244);
+        roundtrip!(unique, OP_RETURN_245);
+        roundtrip!(unique, OP_RETURN_246);
+        roundtrip!(unique, OP_RETURN_247);
+        roundtrip!(unique, OP_RETURN_248);
+        roundtrip!(unique, OP_RETURN_249);
+        roundtrip!(unique, OP_RETURN_250);
+        roundtrip!(unique, OP_RETURN_251);
+        roundtrip!(unique, OP_RETURN_252);
+        roundtrip!(unique, OP_RETURN_253);
+        roundtrip!(unique, OP_RETURN_254);
+        roundtrip!(unique, OP_RETURN_255);
+        assert_eq!(unique.len(), 256);
+    }
 }

--- a/libs/chainscript/src/opcodes.rs
+++ b/libs/chainscript/src/opcodes.rs
@@ -575,8 +575,9 @@ impl fmt::Debug for All {
 			all::OP_PUSHDATA4 => write!(f, "PUSHDATA4"),
 			all::OP_PUSHNUM_NEG1 => write!(f, "PUSHNUM_NEG1"),
 			all::OP_RESERVED => write!(f, "RESERVED"),
-			All { code: x } if x >= all::OP_PUSHNUM_1.code && x <= all::OP_PUSHNUM_16.code =>
-				write!(f, "PUSHNUM_{}", x - all::OP_PUSHNUM_1.code + 1),
+			All { code: x } if x >= all::OP_PUSHNUM_1.code && x <= all::OP_PUSHNUM_16.code => {
+				write!(f, "PUSHNUM_{}", x - all::OP_PUSHNUM_1.code + 1)
+			},
 			all::OP_NOP => write!(f, "NOP"),
 			all::OP_VER => write!(f, "VER"),
 			all::OP_IF => write!(f, "IF"),
@@ -658,8 +659,9 @@ impl fmt::Debug for All {
 			all::OP_CHECKMULTISIGVERIFY => write!(f, "CHECKMULTISIGVERIFY"),
 			all::OP_CLTV => write!(f, "CLTV"),
 			all::OP_CSV => write!(f, "CSV"),
-			All { code: x } if x >= all::OP_NOP1.code && x <= all::OP_NOP10.code =>
-				write!(f, "NOP{}", x - all::OP_NOP1.code + 1),
+			All { code: x } if x >= all::OP_NOP1.code && x <= all::OP_NOP10.code => {
+				write!(f, "NOP{}", x - all::OP_NOP1.code + 1)
+			},
 			All { code: x } => write!(f, "RETURN_{}", x),
 		}
 	}

--- a/libs/chainscript/src/opcodes.rs
+++ b/libs/chainscript/src/opcodes.rs
@@ -1,0 +1,1100 @@
+// Rust Bitcoin Library
+// Written in 2014 by
+//   Andrew Poelstra <apoelstra@wpsoftware.net>
+//
+// Modified in 2021 by
+//   Lukas Kuklinek <lukas.kuklinek@mintlayer.org>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! Opcodes
+//!
+//! Bitcoin's script uses a stack-based assembly language. This module defines
+//! all of the opcodes
+//!
+
+#![allow(non_camel_case_types)]
+
+#[cfg(feature = "serde")] use serde;
+
+#[cfg(feature = "serde")] use prelude::*;
+
+use core::{fmt, convert::From};
+
+// Note: I am deliberately not implementing PartialOrd or Ord on the
+//       opcode enum. If you want to check ranges of opcodes, etc.,
+//       write an #[inline] helper function which casts to u8s.
+
+/// A script Opcode
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct All {
+    code: u8,
+}
+
+pub mod all {
+    //! Constants associated with All type
+    use super::All;
+
+    /// Push an empty array onto the stack
+    pub const OP_PUSHBYTES_0: All = All {code: 0x00};
+    /// Push the next byte as an array onto the stack
+    pub const OP_PUSHBYTES_1: All = All {code: 0x01};
+    /// Push the next 2 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_2: All = All {code: 0x02};
+    /// Push the next 2 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_3: All = All {code: 0x03};
+    /// Push the next 4 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_4: All = All {code: 0x04};
+    /// Push the next 5 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_5: All = All {code: 0x05};
+    /// Push the next 6 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_6: All = All {code: 0x06};
+    /// Push the next 7 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_7: All = All {code: 0x07};
+    /// Push the next 8 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_8: All = All {code: 0x08};
+    /// Push the next 9 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_9: All = All {code: 0x09};
+    /// Push the next 10 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_10: All = All {code: 0x0a};
+    /// Push the next 11 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_11: All = All {code: 0x0b};
+    /// Push the next 12 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_12: All = All {code: 0x0c};
+    /// Push the next 13 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_13: All = All {code: 0x0d};
+    /// Push the next 14 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_14: All = All {code: 0x0e};
+    /// Push the next 15 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_15: All = All {code: 0x0f};
+    /// Push the next 16 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_16: All = All {code: 0x10};
+    /// Push the next 17 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_17: All = All {code: 0x11};
+    /// Push the next 18 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_18: All = All {code: 0x12};
+    /// Push the next 19 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_19: All = All {code: 0x13};
+    /// Push the next 20 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_20: All = All {code: 0x14};
+    /// Push the next 21 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_21: All = All {code: 0x15};
+    /// Push the next 22 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_22: All = All {code: 0x16};
+    /// Push the next 23 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_23: All = All {code: 0x17};
+    /// Push the next 24 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_24: All = All {code: 0x18};
+    /// Push the next 25 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_25: All = All {code: 0x19};
+    /// Push the next 26 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_26: All = All {code: 0x1a};
+    /// Push the next 27 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_27: All = All {code: 0x1b};
+    /// Push the next 28 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_28: All = All {code: 0x1c};
+    /// Push the next 29 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_29: All = All {code: 0x1d};
+    /// Push the next 30 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_30: All = All {code: 0x1e};
+    /// Push the next 31 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_31: All = All {code: 0x1f};
+    /// Push the next 32 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_32: All = All {code: 0x20};
+    /// Push the next 33 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_33: All = All {code: 0x21};
+    /// Push the next 34 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_34: All = All {code: 0x22};
+    /// Push the next 35 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_35: All = All {code: 0x23};
+    /// Push the next 36 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_36: All = All {code: 0x24};
+    /// Push the next 37 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_37: All = All {code: 0x25};
+    /// Push the next 38 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_38: All = All {code: 0x26};
+    /// Push the next 39 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_39: All = All {code: 0x27};
+    /// Push the next 40 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_40: All = All {code: 0x28};
+    /// Push the next 41 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_41: All = All {code: 0x29};
+    /// Push the next 42 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_42: All = All {code: 0x2a};
+    /// Push the next 43 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_43: All = All {code: 0x2b};
+    /// Push the next 44 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_44: All = All {code: 0x2c};
+    /// Push the next 45 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_45: All = All {code: 0x2d};
+    /// Push the next 46 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_46: All = All {code: 0x2e};
+    /// Push the next 47 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_47: All = All {code: 0x2f};
+    /// Push the next 48 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_48: All = All {code: 0x30};
+    /// Push the next 49 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_49: All = All {code: 0x31};
+    /// Push the next 50 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_50: All = All {code: 0x32};
+    /// Push the next 51 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_51: All = All {code: 0x33};
+    /// Push the next 52 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_52: All = All {code: 0x34};
+    /// Push the next 53 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_53: All = All {code: 0x35};
+    /// Push the next 54 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_54: All = All {code: 0x36};
+    /// Push the next 55 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_55: All = All {code: 0x37};
+    /// Push the next 56 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_56: All = All {code: 0x38};
+    /// Push the next 57 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_57: All = All {code: 0x39};
+    /// Push the next 58 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_58: All = All {code: 0x3a};
+    /// Push the next 59 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_59: All = All {code: 0x3b};
+    /// Push the next 60 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_60: All = All {code: 0x3c};
+    /// Push the next 61 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_61: All = All {code: 0x3d};
+    /// Push the next 62 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_62: All = All {code: 0x3e};
+    /// Push the next 63 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_63: All = All {code: 0x3f};
+    /// Push the next 64 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_64: All = All {code: 0x40};
+    /// Push the next 65 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_65: All = All {code: 0x41};
+    /// Push the next 66 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_66: All = All {code: 0x42};
+    /// Push the next 67 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_67: All = All {code: 0x43};
+    /// Push the next 68 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_68: All = All {code: 0x44};
+    /// Push the next 69 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_69: All = All {code: 0x45};
+    /// Push the next 70 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_70: All = All {code: 0x46};
+    /// Push the next 71 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_71: All = All {code: 0x47};
+    /// Push the next 72 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_72: All = All {code: 0x48};
+    /// Push the next 73 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_73: All = All {code: 0x49};
+    /// Push the next 74 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_74: All = All {code: 0x4a};
+    /// Push the next 75 bytes as an array onto the stack
+    pub const OP_PUSHBYTES_75: All = All {code: 0x4b};
+    /// Read the next byte as N; push the next N bytes as an array onto the stack
+    pub const OP_PUSHDATA1: All = All {code: 0x4c};
+    /// Read the next 2 bytes as N; push the next N bytes as an array onto the stack
+    pub const OP_PUSHDATA2: All = All {code: 0x4d};
+    /// Read the next 4 bytes as N; push the next N bytes as an array onto the stack
+    pub const OP_PUSHDATA4: All = All {code: 0x4e};
+    /// Push the array `0x81` onto the stack
+    pub const OP_PUSHNUM_NEG1: All = All {code: 0x4f};
+    /// Synonym for OP_RETURN
+    pub const OP_RESERVED: All = All {code: 0x50};
+    /// Push the array `0x01` onto the stack
+    pub const OP_PUSHNUM_1: All = All {code: 0x51};
+    /// Push the array `0x02` onto the stack
+    pub const OP_PUSHNUM_2: All = All {code: 0x52};
+    /// Push the array `0x03` onto the stack
+    pub const OP_PUSHNUM_3: All = All {code: 0x53};
+    /// Push the array `0x04` onto the stack
+    pub const OP_PUSHNUM_4: All = All {code: 0x54};
+    /// Push the array `0x05` onto the stack
+    pub const OP_PUSHNUM_5: All = All {code: 0x55};
+    /// Push the array `0x06` onto the stack
+    pub const OP_PUSHNUM_6: All = All {code: 0x56};
+    /// Push the array `0x07` onto the stack
+    pub const OP_PUSHNUM_7: All = All {code: 0x57};
+    /// Push the array `0x08` onto the stack
+    pub const OP_PUSHNUM_8: All = All {code: 0x58};
+    /// Push the array `0x09` onto the stack
+    pub const OP_PUSHNUM_9: All = All {code: 0x59};
+    /// Push the array `0x0a` onto the stack
+    pub const OP_PUSHNUM_10: All = All {code: 0x5a};
+    /// Push the array `0x0b` onto the stack
+    pub const OP_PUSHNUM_11: All = All {code: 0x5b};
+    /// Push the array `0x0c` onto the stack
+    pub const OP_PUSHNUM_12: All = All {code: 0x5c};
+    /// Push the array `0x0d` onto the stack
+    pub const OP_PUSHNUM_13: All = All {code: 0x5d};
+    /// Push the array `0x0e` onto the stack
+    pub const OP_PUSHNUM_14: All = All {code: 0x5e};
+    /// Push the array `0x0f` onto the stack
+    pub const OP_PUSHNUM_15: All = All {code: 0x5f};
+    /// Push the array `0x10` onto the stack
+    pub const OP_PUSHNUM_16: All = All {code: 0x60};
+    /// Does nothing
+    pub const OP_NOP: All = All {code: 0x61};
+    /// Synonym for OP_RETURN
+    pub const OP_VER: All = All {code: 0x62};
+    /// Pop and execute the next statements if a nonzero element was popped
+    pub const OP_IF: All = All {code: 0x63};
+    /// Pop and execute the next statements if a zero element was popped
+    pub const OP_NOTIF: All = All {code: 0x64};
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_VERIF: All = All {code: 0x65};
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_VERNOTIF: All = All {code: 0x66};
+    /// Execute statements if those after the previous OP_IF were not, and vice-versa.
+    /// If there is no previous OP_IF, this acts as a RETURN.
+    pub const OP_ELSE: All = All {code: 0x67};
+    /// Pop and execute the next statements if a zero element was popped
+    pub const OP_ENDIF: All = All {code: 0x68};
+    /// If the top value is zero or the stack is empty, fail; otherwise, pop the stack
+    pub const OP_VERIFY: All = All {code: 0x69};
+    /// Fail the script immediately. (Must be executed.)
+    pub const OP_RETURN: All = All {code: 0x6a};
+    /// Pop one element from the main stack onto the alt stack
+    pub const OP_TOALTSTACK: All = All {code: 0x6b};
+    /// Pop one element from the alt stack onto the main stack
+    pub const OP_FROMALTSTACK: All = All {code: 0x6c};
+    /// Drops the top two stack items
+    pub const OP_2DROP: All = All {code: 0x6d};
+    /// Duplicates the top two stack items as AB -> ABAB
+    pub const OP_2DUP: All = All {code: 0x6e};
+    /// Duplicates the two three stack items as ABC -> ABCABC
+    pub const OP_3DUP: All = All {code: 0x6f};
+    /// Copies the two stack items of items two spaces back to
+    /// the front, as xxAB -> ABxxAB
+    pub const OP_2OVER: All = All {code: 0x70};
+    /// Moves the two stack items four spaces back to the front,
+    /// as xxxxAB -> ABxxxx
+    pub const OP_2ROT: All = All {code: 0x71};
+    /// Swaps the top two pairs, as ABCD -> CDAB
+    pub const OP_2SWAP: All = All {code: 0x72};
+    /// Duplicate the top stack element unless it is zero
+    pub const OP_IFDUP: All = All {code: 0x73};
+    /// Push the current number of stack items onto the stack
+    pub const OP_DEPTH: All = All {code: 0x74};
+    /// Drops the top stack item
+    pub const OP_DROP: All = All {code: 0x75};
+    /// Duplicates the top stack item
+    pub const OP_DUP: All = All {code: 0x76};
+    /// Drops the second-to-top stack item
+    pub const OP_NIP: All = All {code: 0x77};
+    /// Copies the second-to-top stack item, as xA -> AxA
+    pub const OP_OVER: All = All {code: 0x78};
+    /// Pop the top stack element as N. Copy the Nth stack element to the top
+    pub const OP_PICK: All = All {code: 0x79};
+    /// Pop the top stack element as N. Move the Nth stack element to the top
+    pub const OP_ROLL: All = All {code: 0x7a};
+    /// Rotate the top three stack items, as [top next1 next2] -> [next2 top next1]
+    pub const OP_ROT: All = All {code: 0x7b};
+    /// Swap the top two stack items
+    pub const OP_SWAP: All = All {code: 0x7c};
+    /// Copy the top stack item to before the second item, as [top next] -> [top next top]
+    pub const OP_TUCK: All = All {code: 0x7d};
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_CAT: All = All {code: 0x7e};
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_SUBSTR: All = All {code: 0x7f};
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_LEFT: All = All {code: 0x80};
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_RIGHT: All = All {code: 0x81};
+    /// Pushes the length of the top stack item onto the stack
+    pub const OP_SIZE: All = All {code: 0x82};
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_INVERT: All = All {code: 0x83};
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_AND: All = All {code: 0x84};
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_OR: All = All {code: 0x85};
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_XOR: All = All {code: 0x86};
+    /// Pushes 1 if the inputs are exactly equal, 0 otherwise
+    pub const OP_EQUAL: All = All {code: 0x87};
+    /// Returns success if the inputs are exactly equal, failure otherwise
+    pub const OP_EQUALVERIFY: All = All {code: 0x88};
+    /// Synonym for OP_RETURN
+    pub const OP_RESERVED1: All = All {code: 0x89};
+    /// Synonym for OP_RETURN
+    pub const OP_RESERVED2: All = All {code: 0x8a};
+    /// Increment the top stack element in place
+    pub const OP_1ADD: All = All {code: 0x8b};
+    /// Decrement the top stack element in place
+    pub const OP_1SUB: All = All {code: 0x8c};
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_2MUL: All = All {code: 0x8d};
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_2DIV: All = All {code: 0x8e};
+    /// Multiply the top stack item by -1 in place
+    pub const OP_NEGATE: All = All {code: 0x8f};
+    /// Absolute value the top stack item in place
+    pub const OP_ABS: All = All {code: 0x90};
+    /// Map 0 to 1 and everything else to 0, in place
+    pub const OP_NOT: All = All {code: 0x91};
+    /// Map 0 to 0 and everything else to 1, in place
+    pub const OP_0NOTEQUAL: All = All {code: 0x92};
+    /// Pop two stack items and push their sum
+    pub const OP_ADD: All = All {code: 0x93};
+    /// Pop two stack items and push the second minus the top
+    pub const OP_SUB: All = All {code: 0x94};
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_MUL: All = All {code: 0x95};
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_DIV: All = All {code: 0x96};
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_MOD: All = All {code: 0x97};
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_LSHIFT: All = All {code: 0x98};
+    /// Fail the script unconditionally, does not even need to be executed
+    pub const OP_RSHIFT: All = All {code: 0x99};
+    /// Pop the top two stack items and push 1 if both are nonzero, else push 0
+    pub const OP_BOOLAND: All = All {code: 0x9a};
+    /// Pop the top two stack items and push 1 if either is nonzero, else push 0
+    pub const OP_BOOLOR: All = All {code: 0x9b};
+    /// Pop the top two stack items and push 1 if both are numerically equal, else push 0
+    pub const OP_NUMEQUAL: All = All {code: 0x9c};
+    /// Pop the top two stack items and return success if both are numerically equal, else return failure
+    pub const OP_NUMEQUALVERIFY: All = All {code: 0x9d};
+    /// Pop the top two stack items and push 0 if both are numerically equal, else push 1
+    pub const OP_NUMNOTEQUAL: All = All {code: 0x9e};
+    /// Pop the top two items; push 1 if the second is less than the top, 0 otherwise
+    pub const OP_LESSTHAN : All = All {code: 0x9f};
+    /// Pop the top two items; push 1 if the second is greater than the top, 0 otherwise
+    pub const OP_GREATERTHAN : All = All {code: 0xa0};
+    /// Pop the top two items; push 1 if the second is <= the top, 0 otherwise
+    pub const OP_LESSTHANOREQUAL : All = All {code: 0xa1};
+    /// Pop the top two items; push 1 if the second is >= the top, 0 otherwise
+    pub const OP_GREATERTHANOREQUAL : All = All {code: 0xa2};
+    /// Pop the top two items; push the smaller
+    pub const OP_MIN: All = All {code: 0xa3};
+    /// Pop the top two items; push the larger
+    pub const OP_MAX: All = All {code: 0xa4};
+    /// Pop the top three items; if the top is >= the second and < the third, push 1, otherwise push 0
+    pub const OP_WITHIN: All = All {code: 0xa5};
+    /// Pop the top stack item and push its RIPEMD160 hash
+    pub const OP_RIPEMD160: All = All {code: 0xa6};
+    /// Pop the top stack item and push its SHA1 hash
+    pub const OP_SHA1: All = All {code: 0xa7};
+    /// Pop the top stack item and push its SHA256 hash
+    pub const OP_SHA256: All = All {code: 0xa8};
+    /// Pop the top stack item and push its RIPEMD(SHA256) hash
+    pub const OP_HASH160: All = All {code: 0xa9};
+    /// Pop the top stack item and push its SHA256(SHA256) hash
+    pub const OP_HASH256: All = All {code: 0xaa};
+    /// Ignore this and everything preceding when deciding what to sign when signature-checking
+    pub const OP_CODESEPARATOR: All = All {code: 0xab};
+    /// <https://en.bitcoin.it/wiki/OP_CHECKSIG> pushing 1/0 for success/failure
+    pub const OP_CHECKSIG: All = All {code: 0xac};
+    /// <https://en.bitcoin.it/wiki/OP_CHECKSIG> returning success/failure
+    pub const OP_CHECKSIGVERIFY: All = All {code: 0xad};
+    /// Pop N, N pubkeys, M, M signatures, a dummy (due to bug in reference code), and verify that all M signatures are valid.
+    /// Push 1 for "all valid", 0 otherwise
+    pub const OP_CHECKMULTISIG: All = All {code: 0xae};
+    /// Like the above but return success/failure
+    pub const OP_CHECKMULTISIGVERIFY: All = All {code: 0xaf};
+    /// Does nothing
+    pub const OP_NOP1: All = All {code: 0xb0};
+    /// <https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki>
+    pub const OP_CLTV: All = All {code: 0xb1};
+    /// <https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki>
+    pub const OP_CSV: All = All {code: 0xb2};
+    /// Does nothing
+    pub const OP_NOP4: All = All {code: 0xb3};
+    /// Does nothing
+    pub const OP_NOP5: All = All {code: 0xb4};
+    /// Does nothing
+    pub const OP_NOP6: All = All {code: 0xb5};
+    /// Does nothing
+    pub const OP_NOP7: All = All {code: 0xb6};
+    /// Does nothing
+    pub const OP_NOP8: All = All {code: 0xb7};
+    /// Does nothing
+    pub const OP_NOP9: All = All {code: 0xb8};
+    /// Does nothing
+    pub const OP_NOP10: All = All {code: 0xb9};
+    // Every other opcode acts as OP_RETURN
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_186: All = All {code: 0xba};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_187: All = All {code: 0xbb};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_188: All = All {code: 0xbc};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_189: All = All {code: 0xbd};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_190: All = All {code: 0xbe};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_191: All = All {code: 0xbf};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_192: All = All {code: 0xc0};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_193: All = All {code: 0xc1};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_194: All = All {code: 0xc2};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_195: All = All {code: 0xc3};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_196: All = All {code: 0xc4};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_197: All = All {code: 0xc5};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_198: All = All {code: 0xc6};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_199: All = All {code: 0xc7};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_200: All = All {code: 0xc8};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_201: All = All {code: 0xc9};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_202: All = All {code: 0xca};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_203: All = All {code: 0xcb};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_204: All = All {code: 0xcc};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_205: All = All {code: 0xcd};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_206: All = All {code: 0xce};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_207: All = All {code: 0xcf};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_208: All = All {code: 0xd0};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_209: All = All {code: 0xd1};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_210: All = All {code: 0xd2};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_211: All = All {code: 0xd3};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_212: All = All {code: 0xd4};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_213: All = All {code: 0xd5};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_214: All = All {code: 0xd6};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_215: All = All {code: 0xd7};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_216: All = All {code: 0xd8};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_217: All = All {code: 0xd9};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_218: All = All {code: 0xda};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_219: All = All {code: 0xdb};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_220: All = All {code: 0xdc};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_221: All = All {code: 0xdd};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_222: All = All {code: 0xde};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_223: All = All {code: 0xdf};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_224: All = All {code: 0xe0};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_225: All = All {code: 0xe1};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_226: All = All {code: 0xe2};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_227: All = All {code: 0xe3};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_228: All = All {code: 0xe4};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_229: All = All {code: 0xe5};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_230: All = All {code: 0xe6};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_231: All = All {code: 0xe7};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_232: All = All {code: 0xe8};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_233: All = All {code: 0xe9};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_234: All = All {code: 0xea};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_235: All = All {code: 0xeb};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_236: All = All {code: 0xec};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_237: All = All {code: 0xed};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_238: All = All {code: 0xee};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_239: All = All {code: 0xef};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_240: All = All {code: 0xf0};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_241: All = All {code: 0xf1};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_242: All = All {code: 0xf2};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_243: All = All {code: 0xf3};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_244: All = All {code: 0xf4};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_245: All = All {code: 0xf5};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_246: All = All {code: 0xf6};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_247: All = All {code: 0xf7};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_248: All = All {code: 0xf8};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_249: All = All {code: 0xf9};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_250: All = All {code: 0xfa};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_251: All = All {code: 0xfb};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_252: All = All {code: 0xfc};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_253: All = All {code: 0xfd};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_254: All = All {code: 0xfe};
+    /// Synonym for OP_RETURN
+    pub const OP_RETURN_255: All = All {code: 0xff};
+}
+
+impl fmt::Debug for All {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("OP_")?;
+        match *self {
+            All {code: x} if x <= 75 => write!(f, "PUSHBYTES_{}", self.code),
+            all::OP_PUSHDATA1 => write!(f, "PUSHDATA1"),
+            all::OP_PUSHDATA2 => write!(f, "PUSHDATA2"),
+            all::OP_PUSHDATA4 => write!(f, "PUSHDATA4"),
+            all::OP_PUSHNUM_NEG1 => write!(f, "PUSHNUM_NEG1"),
+            all::OP_RESERVED => write!(f, "RESERVED"),
+            All {code: x} if x >= all::OP_PUSHNUM_1.code && x <= all::OP_PUSHNUM_16.code => write!(f, "PUSHNUM_{}", x - all::OP_PUSHNUM_1.code + 1),
+            all::OP_NOP => write!(f, "NOP"),
+            all::OP_VER => write!(f, "VER"),
+            all::OP_IF => write!(f, "IF"),
+            all::OP_NOTIF => write!(f, "NOTIF"),
+            all::OP_VERIF => write!(f, "VERIF"),
+            all::OP_VERNOTIF => write!(f, "VERNOTIF"),
+            all::OP_ELSE => write!(f, "ELSE"),
+            all::OP_ENDIF => write!(f, "ENDIF"),
+            all::OP_VERIFY => write!(f, "VERIFY"),
+            all::OP_RETURN => write!(f, "RETURN"),
+            all::OP_TOALTSTACK => write!(f, "TOALTSTACK"),
+            all::OP_FROMALTSTACK => write!(f, "FROMALTSTACK"),
+            all::OP_2DROP => write!(f, "2DROP"),
+            all::OP_2DUP => write!(f, "2DUP"),
+            all::OP_3DUP => write!(f, "3DUP"),
+            all::OP_2OVER => write!(f, "2OVER"),
+            all::OP_2ROT => write!(f, "2ROT"),
+            all::OP_2SWAP => write!(f, "2SWAP"),
+            all::OP_IFDUP => write!(f, "IFDUP"),
+            all::OP_DEPTH => write!(f, "DEPTH"),
+            all::OP_DROP => write!(f, "DROP"),
+            all::OP_DUP => write!(f, "DUP"),
+            all::OP_NIP => write!(f, "NIP"),
+            all::OP_OVER => write!(f, "OVER"),
+            all::OP_PICK => write!(f, "PICK"),
+            all::OP_ROLL => write!(f, "ROLL"),
+            all::OP_ROT => write!(f, "ROT"),
+            all::OP_SWAP => write!(f, "SWAP"),
+            all::OP_TUCK => write!(f, "TUCK"),
+            all::OP_CAT => write!(f, "CAT"),
+            all::OP_SUBSTR => write!(f, "SUBSTR"),
+            all::OP_LEFT => write!(f, "LEFT"),
+            all::OP_RIGHT => write!(f, "RIGHT"),
+            all::OP_SIZE => write!(f, "SIZE"),
+            all::OP_INVERT => write!(f, "INVERT"),
+            all::OP_AND => write!(f, "AND"),
+            all::OP_OR => write!(f, "OR"),
+            all::OP_XOR => write!(f, "XOR"),
+            all::OP_EQUAL => write!(f, "EQUAL"),
+            all::OP_EQUALVERIFY => write!(f, "EQUALVERIFY"),
+            all::OP_RESERVED1 => write!(f, "RESERVED1"),
+            all::OP_RESERVED2 => write!(f, "RESERVED2"),
+            all::OP_1ADD => write!(f, "1ADD"),
+            all::OP_1SUB => write!(f, "1SUB"),
+            all::OP_2MUL => write!(f, "2MUL"),
+            all::OP_2DIV => write!(f, "2DIV"),
+            all::OP_NEGATE => write!(f, "NEGATE"),
+            all::OP_ABS => write!(f, "ABS"),
+            all::OP_NOT => write!(f, "NOT"),
+            all::OP_0NOTEQUAL => write!(f, "0NOTEQUAL"),
+            all::OP_ADD => write!(f, "ADD"),
+            all::OP_SUB => write!(f, "SUB"),
+            all::OP_MUL => write!(f, "MUL"),
+            all::OP_DIV => write!(f, "DIV"),
+            all::OP_MOD => write!(f, "MOD"),
+            all::OP_LSHIFT => write!(f, "LSHIFT"),
+            all::OP_RSHIFT => write!(f, "RSHIFT"),
+            all::OP_BOOLAND => write!(f, "BOOLAND"),
+            all::OP_BOOLOR => write!(f, "BOOLOR"),
+            all::OP_NUMEQUAL => write!(f, "NUMEQUAL"),
+            all::OP_NUMEQUALVERIFY => write!(f, "NUMEQUALVERIFY"),
+            all::OP_NUMNOTEQUAL => write!(f, "NUMNOTEQUAL"),
+            all::OP_LESSTHAN  => write!(f, "LESSTHAN"),
+            all::OP_GREATERTHAN  => write!(f, "GREATERTHAN"),
+            all::OP_LESSTHANOREQUAL  => write!(f, "LESSTHANOREQUAL"),
+            all::OP_GREATERTHANOREQUAL  => write!(f, "GREATERTHANOREQUAL"),
+            all::OP_MIN => write!(f, "MIN"),
+            all::OP_MAX => write!(f, "MAX"),
+            all::OP_WITHIN => write!(f, "WITHIN"),
+            all::OP_RIPEMD160 => write!(f, "RIPEMD160"),
+            all::OP_SHA1 => write!(f, "SHA1"),
+            all::OP_SHA256 => write!(f, "SHA256"),
+            all::OP_HASH160 => write!(f, "HASH160"),
+            all::OP_HASH256 => write!(f, "HASH256"),
+            all::OP_CODESEPARATOR => write!(f, "CODESEPARATOR"),
+            all::OP_CHECKSIG => write!(f, "CHECKSIG"),
+            all::OP_CHECKSIGVERIFY => write!(f, "CHECKSIGVERIFY"),
+            all::OP_CHECKMULTISIG => write!(f, "CHECKMULTISIG"),
+            all::OP_CHECKMULTISIGVERIFY => write!(f, "CHECKMULTISIGVERIFY"),
+            all::OP_CLTV => write!(f, "CLTV"),
+            all::OP_CSV => write!(f, "CSV"),
+            All {code: x} if x >= all::OP_NOP1.code && x <= all::OP_NOP10.code => write!(f, "NOP{}", x - all::OP_NOP1.code + 1),
+            All {code: x} => write!(f, "RETURN_{}", x),
+        }
+    }
+}
+
+impl All {
+    /// Classifies an Opcode into a broad class
+    #[inline]
+    pub fn classify(self) -> Class {
+        // 17 opcodes
+        if self == all::OP_VERIF || self == all::OP_VERNOTIF ||
+           self == all::OP_CAT || self == all::OP_SUBSTR ||
+           self == all::OP_LEFT || self == all::OP_RIGHT ||
+           self == all::OP_INVERT || self == all::OP_AND ||
+           self == all::OP_OR || self == all::OP_XOR ||
+           self == all::OP_2MUL || self == all::OP_2DIV ||
+           self == all::OP_MUL || self == all::OP_DIV || self == all::OP_MOD ||
+           self == all::OP_LSHIFT || self == all::OP_RSHIFT {
+            Class::IllegalOp
+        // 11 opcodes
+        } else if self == all::OP_NOP ||
+                  (all::OP_NOP1.code <= self.code &&
+                   self.code <= all::OP_NOP10.code) {
+            Class::NoOp
+        // 75 opcodes
+        } else if self == all::OP_RESERVED || self == all::OP_VER || self == all::OP_RETURN ||
+                  self == all::OP_RESERVED1 || self == all::OP_RESERVED2 ||
+                  self.code >= all::OP_RETURN_186.code {
+            Class::ReturnOp
+        // 1 opcode
+        } else if self == all::OP_PUSHNUM_NEG1 {
+            Class::PushNum(-1)
+        // 16 opcodes
+        } else if all::OP_PUSHNUM_1.code <= self.code &&
+                  self.code <= all::OP_PUSHNUM_16.code {
+            Class::PushNum(1 + self.code as i32 - all::OP_PUSHNUM_1.code as i32)
+        // 76 opcodes
+        } else if self.code <= all::OP_PUSHBYTES_75.code {
+            Class::PushBytes(self.code as u32)
+        // 60 opcodes
+        } else {
+            Class::Ordinary(Ordinary::try_from_all(self).unwrap())
+        }
+    }
+
+    /// Encode as a byte
+    #[inline]
+    pub fn into_u8(self) -> u8 {
+        self.code
+    }
+}
+
+impl From<u8> for All {
+    #[inline]
+    fn from(b: u8) -> All {
+        All {code: b}
+    }
+}
+
+display_from_debug!(All);
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for All {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+/// Empty stack is also FALSE
+pub static OP_FALSE: All = all::OP_PUSHBYTES_0;
+/// Number 1 is also TRUE
+pub static OP_TRUE: All = all::OP_PUSHNUM_1;
+/// previously called OP_NOP2
+pub static OP_NOP2: All = all::OP_CLTV;
+/// previously called OP_NOP3
+pub static OP_NOP3: All = all::OP_CSV;
+
+/// Broad categories of opcodes with similar behavior
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum Class {
+    /// Pushes the given number onto the stack
+    PushNum(i32),
+    /// Pushes the given number of bytes onto the stack
+    PushBytes(u32),
+    /// Fails the script if executed
+    ReturnOp,
+    /// Fails the script even if not executed
+    IllegalOp,
+    /// Does nothing
+    NoOp,
+    /// Any opcode not covered above
+    Ordinary(Ordinary)
+}
+
+display_from_debug!(Class);
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Class {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+macro_rules! ordinary_opcode {
+    ($($op:ident),*) => (
+        #[repr(u8)]
+        #[doc(hidden)]
+        #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+        pub enum Ordinary {
+            $( $op = all::$op.code ),*
+        }
+
+        impl Ordinary {
+            /// Try to create from an All
+            pub fn try_from_all(b: All) -> Option<Self> {
+                match b {
+                    $( all::$op => { Some(Ordinary::$op) } ),*
+                    _ => None,
+                }
+            }
+        }
+    );
+}
+
+// "Ordinary" opcodes -- should be 60 of these
+ordinary_opcode! {
+    // pushdata
+    OP_PUSHDATA1, OP_PUSHDATA2, OP_PUSHDATA4,
+    // control flow
+    OP_IF, OP_NOTIF, OP_ELSE, OP_ENDIF, OP_VERIFY,
+    // stack
+    OP_TOALTSTACK, OP_FROMALTSTACK,
+    OP_2DROP, OP_2DUP, OP_3DUP, OP_2OVER, OP_2ROT, OP_2SWAP,
+    OP_DROP, OP_DUP, OP_NIP, OP_OVER, OP_PICK, OP_ROLL, OP_ROT, OP_SWAP, OP_TUCK,
+    OP_IFDUP, OP_DEPTH, OP_SIZE,
+    // equality
+    OP_EQUAL, OP_EQUALVERIFY,
+    // arithmetic
+    OP_1ADD, OP_1SUB, OP_NEGATE, OP_ABS, OP_NOT, OP_0NOTEQUAL,
+    OP_ADD, OP_SUB, OP_BOOLAND, OP_BOOLOR,
+    OP_NUMEQUAL, OP_NUMEQUALVERIFY, OP_NUMNOTEQUAL, OP_LESSTHAN,
+    OP_GREATERTHAN, OP_LESSTHANOREQUAL, OP_GREATERTHANOREQUAL,
+    OP_MIN, OP_MAX, OP_WITHIN,
+    // crypto
+    OP_RIPEMD160, OP_SHA1, OP_SHA256, OP_HASH160, OP_HASH256,
+    OP_CODESEPARATOR, OP_CHECKSIG, OP_CHECKSIGVERIFY,
+    OP_CHECKMULTISIG, OP_CHECKMULTISIGVERIFY
+}
+
+impl Ordinary {
+    /// Encode as a byte
+    #[inline]
+    pub fn into_u8(self) -> u8 {
+      self as u8
+  }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    macro_rules! roundtrip {
+        ($unique:expr, $op:ident) => {
+            assert_eq!(all::$op, All::from(all::$op.into_u8()));
+
+            //let s1 = format!("{}", all::$op);
+            let s2 = format!("{:?}", all::$op);
+            //assert_eq!(s1, s2);
+            assert_eq!(s2, stringify!($op));
+            assert!($unique.insert(s2));
+        }
+    }
+
+    #[test]
+    fn str_roundtrip() {
+        let mut unique = HashSet::new();
+        roundtrip!(unique, OP_PUSHBYTES_0);
+        roundtrip!(unique, OP_PUSHBYTES_1);
+        roundtrip!(unique, OP_PUSHBYTES_2);
+        roundtrip!(unique, OP_PUSHBYTES_3);
+        roundtrip!(unique, OP_PUSHBYTES_4);
+        roundtrip!(unique, OP_PUSHBYTES_5);
+        roundtrip!(unique, OP_PUSHBYTES_6);
+        roundtrip!(unique, OP_PUSHBYTES_7);
+        roundtrip!(unique, OP_PUSHBYTES_8);
+        roundtrip!(unique, OP_PUSHBYTES_9);
+        roundtrip!(unique, OP_PUSHBYTES_10);
+        roundtrip!(unique, OP_PUSHBYTES_11);
+        roundtrip!(unique, OP_PUSHBYTES_12);
+        roundtrip!(unique, OP_PUSHBYTES_13);
+        roundtrip!(unique, OP_PUSHBYTES_14);
+        roundtrip!(unique, OP_PUSHBYTES_15);
+        roundtrip!(unique, OP_PUSHBYTES_16);
+        roundtrip!(unique, OP_PUSHBYTES_17);
+        roundtrip!(unique, OP_PUSHBYTES_18);
+        roundtrip!(unique, OP_PUSHBYTES_19);
+        roundtrip!(unique, OP_PUSHBYTES_20);
+        roundtrip!(unique, OP_PUSHBYTES_21);
+        roundtrip!(unique, OP_PUSHBYTES_22);
+        roundtrip!(unique, OP_PUSHBYTES_23);
+        roundtrip!(unique, OP_PUSHBYTES_24);
+        roundtrip!(unique, OP_PUSHBYTES_25);
+        roundtrip!(unique, OP_PUSHBYTES_26);
+        roundtrip!(unique, OP_PUSHBYTES_27);
+        roundtrip!(unique, OP_PUSHBYTES_28);
+        roundtrip!(unique, OP_PUSHBYTES_29);
+        roundtrip!(unique, OP_PUSHBYTES_30);
+        roundtrip!(unique, OP_PUSHBYTES_31);
+        roundtrip!(unique, OP_PUSHBYTES_32);
+        roundtrip!(unique, OP_PUSHBYTES_33);
+        roundtrip!(unique, OP_PUSHBYTES_34);
+        roundtrip!(unique, OP_PUSHBYTES_35);
+        roundtrip!(unique, OP_PUSHBYTES_36);
+        roundtrip!(unique, OP_PUSHBYTES_37);
+        roundtrip!(unique, OP_PUSHBYTES_38);
+        roundtrip!(unique, OP_PUSHBYTES_39);
+        roundtrip!(unique, OP_PUSHBYTES_40);
+        roundtrip!(unique, OP_PUSHBYTES_41);
+        roundtrip!(unique, OP_PUSHBYTES_42);
+        roundtrip!(unique, OP_PUSHBYTES_43);
+        roundtrip!(unique, OP_PUSHBYTES_44);
+        roundtrip!(unique, OP_PUSHBYTES_45);
+        roundtrip!(unique, OP_PUSHBYTES_46);
+        roundtrip!(unique, OP_PUSHBYTES_47);
+        roundtrip!(unique, OP_PUSHBYTES_48);
+        roundtrip!(unique, OP_PUSHBYTES_49);
+        roundtrip!(unique, OP_PUSHBYTES_50);
+        roundtrip!(unique, OP_PUSHBYTES_51);
+        roundtrip!(unique, OP_PUSHBYTES_52);
+        roundtrip!(unique, OP_PUSHBYTES_53);
+        roundtrip!(unique, OP_PUSHBYTES_54);
+        roundtrip!(unique, OP_PUSHBYTES_55);
+        roundtrip!(unique, OP_PUSHBYTES_56);
+        roundtrip!(unique, OP_PUSHBYTES_57);
+        roundtrip!(unique, OP_PUSHBYTES_58);
+        roundtrip!(unique, OP_PUSHBYTES_59);
+        roundtrip!(unique, OP_PUSHBYTES_60);
+        roundtrip!(unique, OP_PUSHBYTES_61);
+        roundtrip!(unique, OP_PUSHBYTES_62);
+        roundtrip!(unique, OP_PUSHBYTES_63);
+        roundtrip!(unique, OP_PUSHBYTES_64);
+        roundtrip!(unique, OP_PUSHBYTES_65);
+        roundtrip!(unique, OP_PUSHBYTES_66);
+        roundtrip!(unique, OP_PUSHBYTES_67);
+        roundtrip!(unique, OP_PUSHBYTES_68);
+        roundtrip!(unique, OP_PUSHBYTES_69);
+        roundtrip!(unique, OP_PUSHBYTES_70);
+        roundtrip!(unique, OP_PUSHBYTES_71);
+        roundtrip!(unique, OP_PUSHBYTES_72);
+        roundtrip!(unique, OP_PUSHBYTES_73);
+        roundtrip!(unique, OP_PUSHBYTES_74);
+        roundtrip!(unique, OP_PUSHBYTES_75);
+        roundtrip!(unique, OP_PUSHDATA1);
+        roundtrip!(unique, OP_PUSHDATA2);
+        roundtrip!(unique, OP_PUSHDATA4);
+        roundtrip!(unique, OP_PUSHNUM_NEG1);
+        roundtrip!(unique, OP_RESERVED);
+        roundtrip!(unique, OP_PUSHNUM_1);
+        roundtrip!(unique, OP_PUSHNUM_2);
+        roundtrip!(unique, OP_PUSHNUM_3);
+        roundtrip!(unique, OP_PUSHNUM_4);
+        roundtrip!(unique, OP_PUSHNUM_5);
+        roundtrip!(unique, OP_PUSHNUM_6);
+        roundtrip!(unique, OP_PUSHNUM_7);
+        roundtrip!(unique, OP_PUSHNUM_8);
+        roundtrip!(unique, OP_PUSHNUM_9);
+        roundtrip!(unique, OP_PUSHNUM_10);
+        roundtrip!(unique, OP_PUSHNUM_11);
+        roundtrip!(unique, OP_PUSHNUM_12);
+        roundtrip!(unique, OP_PUSHNUM_13);
+        roundtrip!(unique, OP_PUSHNUM_14);
+        roundtrip!(unique, OP_PUSHNUM_15);
+        roundtrip!(unique, OP_PUSHNUM_16);
+        roundtrip!(unique, OP_NOP);
+        roundtrip!(unique, OP_VER);
+        roundtrip!(unique, OP_IF);
+        roundtrip!(unique, OP_NOTIF);
+        roundtrip!(unique, OP_VERIF);
+        roundtrip!(unique, OP_VERNOTIF);
+        roundtrip!(unique, OP_ELSE);
+        roundtrip!(unique, OP_ENDIF);
+        roundtrip!(unique, OP_VERIFY);
+        roundtrip!(unique, OP_RETURN);
+        roundtrip!(unique, OP_TOALTSTACK);
+        roundtrip!(unique, OP_FROMALTSTACK);
+        roundtrip!(unique, OP_2DROP);
+        roundtrip!(unique, OP_2DUP);
+        roundtrip!(unique, OP_3DUP);
+        roundtrip!(unique, OP_2OVER);
+        roundtrip!(unique, OP_2ROT);
+        roundtrip!(unique, OP_2SWAP);
+        roundtrip!(unique, OP_IFDUP);
+        roundtrip!(unique, OP_DEPTH);
+        roundtrip!(unique, OP_DROP);
+        roundtrip!(unique, OP_DUP);
+        roundtrip!(unique, OP_NIP);
+        roundtrip!(unique, OP_OVER);
+        roundtrip!(unique, OP_PICK);
+        roundtrip!(unique, OP_ROLL);
+        roundtrip!(unique, OP_ROT);
+        roundtrip!(unique, OP_SWAP);
+        roundtrip!(unique, OP_TUCK);
+        roundtrip!(unique, OP_CAT);
+        roundtrip!(unique, OP_SUBSTR);
+        roundtrip!(unique, OP_LEFT);
+        roundtrip!(unique, OP_RIGHT);
+        roundtrip!(unique, OP_SIZE);
+        roundtrip!(unique, OP_INVERT);
+        roundtrip!(unique, OP_AND);
+        roundtrip!(unique, OP_OR);
+        roundtrip!(unique, OP_XOR);
+        roundtrip!(unique, OP_EQUAL);
+        roundtrip!(unique, OP_EQUALVERIFY);
+        roundtrip!(unique, OP_RESERVED1);
+        roundtrip!(unique, OP_RESERVED2);
+        roundtrip!(unique, OP_1ADD);
+        roundtrip!(unique, OP_1SUB);
+        roundtrip!(unique, OP_2MUL);
+        roundtrip!(unique, OP_2DIV);
+        roundtrip!(unique, OP_NEGATE);
+        roundtrip!(unique, OP_ABS);
+        roundtrip!(unique, OP_NOT);
+        roundtrip!(unique, OP_0NOTEQUAL);
+        roundtrip!(unique, OP_ADD);
+        roundtrip!(unique, OP_SUB);
+        roundtrip!(unique, OP_MUL);
+        roundtrip!(unique, OP_DIV);
+        roundtrip!(unique, OP_MOD);
+        roundtrip!(unique, OP_LSHIFT);
+        roundtrip!(unique, OP_RSHIFT);
+        roundtrip!(unique, OP_BOOLAND);
+        roundtrip!(unique, OP_BOOLOR);
+        roundtrip!(unique, OP_NUMEQUAL);
+        roundtrip!(unique, OP_NUMEQUALVERIFY);
+        roundtrip!(unique, OP_NUMNOTEQUAL);
+        roundtrip!(unique, OP_LESSTHAN );
+        roundtrip!(unique, OP_GREATERTHAN );
+        roundtrip!(unique, OP_LESSTHANOREQUAL );
+        roundtrip!(unique, OP_GREATERTHANOREQUAL );
+        roundtrip!(unique, OP_MIN);
+        roundtrip!(unique, OP_MAX);
+        roundtrip!(unique, OP_WITHIN);
+        roundtrip!(unique, OP_RIPEMD160);
+        roundtrip!(unique, OP_SHA1);
+        roundtrip!(unique, OP_SHA256);
+        roundtrip!(unique, OP_HASH160);
+        roundtrip!(unique, OP_HASH256);
+        roundtrip!(unique, OP_CODESEPARATOR);
+        roundtrip!(unique, OP_CHECKSIG);
+        roundtrip!(unique, OP_CHECKSIGVERIFY);
+        roundtrip!(unique, OP_CHECKMULTISIG);
+        roundtrip!(unique, OP_CHECKMULTISIGVERIFY);
+        roundtrip!(unique, OP_NOP1);
+        roundtrip!(unique, OP_CLTV);
+        roundtrip!(unique, OP_CSV);
+        roundtrip!(unique, OP_NOP4);
+        roundtrip!(unique, OP_NOP5);
+        roundtrip!(unique, OP_NOP6);
+        roundtrip!(unique, OP_NOP7);
+        roundtrip!(unique, OP_NOP8);
+        roundtrip!(unique, OP_NOP9);
+        roundtrip!(unique, OP_NOP10);
+        roundtrip!(unique, OP_RETURN_186);
+        roundtrip!(unique, OP_RETURN_187);
+        roundtrip!(unique, OP_RETURN_188);
+        roundtrip!(unique, OP_RETURN_189);
+        roundtrip!(unique, OP_RETURN_190);
+        roundtrip!(unique, OP_RETURN_191);
+        roundtrip!(unique, OP_RETURN_192);
+        roundtrip!(unique, OP_RETURN_193);
+        roundtrip!(unique, OP_RETURN_194);
+        roundtrip!(unique, OP_RETURN_195);
+        roundtrip!(unique, OP_RETURN_196);
+        roundtrip!(unique, OP_RETURN_197);
+        roundtrip!(unique, OP_RETURN_198);
+        roundtrip!(unique, OP_RETURN_199);
+        roundtrip!(unique, OP_RETURN_200);
+        roundtrip!(unique, OP_RETURN_201);
+        roundtrip!(unique, OP_RETURN_202);
+        roundtrip!(unique, OP_RETURN_203);
+        roundtrip!(unique, OP_RETURN_204);
+        roundtrip!(unique, OP_RETURN_205);
+        roundtrip!(unique, OP_RETURN_206);
+        roundtrip!(unique, OP_RETURN_207);
+        roundtrip!(unique, OP_RETURN_208);
+        roundtrip!(unique, OP_RETURN_209);
+        roundtrip!(unique, OP_RETURN_210);
+        roundtrip!(unique, OP_RETURN_211);
+        roundtrip!(unique, OP_RETURN_212);
+        roundtrip!(unique, OP_RETURN_213);
+        roundtrip!(unique, OP_RETURN_214);
+        roundtrip!(unique, OP_RETURN_215);
+        roundtrip!(unique, OP_RETURN_216);
+        roundtrip!(unique, OP_RETURN_217);
+        roundtrip!(unique, OP_RETURN_218);
+        roundtrip!(unique, OP_RETURN_219);
+        roundtrip!(unique, OP_RETURN_220);
+        roundtrip!(unique, OP_RETURN_221);
+        roundtrip!(unique, OP_RETURN_222);
+        roundtrip!(unique, OP_RETURN_223);
+        roundtrip!(unique, OP_RETURN_224);
+        roundtrip!(unique, OP_RETURN_225);
+        roundtrip!(unique, OP_RETURN_226);
+        roundtrip!(unique, OP_RETURN_227);
+        roundtrip!(unique, OP_RETURN_228);
+        roundtrip!(unique, OP_RETURN_229);
+        roundtrip!(unique, OP_RETURN_230);
+        roundtrip!(unique, OP_RETURN_231);
+        roundtrip!(unique, OP_RETURN_232);
+        roundtrip!(unique, OP_RETURN_233);
+        roundtrip!(unique, OP_RETURN_234);
+        roundtrip!(unique, OP_RETURN_235);
+        roundtrip!(unique, OP_RETURN_236);
+        roundtrip!(unique, OP_RETURN_237);
+        roundtrip!(unique, OP_RETURN_238);
+        roundtrip!(unique, OP_RETURN_239);
+        roundtrip!(unique, OP_RETURN_240);
+        roundtrip!(unique, OP_RETURN_241);
+        roundtrip!(unique, OP_RETURN_242);
+        roundtrip!(unique, OP_RETURN_243);
+        roundtrip!(unique, OP_RETURN_244);
+        roundtrip!(unique, OP_RETURN_245);
+        roundtrip!(unique, OP_RETURN_246);
+        roundtrip!(unique, OP_RETURN_247);
+        roundtrip!(unique, OP_RETURN_248);
+        roundtrip!(unique, OP_RETURN_249);
+        roundtrip!(unique, OP_RETURN_250);
+        roundtrip!(unique, OP_RETURN_251);
+        roundtrip!(unique, OP_RETURN_252);
+        roundtrip!(unique, OP_RETURN_253);
+        roundtrip!(unique, OP_RETURN_254);
+        roundtrip!(unique, OP_RETURN_255);
+        assert_eq!(unique.len(), 256);
+    }
+}

--- a/libs/chainscript/src/script.rs
+++ b/libs/chainscript/src/script.rs
@@ -25,11 +25,10 @@
 //! Forth.
 //!
 //! This module provides the structures and functions needed to support scripts.
-//!
 
 use sp_std::prelude::*;
 
-use core::{fmt, default::Default};
+use core::{default::Default, fmt};
 
 use crate::opcodes;
 
@@ -42,62 +41,60 @@ type ScriptHash = [u8];
 pub struct Script(Box<[u8]>);
 
 impl AsRef<[u8]> for Script {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
+	fn as_ref(&self) -> &[u8] {
+		&self.0
+	}
 }
 
 impl fmt::Debug for Script {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("Script(")?;
-        self.fmt_asm(f)?;
-        f.write_str(")")
-    }
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		f.write_str("Script(")?;
+		self.fmt_asm(f)?;
+		f.write_str(")")
+	}
 }
 
 impl fmt::Display for Script {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
-    }
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		fmt::Debug::fmt(self, f)
+	}
 }
 
 impl fmt::LowerHex for Script {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for &ch in self.0.iter() {
-            write!(f, "{:02x}", ch)?;
-        }
-        Ok(())
-    }
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		for &ch in self.0.iter() {
+			write!(f, "{:02x}", ch)?;
+		}
+		Ok(())
+	}
 }
 
 impl fmt::UpperHex for Script {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for &ch in self.0.iter() {
-            write!(f, "{:02X}", ch)?;
-        }
-        Ok(())
-    }
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		for &ch in self.0.iter() {
+			write!(f, "{:02X}", ch)?;
+		}
+		Ok(())
+	}
 }
 
 #[cfg(any())]
 impl hex::FromHex for Script {
-    fn from_byte_iter<I>(iter: I) -> Result<Self, hex::Error>
-        where I: Iterator<Item=Result<u8, hex::Error>> +
-            ExactSizeIterator +
-            DoubleEndedIterator,
-    {
-        Vec::from_byte_iter(iter).map(|v| Script(Box::<[u8]>::from(v)))
-    }
+	fn from_byte_iter<I>(iter: I) -> Result<Self, hex::Error>
+	where
+		I: Iterator<Item = Result<u8, hex::Error>> + ExactSizeIterator + DoubleEndedIterator,
+	{
+		Vec::from_byte_iter(iter).map(|v| Script(Box::<[u8]>::from(v)))
+	}
 }
 
 #[cfg(any())]
 impl ::sp_std::str::FromStr for Script {
-    type Err = hex::Error;
-    fn from_str(s: &str) -> Result<Self, hex::Error> {
-        hex::FromHex::from_hex(s)
-    }
+	type Err = hex::Error;
+	fn from_str(s: &str) -> Result<Self, hex::Error> {
+		hex::FromHex::from_hex(s)
+	}
 }
-
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 /// An object which can be used to construct a script piece by piece
@@ -109,77 +106,80 @@ display_from_debug!(Builder);
 /// would help you.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
 pub enum Error {
-    /// Something did a non-minimal push; for more information see
-    /// `https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#Push_operators`
-    NonMinimalPush,
-    /// Some opcode expected a parameter, but it was missing or truncated
-    EarlyEndOfScript,
-    /// Tried to read an array off the stack as a number when it was more than 4 bytes
-    NumericOverflow,
-    #[cfg(feature="bitcoinconsensus")]
-    /// Error validating the script with bitcoinconsensus library
-    BitcoinConsensus(bitcoinconsensus::Error),
-    #[cfg(feature="bitcoinconsensus")]
-    /// Can not find the spent output
-    UnknownSpentOutput(OutPoint),
-    #[cfg(feature="bitcoinconsensus")]
-    /// Can not serialize the spending transaction
-    SerializationError
+	/// Something did a non-minimal push; for more information see
+	/// `https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#Push_operators`
+	NonMinimalPush,
+	/// Some opcode expected a parameter, but it was missing or truncated
+	EarlyEndOfScript,
+	/// Tried to read an array off the stack as a number when it was more than 4 bytes
+	NumericOverflow,
+	#[cfg(feature = "bitcoinconsensus")]
+	/// Error validating the script with bitcoinconsensus library
+	BitcoinConsensus(bitcoinconsensus::Error),
+	#[cfg(feature = "bitcoinconsensus")]
+	/// Can not find the spent output
+	UnknownSpentOutput(OutPoint),
+	#[cfg(feature = "bitcoinconsensus")]
+	/// Can not serialize the spending transaction
+	SerializationError,
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let str = match *self {
-            Error::NonMinimalPush => "non-minimal datapush",
-            Error::EarlyEndOfScript => "unexpected end of script",
-            Error::NumericOverflow => "numeric overflow (number on stack larger than 4 bytes)",
-            #[cfg(feature="bitcoinconsensus")]
-            Error::BitcoinConsensus(ref _n) => "bitcoinconsensus verification failed",
-            #[cfg(feature="bitcoinconsensus")]
-            Error::UnknownSpentOutput(ref _point) => "unknown spent output Transaction::verify()",
-            #[cfg(feature="bitcoinconsensus")]
-            Error::SerializationError => "can not serialize the spending transaction in Transaction::verify()",
-        };
-        f.write_str(str)
-    }
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		let str = match *self {
+			Error::NonMinimalPush => "non-minimal datapush",
+			Error::EarlyEndOfScript => "unexpected end of script",
+			Error::NumericOverflow => "numeric overflow (number on stack larger than 4 bytes)",
+			#[cfg(feature = "bitcoinconsensus")]
+			Error::BitcoinConsensus(ref _n) => "bitcoinconsensus verification failed",
+			#[cfg(feature = "bitcoinconsensus")]
+			Error::UnknownSpentOutput(ref _point) => "unknown spent output Transaction::verify()",
+			#[cfg(feature = "bitcoinconsensus")]
+			Error::SerializationError =>
+				"can not serialize the spending transaction in Transaction::verify()",
+		};
+		f.write_str(str)
+	}
 }
 
 #[cfg(feature = "std")]
 impl ::std::error::Error for Error {}
 
-#[cfg(feature="bitcoinconsensus")]
+#[cfg(feature = "bitcoinconsensus")]
 #[doc(hidden)]
 impl From<bitcoinconsensus::Error> for Error {
-    fn from(err: bitcoinconsensus::Error) -> Error {
-        match err {
-            _ => Error::BitcoinConsensus(err)
-        }
-    }
+	fn from(err: bitcoinconsensus::Error) -> Error {
+		match err {
+			_ => Error::BitcoinConsensus(err),
+		}
+	}
 }
 /// Helper to encode an integer in script format
 fn build_scriptint(n: i64) -> Vec<u8> {
-    if n == 0 { return vec![] }
+	if n == 0 {
+		return vec![]
+	}
 
-    let neg = n < 0;
+	let neg = n < 0;
 
-    let mut abs = if neg { -n } else { n } as usize;
-    let mut v = vec![];
-    while abs > 0xFF {
-        v.push((abs & 0xFF) as u8);
-        abs >>= 8;
-    }
-    // If the number's value causes the sign bit to be set, we need an extra
-    // byte to get the correct value and correct sign bit
-    if abs & 0x80 != 0 {
-        v.push(abs as u8);
-        v.push(if neg { 0x80u8 } else { 0u8 });
-    }
-    // Otherwise we just set the sign bit ourselves
-    else {
-        abs |= if neg { 0x80 } else { 0 };
-        v.push(abs as u8);
-    }
-    v
+	let mut abs = if neg { -n } else { n } as usize;
+	let mut v = vec![];
+	while abs > 0xFF {
+		v.push((abs & 0xFF) as u8);
+		abs >>= 8;
+	}
+	// If the number's value causes the sign bit to be set, we need an extra
+	// byte to get the correct value and correct sign bit
+	if abs & 0x80 != 0 {
+		v.push(abs as u8);
+		v.push(if neg { 0x80u8 } else { 0u8 });
+	}
+	// Otherwise we just set the sign bit ourselves
+	else {
+		abs |= if neg { 0x80 } else { 0 };
+		v.push(abs as u8);
+	}
+	v
 }
 
 /// Helper to decode an integer in script format
@@ -197,188 +197,200 @@ fn build_scriptint(n: i64) -> Vec<u8> {
 /// simply say, anything in excess of 32 bits is no longer a number.
 /// This is basically a ranged type implementation.
 pub fn read_scriptint(v: &[u8]) -> Result<i64, Error> {
-    let len = v.len();
-    if len == 0 { return Ok(0); }
-    if len > 4 { return Err(Error::NumericOverflow); }
+	let len = v.len();
+	if len == 0 {
+		return Ok(0)
+	}
+	if len > 4 {
+		return Err(Error::NumericOverflow)
+	}
 
-    let (mut ret, sh) = v.iter()
-                         .fold((0, 0), |(acc, sh), n| (acc + ((*n as i64) << sh), sh + 8));
-    if v[len - 1] & 0x80 != 0 {
-        ret &= (1 << (sh - 1)) - 1;
-        ret = -ret;
-    }
-    Ok(ret)
+	let (mut ret, sh) = v.iter().fold((0, 0), |(acc, sh), n| (acc + ((*n as i64) << sh), sh + 8));
+	if v[len - 1] & 0x80 != 0 {
+		ret &= (1 << (sh - 1)) - 1;
+		ret = -ret;
+	}
+	Ok(ret)
 }
 
 /// This is like "`read_scriptint` then map 0 to false and everything
 /// else as true", except that the overflow rules don't apply.
 #[inline]
 pub fn read_scriptbool(v: &[u8]) -> bool {
-    !(v.is_empty() ||
-        ((v[v.len() - 1] == 0 || v[v.len() - 1] == 0x80) &&
-         v.iter().rev().skip(1).all(|&w| w == 0)))
+	!(v.is_empty() ||
+		((v[v.len() - 1] == 0 || v[v.len() - 1] == 0x80) &&
+			v.iter().rev().skip(1).all(|&w| w == 0)))
 }
 
 /// Read a script-encoded unsigned integer
 pub fn read_uint(data: &[u8], size: usize) -> Result<usize, Error> {
-    if data.len() < size {
-        Err(Error::EarlyEndOfScript)
-    } else {
-        let mut ret = 0;
-        for (i, item) in data.iter().take(size).enumerate() {
-            ret += (*item as usize) << (i * 8);
-        }
-        Ok(ret)
-    }
+	if data.len() < size {
+		Err(Error::EarlyEndOfScript)
+	} else {
+		let mut ret = 0;
+		for (i, item) in data.iter().take(size).enumerate() {
+			ret += (*item as usize) << (i * 8);
+		}
+		Ok(ret)
+	}
 }
 
 impl Script {
-    /// Creates a new empty script
-    pub fn new() -> Script { Script(vec![].into_boxed_slice()) }
+	/// Creates a new empty script
+	pub fn new() -> Script {
+		Script(vec![].into_boxed_slice())
+	}
 
-    /// Generates P2PK-type of scriptPubkey
-    pub fn new_p2pk(pubkey: &[u8]) -> Script {
-        Builder::new()
-            .push_slice(pubkey)
-            .push_opcode(opcodes::all::OP_CHECKSIG)
-            .into_script()
-    }
+	/// Generates P2PK-type of scriptPubkey
+	pub fn new_p2pk(pubkey: &[u8]) -> Script {
+		Builder::new()
+			.push_slice(pubkey)
+			.push_opcode(opcodes::all::OP_CHECKSIG)
+			.into_script()
+	}
 
-    /// Generates P2PKH-type of scriptPubkey
-    pub fn new_p2pkh(pubkey_hash: &PubkeyHash) -> Script {
-        Builder::new()
-            .push_opcode(opcodes::all::OP_DUP)
-            .push_opcode(opcodes::all::OP_HASH160)
-            .push_slice(&pubkey_hash[..])
-            .push_opcode(opcodes::all::OP_EQUALVERIFY)
-            .push_opcode(opcodes::all::OP_CHECKSIG)
-            .into_script()
-    }
+	/// Generates P2PKH-type of scriptPubkey
+	pub fn new_p2pkh(pubkey_hash: &PubkeyHash) -> Script {
+		Builder::new()
+			.push_opcode(opcodes::all::OP_DUP)
+			.push_opcode(opcodes::all::OP_HASH160)
+			.push_slice(&pubkey_hash[..])
+			.push_opcode(opcodes::all::OP_EQUALVERIFY)
+			.push_opcode(opcodes::all::OP_CHECKSIG)
+			.into_script()
+	}
 
-    /// Generates P2SH-type of scriptPubkey with a given hash of the redeem script
-    pub fn new_p2sh(script_hash: &ScriptHash) -> Script {
-        Builder::new()
-            .push_opcode(opcodes::all::OP_HASH160)
-            .push_slice(&script_hash[..])
-            .push_opcode(opcodes::all::OP_EQUAL)
-            .into_script()
-    }
+	/// Generates P2SH-type of scriptPubkey with a given hash of the redeem script
+	pub fn new_p2sh(script_hash: &ScriptHash) -> Script {
+		Builder::new()
+			.push_opcode(opcodes::all::OP_HASH160)
+			.push_slice(&script_hash[..])
+			.push_opcode(opcodes::all::OP_EQUAL)
+			.into_script()
+	}
 
-    /// Generates P2WPKH-type of scriptPubkey
-    #[cfg(any())]
-    pub fn new_v0_wpkh(pubkey_hash: &WPubkeyHash) -> Script {
-        Script::new_witness_program(::bech32::u5::try_from_u8(0).unwrap(), &pubkey_hash.to_vec())
-    }
+	/// Generates P2WPKH-type of scriptPubkey
+	#[cfg(any())]
+	pub fn new_v0_wpkh(pubkey_hash: &WPubkeyHash) -> Script {
+		Script::new_witness_program(::bech32::u5::try_from_u8(0).unwrap(), &pubkey_hash.to_vec())
+	}
 
-    /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script
-    #[cfg(any())]
-    pub fn new_v0_wsh(script_hash: &WScriptHash) -> Script {
-        Script::new_witness_program(::bech32::u5::try_from_u8(0).unwrap(), &script_hash.to_vec())
-    }
+	/// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script
+	#[cfg(any())]
+	pub fn new_v0_wsh(script_hash: &WScriptHash) -> Script {
+		Script::new_witness_program(::bech32::u5::try_from_u8(0).unwrap(), &script_hash.to_vec())
+	}
 
-    /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script
-    #[cfg(any())]
-    pub fn new_witness_program(ver: ::bech32::u5, program: &[u8]) -> Script {
-        let mut verop = ver.to_u8();
-        assert!(verop <= 16, "incorrect witness version provided: {}", verop);
-        if verop > 0 {
-            verop = 0x50 + verop;
-        }
-        Builder::new()
-            .push_opcode(verop.into())
-            .push_slice(&program)
-            .into_script()
-    }
+	/// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script
+	#[cfg(any())]
+	pub fn new_witness_program(ver: ::bech32::u5, program: &[u8]) -> Script {
+		let mut verop = ver.to_u8();
+		assert!(verop <= 16, "incorrect witness version provided: {}", verop);
+		if verop > 0 {
+			verop = 0x50 + verop;
+		}
+		Builder::new().push_opcode(verop.into()).push_slice(&program).into_script()
+	}
 
-    /// Generates OP_RETURN-type of scriptPubkey for a given data
-    pub fn new_op_return(data: &[u8]) -> Script {
-        Builder::new()
-            .push_opcode(opcodes::all::OP_RETURN)
-            .push_slice(data)
-            .into_script()
-    }
+	/// Generates OP_RETURN-type of scriptPubkey for a given data
+	pub fn new_op_return(data: &[u8]) -> Script {
+		Builder::new()
+			.push_opcode(opcodes::all::OP_RETURN)
+			.push_slice(data)
+			.into_script()
+	}
 
-    /// Returns 160-bit hash of the script
-    #[cfg(any())]
-    pub fn script_hash(&self) -> ScriptHash {
-        ScriptHash::hash(&self.as_bytes())
-    }
+	/// Returns 160-bit hash of the script
+	#[cfg(any())]
+	pub fn script_hash(&self) -> ScriptHash {
+		ScriptHash::hash(&self.as_bytes())
+	}
 
-    /// Returns 256-bit hash of the script for P2WSH outputs
-    #[cfg(any())]
-    pub fn wscript_hash(&self) -> WScriptHash {
-        WScriptHash::hash(&self.as_bytes())
-    }
+	/// Returns 256-bit hash of the script for P2WSH outputs
+	#[cfg(any())]
+	pub fn wscript_hash(&self) -> WScriptHash {
+		WScriptHash::hash(&self.as_bytes())
+	}
 
-    /// The length in bytes of the script
-    pub fn len(&self) -> usize { self.0.len() }
+	/// The length in bytes of the script
+	pub fn len(&self) -> usize {
+		self.0.len()
+	}
 
-    /// Whether the script is the empty script
-    pub fn is_empty(&self) -> bool { self.0.is_empty() }
+	/// Whether the script is the empty script
+	pub fn is_empty(&self) -> bool {
+		self.0.is_empty()
+	}
 
-    /// Returns the script data
-    pub fn as_bytes(&self) -> &[u8] { &*self.0 }
+	/// Returns the script data
+	pub fn as_bytes(&self) -> &[u8] {
+		&*self.0
+	}
 
-    /// Returns a copy of the script data
-    pub fn to_bytes(&self) -> Vec<u8> { self.0.clone().into_vec() }
+	/// Returns a copy of the script data
+	pub fn to_bytes(&self) -> Vec<u8> {
+		self.0.clone().into_vec()
+	}
 
-    /// Convert the script into a byte vector
-    pub fn into_bytes(self) -> Vec<u8> { self.0.into_vec() }
+	/// Convert the script into a byte vector
+	pub fn into_bytes(self) -> Vec<u8> {
+		self.0.into_vec()
+	}
 
-    /// Compute the P2SH output corresponding to this redeem script
-    #[cfg(any())]
-    pub fn to_p2sh(&self) -> Script {
-        Script::new_p2sh(&self.script_hash())
-    }
+	/// Compute the P2SH output corresponding to this redeem script
+	#[cfg(any())]
+	pub fn to_p2sh(&self) -> Script {
+		Script::new_p2sh(&self.script_hash())
+	}
 
-    /// Compute the P2WSH output corresponding to this witnessScript (aka the "witness redeem
-    /// script")
-    #[cfg(any())]
-    pub fn to_v0_p2wsh(&self) -> Script {
-        Script::new_v0_wsh(&self.wscript_hash())
-    }
+	/// Compute the P2WSH output corresponding to this witnessScript (aka the "witness redeem
+	/// script")
+	#[cfg(any())]
+	pub fn to_v0_p2wsh(&self) -> Script {
+		Script::new_v0_wsh(&self.wscript_hash())
+	}
 
-    /// Checks whether a script pubkey is a p2sh output
-    #[inline]
-    pub fn is_p2sh(&self) -> bool {
-        self.0.len() == 23 &&
-        self.0[0] == opcodes::all::OP_HASH160.into_u8() &&
-        self.0[1] == opcodes::all::OP_PUSHBYTES_20.into_u8() &&
-        self.0[22] == opcodes::all::OP_EQUAL.into_u8()
-    }
+	/// Checks whether a script pubkey is a p2sh output
+	#[inline]
+	pub fn is_p2sh(&self) -> bool {
+		self.0.len() == 23 &&
+			self.0[0] == opcodes::all::OP_HASH160.into_u8() &&
+			self.0[1] == opcodes::all::OP_PUSHBYTES_20.into_u8() &&
+			self.0[22] == opcodes::all::OP_EQUAL.into_u8()
+	}
 
-    /// Checks whether a script pubkey is a p2pkh output
-    #[inline]
-    pub fn is_p2pkh(&self) -> bool {
-        self.0.len() == 25 &&
-        self.0[0] == opcodes::all::OP_DUP.into_u8() &&
-        self.0[1] == opcodes::all::OP_HASH160.into_u8() &&
-        self.0[2] == opcodes::all::OP_PUSHBYTES_20.into_u8() &&
-        self.0[23] == opcodes::all::OP_EQUALVERIFY.into_u8() &&
-        self.0[24] == opcodes::all::OP_CHECKSIG.into_u8()
-    }
+	/// Checks whether a script pubkey is a p2pkh output
+	#[inline]
+	pub fn is_p2pkh(&self) -> bool {
+		self.0.len() == 25 &&
+			self.0[0] == opcodes::all::OP_DUP.into_u8() &&
+			self.0[1] == opcodes::all::OP_HASH160.into_u8() &&
+			self.0[2] == opcodes::all::OP_PUSHBYTES_20.into_u8() &&
+			self.0[23] == opcodes::all::OP_EQUALVERIFY.into_u8() &&
+			self.0[24] == opcodes::all::OP_CHECKSIG.into_u8()
+	}
 
-    /// Checks whether a script pubkey is a p2pk output
-    #[inline]
-    pub fn is_p2pk(&self) -> bool {
-        (self.0.len() == 67 &&
-            self.0[0] == opcodes::all::OP_PUSHBYTES_65.into_u8() &&
-            self.0[66] == opcodes::all::OP_CHECKSIG.into_u8())
-     || (self.0.len() == 35 &&
-            self.0[0] == opcodes::all::OP_PUSHBYTES_33.into_u8() &&
-            self.0[34] == opcodes::all::OP_CHECKSIG.into_u8())
-    }
+	/// Checks whether a script pubkey is a p2pk output
+	#[inline]
+	pub fn is_p2pk(&self) -> bool {
+		(self.0.len() == 67 &&
+			self.0[0] == opcodes::all::OP_PUSHBYTES_65.into_u8() &&
+			self.0[66] == opcodes::all::OP_CHECKSIG.into_u8()) ||
+			(self.0.len() == 35 &&
+				self.0[0] == opcodes::all::OP_PUSHBYTES_33.into_u8() &&
+				self.0[34] == opcodes::all::OP_CHECKSIG.into_u8())
+	}
 
-    /// Checks whether a script pubkey is a Segregated Witness (segwit) program.
-    #[inline]
-    pub fn is_witness_program(&self) -> bool {
-        // A scriptPubKey (or redeemScript as defined in BIP16/P2SH) that consists of a 1-byte
-        // push opcode (for 0 to 16) followed by a data push between 2 and 40 bytes gets a new
-        // special meaning. The value of the first push is called the "version byte". The following
-        // byte vector pushed is called the "witness program".
-        let min_vernum: u8 = opcodes::all::OP_PUSHNUM_1.into_u8();
-        let max_vernum: u8 = opcodes::all::OP_PUSHNUM_16.into_u8();
-        self.0.len() >= 4
+	/// Checks whether a script pubkey is a Segregated Witness (segwit) program.
+	#[inline]
+	pub fn is_witness_program(&self) -> bool {
+		// A scriptPubKey (or redeemScript as defined in BIP16/P2SH) that consists of a 1-byte
+		// push opcode (for 0 to 16) followed by a data push between 2 and 40 bytes gets a new
+		// special meaning. The value of the first push is called the "version byte". The following
+		// byte vector pushed is called the "witness program".
+		let min_vernum: u8 = opcodes::all::OP_PUSHNUM_1.into_u8();
+		let max_vernum: u8 = opcodes::all::OP_PUSHNUM_16.into_u8();
+		self.0.len() >= 4
             && self.0.len() <= 42
             // Version 0 or PUSHNUM_1-PUSHNUM_16
             && (self.0[0] == 0 || self.0[0] >= min_vernum && self.0[0] <= max_vernum)
@@ -387,166 +399,195 @@ impl Script {
             && self.0[1] <= opcodes::all::OP_PUSHBYTES_40.into_u8()
             // Check that the rest of the script has the correct size
             && self.0.len() - 2 == self.0[1] as usize
-    }
+	}
 
-    /// Checks whether a script pubkey is a p2wsh output
-    #[inline]
-    pub fn is_v0_p2wsh(&self) -> bool {
-        self.0.len() == 34 &&
-        self.0[0] == opcodes::all::OP_PUSHBYTES_0.into_u8() &&
-        self.0[1] == opcodes::all::OP_PUSHBYTES_32.into_u8()
-    }
+	/// Checks whether a script pubkey is a p2wsh output
+	#[inline]
+	pub fn is_v0_p2wsh(&self) -> bool {
+		self.0.len() == 34 &&
+			self.0[0] == opcodes::all::OP_PUSHBYTES_0.into_u8() &&
+			self.0[1] == opcodes::all::OP_PUSHBYTES_32.into_u8()
+	}
 
-    /// Checks whether a script pubkey is a p2wpkh output
-    #[inline]
-    pub fn is_v0_p2wpkh(&self) -> bool {
-        self.0.len() == 22 &&
-            self.0[0] == opcodes::all::OP_PUSHBYTES_0.into_u8() &&
-            self.0[1] == opcodes::all::OP_PUSHBYTES_20.into_u8()
-    }
+	/// Checks whether a script pubkey is a p2wpkh output
+	#[inline]
+	pub fn is_v0_p2wpkh(&self) -> bool {
+		self.0.len() == 22 &&
+			self.0[0] == opcodes::all::OP_PUSHBYTES_0.into_u8() &&
+			self.0[1] == opcodes::all::OP_PUSHBYTES_20.into_u8()
+	}
 
-    /// Check if this is an OP_RETURN output
-    pub fn is_op_return (&self) -> bool {
-        !self.0.is_empty() && (opcodes::All::from(self.0[0]) == opcodes::all::OP_RETURN)
-    }
+	/// Check if this is an OP_RETURN output
+	pub fn is_op_return(&self) -> bool {
+		!self.0.is_empty() && (opcodes::All::from(self.0[0]) == opcodes::all::OP_RETURN)
+	}
 
-    /// Whether a script can be proven to have no satisfying input
-    pub fn is_provably_unspendable(&self) -> bool {
-        !self.0.is_empty() && (opcodes::All::from(self.0[0]).classify() == opcodes::Class::ReturnOp ||
-                               opcodes::All::from(self.0[0]).classify() == opcodes::Class::IllegalOp)
-    }
+	/// Whether a script can be proven to have no satisfying input
+	pub fn is_provably_unspendable(&self) -> bool {
+		!self.0.is_empty() &&
+			(opcodes::All::from(self.0[0]).classify() == opcodes::Class::ReturnOp ||
+				opcodes::All::from(self.0[0]).classify() == opcodes::Class::IllegalOp)
+	}
 
-    /// Iterate over the script in the form of `Instruction`s, which are an enum covering
-    /// opcodes, datapushes and errors. At most one error will be returned and then the
-    /// iterator will end. To instead iterate over the script as sequence of bytes, treat
-    /// it as a slice using `script[..]` or convert it to a vector using `into_bytes()`.
-    ///
-    /// To force minimal pushes, use [Self::instructions_minimal].
-    pub fn instructions(&self) -> Instructions {
-        Instructions {
-            data: &self.0[..],
-            enforce_minimal: false,
-        }
-    }
+	/// Iterate over the script in the form of `Instruction`s, which are an enum covering
+	/// opcodes, datapushes and errors. At most one error will be returned and then the
+	/// iterator will end. To instead iterate over the script as sequence of bytes, treat
+	/// it as a slice using `script[..]` or convert it to a vector using `into_bytes()`.
+	///
+	/// To force minimal pushes, use [Self::instructions_minimal].
+	pub fn instructions(&self) -> Instructions {
+		Instructions { data: &self.0[..], enforce_minimal: false }
+	}
 
-    /// Iterate over the script in the form of `Instruction`s while enforcing
-    /// minimal pushes.
-    pub fn instructions_minimal(&self) -> Instructions {
-        Instructions {
-            data: &self.0[..],
-            enforce_minimal: true,
-        }
-    }
+	/// Iterate over the script in the form of `Instruction`s while enforcing
+	/// minimal pushes.
+	pub fn instructions_minimal(&self) -> Instructions {
+		Instructions { data: &self.0[..], enforce_minimal: true }
+	}
 
-    #[cfg(feature="bitcoinconsensus")]
-    /// Shorthand for [Self::verify_with_flags] with flag [bitcoinconsensus::VERIFY_ALL]
-    pub fn verify (&self, index: usize, amount: ::Amount, spending: &[u8]) -> Result<(), Error> {
-        self.verify_with_flags(index, amount, spending, ::bitcoinconsensus::VERIFY_ALL)
-    }
+	#[cfg(feature = "bitcoinconsensus")]
+	/// Shorthand for [Self::verify_with_flags] with flag [bitcoinconsensus::VERIFY_ALL]
+	pub fn verify(&self, index: usize, amount: ::Amount, spending: &[u8]) -> Result<(), Error> {
+		self.verify_with_flags(index, amount, spending, ::bitcoinconsensus::VERIFY_ALL)
+	}
 
-    #[cfg(feature="bitcoinconsensus")]
-    /// Verify spend of an input script
-    /// # Parameters
-    ///  * `index` - the input index in spending which is spending this transaction
-    ///  * `amount` - the amount this script guards
-    ///  * `spending` - the transaction that attempts to spend the output holding this script
-    ///  * `flags` - verification flags, see [bitcoinconsensus::VERIFY_ALL] and similar
-    pub fn verify_with_flags<F: Into<u32>>(&self, index: usize, amount: ::Amount, spending: &[u8], flags: F) -> Result<(), Error> {
-        Ok(bitcoinconsensus::verify_with_flags (&self.0[..], amount.as_sat(), spending, index, flags.into())?)
-    }
+	#[cfg(feature = "bitcoinconsensus")]
+	/// Verify spend of an input script
+	/// # Parameters
+	///  * `index` - the input index in spending which is spending this transaction
+	///  * `amount` - the amount this script guards
+	///  * `spending` - the transaction that attempts to spend the output holding this script
+	///  * `flags` - verification flags, see [bitcoinconsensus::VERIFY_ALL] and similar
+	pub fn verify_with_flags<F: Into<u32>>(
+		&self,
+		index: usize,
+		amount: ::Amount,
+		spending: &[u8],
+		flags: F,
+	) -> Result<(), Error> {
+		Ok(bitcoinconsensus::verify_with_flags(
+			&self.0[..],
+			amount.as_sat(),
+			spending,
+			index,
+			flags.into(),
+		)?)
+	}
 
-    /// Write the assembly decoding of the script bytes to the formatter.
-    pub fn bytes_to_asm_fmt(script: &[u8], f: &mut dyn fmt::Write) -> fmt::Result {
-        let mut index = 0;
-        while index < script.len() {
-            let opcode = opcodes::All::from(script[index]);
-            index += 1;
+	/// Write the assembly decoding of the script bytes to the formatter.
+	pub fn bytes_to_asm_fmt(script: &[u8], f: &mut dyn fmt::Write) -> fmt::Result {
+		let mut index = 0;
+		while index < script.len() {
+			let opcode = opcodes::All::from(script[index]);
+			index += 1;
 
-            let data_len = if let opcodes::Class::PushBytes(n) = opcode.classify() {
-                n as usize
-            } else {
-                match opcode {
-                    opcodes::all::OP_PUSHDATA1 => {
-                        if script.len() < index + 1 {
-                            f.write_str("<unexpected end>")?;
-                            break;
-                        }
-                        match read_uint(&script[index..], 1) {
-                            Ok(n) => { index += 1; n as usize }
-                            Err(_) => { f.write_str("<bad length>")?; break; }
-                        }
-                    }
-                    opcodes::all::OP_PUSHDATA2 => {
-                        if script.len() < index + 2 {
-                            f.write_str("<unexpected end>")?;
-                            break;
-                        }
-                        match read_uint(&script[index..], 2) {
-                            Ok(n) => { index += 2; n as usize }
-                            Err(_) => { f.write_str("<bad length>")?; break; }
-                        }
-                    }
-                    opcodes::all::OP_PUSHDATA4 => {
-                        if script.len() < index + 4 {
-                            f.write_str("<unexpected end>")?;
-                            break;
-                        }
-                        match read_uint(&script[index..], 4) {
-                            Ok(n) => { index += 4; n as usize }
-                            Err(_) => { f.write_str("<bad length>")?; break; }
-                        }
-                    }
-                    _ => 0
-                }
-            };
+			let data_len = if let opcodes::Class::PushBytes(n) = opcode.classify() {
+				n as usize
+			} else {
+				match opcode {
+					opcodes::all::OP_PUSHDATA1 => {
+						if script.len() < index + 1 {
+							f.write_str("<unexpected end>")?;
+							break
+						}
+						match read_uint(&script[index..], 1) {
+							Ok(n) => {
+								index += 1;
+								n as usize
+							},
+							Err(_) => {
+								f.write_str("<bad length>")?;
+								break
+							},
+						}
+					},
+					opcodes::all::OP_PUSHDATA2 => {
+						if script.len() < index + 2 {
+							f.write_str("<unexpected end>")?;
+							break
+						}
+						match read_uint(&script[index..], 2) {
+							Ok(n) => {
+								index += 2;
+								n as usize
+							},
+							Err(_) => {
+								f.write_str("<bad length>")?;
+								break
+							},
+						}
+					},
+					opcodes::all::OP_PUSHDATA4 => {
+						if script.len() < index + 4 {
+							f.write_str("<unexpected end>")?;
+							break
+						}
+						match read_uint(&script[index..], 4) {
+							Ok(n) => {
+								index += 4;
+								n as usize
+							},
+							Err(_) => {
+								f.write_str("<bad length>")?;
+								break
+							},
+						}
+					},
+					_ => 0,
+				}
+			};
 
-            if index > 1 { f.write_str(" ")?; }
-            // Write the opcode
-            if opcode == opcodes::all::OP_PUSHBYTES_0 {
-                f.write_str("OP_0")?;
-            } else {
-                write!(f, "{:?}", opcode)?;
-            }
-            // Write any pushdata
-            if data_len > 0 {
-                f.write_str(" ")?;
-                if index + data_len <= script.len() {
-                    for ch in &script[index..index + data_len] {
-                            write!(f, "{:02x}", ch)?;
-                    }
-                    index += data_len;
-                } else {
-                    f.write_str("<push past end>")?;
-                    break;
-                }
-            }
-        }
-        Ok(())
-    }
+			if index > 1 {
+				f.write_str(" ")?;
+			}
+			// Write the opcode
+			if opcode == opcodes::all::OP_PUSHBYTES_0 {
+				f.write_str("OP_0")?;
+			} else {
+				write!(f, "{:?}", opcode)?;
+			}
+			// Write any pushdata
+			if data_len > 0 {
+				f.write_str(" ")?;
+				if index + data_len <= script.len() {
+					for ch in &script[index..index + data_len] {
+						write!(f, "{:02x}", ch)?;
+					}
+					index += data_len;
+				} else {
+					f.write_str("<push past end>")?;
+					break
+				}
+			}
+		}
+		Ok(())
+	}
 
-    /// Write the assembly decoding of the script to the formatter.
-    pub fn fmt_asm(&self, f: &mut dyn fmt::Write) -> fmt::Result {
-        Script::bytes_to_asm_fmt(self.as_ref(), f)
-    }
+	/// Write the assembly decoding of the script to the formatter.
+	pub fn fmt_asm(&self, f: &mut dyn fmt::Write) -> fmt::Result {
+		Script::bytes_to_asm_fmt(self.as_ref(), f)
+	}
 
-    /// Create an assembly decoding of the script in the given byte slice.
-    #[cfg(feature = "std")]
-    pub fn bytes_to_asm(script: &[u8]) -> String {
-        let mut buf = String::new();
-        Script::bytes_to_asm_fmt(script, &mut buf).unwrap();
-        buf
-    }
+	/// Create an assembly decoding of the script in the given byte slice.
+	#[cfg(feature = "std")]
+	pub fn bytes_to_asm(script: &[u8]) -> String {
+		let mut buf = String::new();
+		Script::bytes_to_asm_fmt(script, &mut buf).unwrap();
+		buf
+	}
 
-    /// Get the assembly decoding of the script.
-    #[cfg(feature = "std")]
-    pub fn asm(&self) -> String {
-        Script::bytes_to_asm(self.as_ref())
-    }
+	/// Get the assembly decoding of the script.
+	#[cfg(feature = "std")]
+	pub fn asm(&self) -> String {
+		Script::bytes_to_asm(self.as_ref())
+	}
 }
 
 /// Creates a new script from an existing vector
 impl From<Vec<u8>> for Script {
-    fn from(v: Vec<u8>) -> Script { Script(v.into_boxed_slice()) }
+	fn from(v: Vec<u8>) -> Script {
+		Script(v.into_boxed_slice())
+	}
 }
 
 impl_index_newtype!(Script, u8);
@@ -554,757 +595,805 @@ impl_index_newtype!(Script, u8);
 /// A "parsed opcode" which allows iterating over a Script in a more sensible way
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Instruction<'a> {
-    /// Push a bunch of data
-    PushBytes(&'a [u8]),
-    /// Some non-push opcode
-    Op(opcodes::All),
+	/// Push a bunch of data
+	PushBytes(&'a [u8]),
+	/// Some non-push opcode
+	Op(opcodes::All),
 }
 
 /// Iterator over a script returning parsed opcodes
 pub struct Instructions<'a> {
-    data: &'a [u8],
-    enforce_minimal: bool,
+	data: &'a [u8],
+	enforce_minimal: bool,
 }
 
 impl<'a> Iterator for Instructions<'a> {
-    type Item = Result<Instruction<'a>, Error>;
+	type Item = Result<Instruction<'a>, Error>;
 
-    fn next(&mut self) -> Option<Result<Instruction<'a>, Error>> {
-        if self.data.is_empty() {
-            return None;
-        }
+	fn next(&mut self) -> Option<Result<Instruction<'a>, Error>> {
+		if self.data.is_empty() {
+			return None
+		}
 
-        match opcodes::All::from(self.data[0]).classify() {
-            opcodes::Class::PushBytes(n) => {
-                let n = n as usize;
-                if self.data.len() < n + 1 {
-                    self.data = &[];  // Kill iterator so that it does not return an infinite stream of errors
-                    return Some(Err(Error::EarlyEndOfScript));
-                }
-                if self.enforce_minimal {
-                    if n == 1 && (self.data[1] == 0x81 || (self.data[1] > 0 && self.data[1] <= 16)) {
-                        self.data = &[];
-                        return Some(Err(Error::NonMinimalPush));
-                    }
-                }
-                let ret = Some(Ok(Instruction::PushBytes(&self.data[1..n+1])));
-                self.data = &self.data[n + 1..];
-                ret
-            }
-            opcodes::Class::Ordinary(opcodes::Ordinary::OP_PUSHDATA1) => {
-                if self.data.len() < 2 {
-                    self.data = &[];
-                    return Some(Err(Error::EarlyEndOfScript));
-                }
-                let n = match read_uint(&self.data[1..], 1) {
-                    Ok(n) => n,
-                    Err(e) => {
-                        self.data = &[];
-                        return Some(Err(e));
-                    }
-                };
-                if self.data.len() < n + 2 {
-                    self.data = &[];
-                    return Some(Err(Error::EarlyEndOfScript));
-                }
-                if self.enforce_minimal && n < 76 {
-                    self.data = &[];
-                    return Some(Err(Error::NonMinimalPush));
-                }
-                let ret = Some(Ok(Instruction::PushBytes(&self.data[2..n+2])));
-                self.data = &self.data[n + 2..];
-                ret
-            }
-            opcodes::Class::Ordinary(opcodes::Ordinary::OP_PUSHDATA2) => {
-                if self.data.len() < 3 {
-                    self.data = &[];
-                    return Some(Err(Error::EarlyEndOfScript));
-                }
-                let n = match read_uint(&self.data[1..], 2) {
-                    Ok(n) => n,
-                    Err(e) => {
-                        self.data = &[];
-                        return Some(Err(e));
-                    }
-                };
-                if self.enforce_minimal && n < 0x100 {
-                    self.data = &[];
-                    return Some(Err(Error::NonMinimalPush));
-                }
-                if self.data.len() < n + 3 {
-                    self.data = &[];
-                    return Some(Err(Error::EarlyEndOfScript));
-                }
-                let ret = Some(Ok(Instruction::PushBytes(&self.data[3..n + 3])));
-                self.data = &self.data[n + 3..];
-                ret
-            }
-            opcodes::Class::Ordinary(opcodes::Ordinary::OP_PUSHDATA4) => {
-                if self.data.len() < 5 {
-                    self.data = &[];
-                    return Some(Err(Error::EarlyEndOfScript));
-                }
-                let n = match read_uint(&self.data[1..], 4) {
-                    Ok(n) => n,
-                    Err(e) => {
-                        self.data = &[];
-                        return Some(Err(e));
-                    }
-                };
-                if self.enforce_minimal && n < 0x10000 {
-                    self.data = &[];
-                    return Some(Err(Error::NonMinimalPush));
-                }
-                if self.data.len() < n + 5 {
-                    self.data = &[];
-                    return Some(Err(Error::EarlyEndOfScript));
-                }
-                let ret = Some(Ok(Instruction::PushBytes(&self.data[5..n + 5])));
-                self.data = &self.data[n + 5..];
-                ret
-            }
-            // Everything else we can push right through
-            _ => {
-                let ret = Some(Ok(Instruction::Op(opcodes::All::from(self.data[0]))));
-                self.data = &self.data[1..];
-                ret
-            }
-        }
-    }
+		match opcodes::All::from(self.data[0]).classify() {
+			opcodes::Class::PushBytes(n) => {
+				let n = n as usize;
+				if self.data.len() < n + 1 {
+					self.data = &[]; // Kill iterator so that it does not return an infinite stream of errors
+					return Some(Err(Error::EarlyEndOfScript))
+				}
+				if self.enforce_minimal {
+					if n == 1 && (self.data[1] == 0x81 || (self.data[1] > 0 && self.data[1] <= 16))
+					{
+						self.data = &[];
+						return Some(Err(Error::NonMinimalPush))
+					}
+				}
+				let ret = Some(Ok(Instruction::PushBytes(&self.data[1..n + 1])));
+				self.data = &self.data[n + 1..];
+				ret
+			},
+			opcodes::Class::Ordinary(opcodes::Ordinary::OP_PUSHDATA1) => {
+				if self.data.len() < 2 {
+					self.data = &[];
+					return Some(Err(Error::EarlyEndOfScript))
+				}
+				let n = match read_uint(&self.data[1..], 1) {
+					Ok(n) => n,
+					Err(e) => {
+						self.data = &[];
+						return Some(Err(e))
+					},
+				};
+				if self.data.len() < n + 2 {
+					self.data = &[];
+					return Some(Err(Error::EarlyEndOfScript))
+				}
+				if self.enforce_minimal && n < 76 {
+					self.data = &[];
+					return Some(Err(Error::NonMinimalPush))
+				}
+				let ret = Some(Ok(Instruction::PushBytes(&self.data[2..n + 2])));
+				self.data = &self.data[n + 2..];
+				ret
+			},
+			opcodes::Class::Ordinary(opcodes::Ordinary::OP_PUSHDATA2) => {
+				if self.data.len() < 3 {
+					self.data = &[];
+					return Some(Err(Error::EarlyEndOfScript))
+				}
+				let n = match read_uint(&self.data[1..], 2) {
+					Ok(n) => n,
+					Err(e) => {
+						self.data = &[];
+						return Some(Err(e))
+					},
+				};
+				if self.enforce_minimal && n < 0x100 {
+					self.data = &[];
+					return Some(Err(Error::NonMinimalPush))
+				}
+				if self.data.len() < n + 3 {
+					self.data = &[];
+					return Some(Err(Error::EarlyEndOfScript))
+				}
+				let ret = Some(Ok(Instruction::PushBytes(&self.data[3..n + 3])));
+				self.data = &self.data[n + 3..];
+				ret
+			},
+			opcodes::Class::Ordinary(opcodes::Ordinary::OP_PUSHDATA4) => {
+				if self.data.len() < 5 {
+					self.data = &[];
+					return Some(Err(Error::EarlyEndOfScript))
+				}
+				let n = match read_uint(&self.data[1..], 4) {
+					Ok(n) => n,
+					Err(e) => {
+						self.data = &[];
+						return Some(Err(e))
+					},
+				};
+				if self.enforce_minimal && n < 0x10000 {
+					self.data = &[];
+					return Some(Err(Error::NonMinimalPush))
+				}
+				if self.data.len() < n + 5 {
+					self.data = &[];
+					return Some(Err(Error::EarlyEndOfScript))
+				}
+				let ret = Some(Ok(Instruction::PushBytes(&self.data[5..n + 5])));
+				self.data = &self.data[n + 5..];
+				ret
+			},
+			// Everything else we can push right through
+			_ => {
+				let ret = Some(Ok(Instruction::Op(opcodes::All::from(self.data[0]))));
+				self.data = &self.data[1..];
+				ret
+			},
+		}
+	}
 }
 
 impl Builder {
-    /// Creates a new empty script
-    pub fn new() -> Self {
-        Builder(vec![], None)
-    }
+	/// Creates a new empty script
+	pub fn new() -> Self {
+		Builder(vec![], None)
+	}
 
-    /// The length in bytes of the script
-    pub fn len(&self) -> usize { self.0.len() }
+	/// The length in bytes of the script
+	pub fn len(&self) -> usize {
+		self.0.len()
+	}
 
-    /// Whether the script is the empty script
-    pub fn is_empty(&self) -> bool { self.0.is_empty() }
+	/// Whether the script is the empty script
+	pub fn is_empty(&self) -> bool {
+		self.0.is_empty()
+	}
 
-    /// Adds instructions to push an integer onto the stack. Integers are
-    /// encoded as little-endian signed-magnitude numbers, but there are
-    /// dedicated opcodes to push some small integers.
-    pub fn push_int(self, data: i64) -> Builder {
-        // We can special-case -1, 1-16
-        if data == -1 || (data >= 1 && data <= 16) {
-            let opcode = opcodes::All::from(
-                (data - 1 + opcodes::OP_TRUE.into_u8() as i64) as u8
-            );
-            self.push_opcode(opcode)
-        }
-        // We can also special-case zero
-        else if data == 0 {
-            self.push_opcode(opcodes::OP_FALSE)
-        }
-        // Otherwise encode it as data
-        else { self.push_scriptint(data) }
-    }
+	/// Adds instructions to push an integer onto the stack. Integers are
+	/// encoded as little-endian signed-magnitude numbers, but there are
+	/// dedicated opcodes to push some small integers.
+	pub fn push_int(self, data: i64) -> Builder {
+		// We can special-case -1, 1-16
+		if data == -1 || (data >= 1 && data <= 16) {
+			let opcode = opcodes::All::from((data - 1 + opcodes::OP_TRUE.into_u8() as i64) as u8);
+			self.push_opcode(opcode)
+		}
+		// We can also special-case zero
+		else if data == 0 {
+			self.push_opcode(opcodes::OP_FALSE)
+		}
+		// Otherwise encode it as data
+		else {
+			self.push_scriptint(data)
+		}
+	}
 
-    /// Adds instructions to push an integer onto the stack, using the explicit
-    /// encoding regardless of the availability of dedicated opcodes.
-    pub fn push_scriptint(self, data: i64) -> Builder {
-        self.push_slice(&build_scriptint(data))
-    }
+	/// Adds instructions to push an integer onto the stack, using the explicit
+	/// encoding regardless of the availability of dedicated opcodes.
+	pub fn push_scriptint(self, data: i64) -> Builder {
+		self.push_slice(&build_scriptint(data))
+	}
 
-    /// Adds instructions to push some arbitrary data onto the stack
-    pub fn push_slice(mut self, data: &[u8]) -> Builder {
-        // Start with a PUSH opcode
-        match data.len() as u64 {
-            n if n < opcodes::Ordinary::OP_PUSHDATA1 as u64 => { self.0.push(n as u8); },
-            n if n < 0x100 => {
-                self.0.push(opcodes::Ordinary::OP_PUSHDATA1.into_u8());
-                self.0.push(n as u8);
-            },
-            n if n < 0x10000 => {
-                self.0.push(opcodes::Ordinary::OP_PUSHDATA2.into_u8());
-                self.0.push((n % 0x100) as u8);
-                self.0.push((n / 0x100) as u8);
-            },
-            n if n < 0x100000000 => {
-                self.0.push(opcodes::Ordinary::OP_PUSHDATA4.into_u8());
-                self.0.push((n % 0x100) as u8);
-                self.0.push(((n / 0x100) % 0x100) as u8);
-                self.0.push(((n / 0x10000) % 0x100) as u8);
-                self.0.push((n / 0x1000000) as u8);
-            }
-            _ => panic!("tried to put a 4bn+ sized object into a script!")
-        }
-        // Then push the raw bytes
-        self.0.extend(data.iter().cloned());
-        self.1 = None;
-        self
-    }
+	/// Adds instructions to push some arbitrary data onto the stack
+	pub fn push_slice(mut self, data: &[u8]) -> Builder {
+		// Start with a PUSH opcode
+		match data.len() as u64 {
+			n if n < opcodes::Ordinary::OP_PUSHDATA1 as u64 => {
+				self.0.push(n as u8);
+			},
+			n if n < 0x100 => {
+				self.0.push(opcodes::Ordinary::OP_PUSHDATA1.into_u8());
+				self.0.push(n as u8);
+			},
+			n if n < 0x10000 => {
+				self.0.push(opcodes::Ordinary::OP_PUSHDATA2.into_u8());
+				self.0.push((n % 0x100) as u8);
+				self.0.push((n / 0x100) as u8);
+			},
+			n if n < 0x100000000 => {
+				self.0.push(opcodes::Ordinary::OP_PUSHDATA4.into_u8());
+				self.0.push((n % 0x100) as u8);
+				self.0.push(((n / 0x100) % 0x100) as u8);
+				self.0.push(((n / 0x10000) % 0x100) as u8);
+				self.0.push((n / 0x1000000) as u8);
+			},
+			_ => panic!("tried to put a 4bn+ sized object into a script!"),
+		}
+		// Then push the raw bytes
+		self.0.extend(data.iter().cloned());
+		self.1 = None;
+		self
+	}
 
-    /// Pushes a public key
-    #[cfg(any())]
-    pub fn push_key(self, key: &PublicKey) -> Builder {
-        if key.compressed {
-            self.push_slice(&key.key.serialize()[..])
-        } else {
-            self.push_slice(&key.key.serialize_uncompressed()[..])
-        }
-    }
+	/// Pushes a public key
+	#[cfg(any())]
+	pub fn push_key(self, key: &PublicKey) -> Builder {
+		if key.compressed {
+			self.push_slice(&key.key.serialize()[..])
+		} else {
+			self.push_slice(&key.key.serialize_uncompressed()[..])
+		}
+	}
 
-    /// Adds a single opcode to the script
-    pub fn push_opcode(mut self, data: opcodes::All) -> Builder {
-        self.0.push(data.into_u8());
-        self.1 = Some(data);
-        self
-    }
+	/// Adds a single opcode to the script
+	pub fn push_opcode(mut self, data: opcodes::All) -> Builder {
+		self.0.push(data.into_u8());
+		self.1 = Some(data);
+		self
+	}
 
-    /// Adds an `OP_VERIFY` to the script, unless the most-recently-added
-    /// opcode has an alternate `VERIFY` form, in which case that opcode
-    /// is replaced. e.g. `OP_CHECKSIG` will become `OP_CHECKSIGVERIFY`.
-    pub fn push_verify(mut self) -> Builder {
-        match self.1 {
-            Some(opcodes::all::OP_EQUAL) => {
-                self.0.pop();
-                self.push_opcode(opcodes::all::OP_EQUALVERIFY)
-            },
-            Some(opcodes::all::OP_NUMEQUAL) => {
-                self.0.pop();
-                self.push_opcode(opcodes::all::OP_NUMEQUALVERIFY)
-            },
-            Some(opcodes::all::OP_CHECKSIG) => {
-                self.0.pop();
-                self.push_opcode(opcodes::all::OP_CHECKSIGVERIFY)
-            },
-            Some(opcodes::all::OP_CHECKMULTISIG) => {
-                self.0.pop();
-                self.push_opcode(opcodes::all::OP_CHECKMULTISIGVERIFY)
-            },
-            _ => self.push_opcode(opcodes::all::OP_VERIFY),
-        }
-    }
+	/// Adds an `OP_VERIFY` to the script, unless the most-recently-added
+	/// opcode has an alternate `VERIFY` form, in which case that opcode
+	/// is replaced. e.g. `OP_CHECKSIG` will become `OP_CHECKSIGVERIFY`.
+	pub fn push_verify(mut self) -> Builder {
+		match self.1 {
+			Some(opcodes::all::OP_EQUAL) => {
+				self.0.pop();
+				self.push_opcode(opcodes::all::OP_EQUALVERIFY)
+			},
+			Some(opcodes::all::OP_NUMEQUAL) => {
+				self.0.pop();
+				self.push_opcode(opcodes::all::OP_NUMEQUALVERIFY)
+			},
+			Some(opcodes::all::OP_CHECKSIG) => {
+				self.0.pop();
+				self.push_opcode(opcodes::all::OP_CHECKSIGVERIFY)
+			},
+			Some(opcodes::all::OP_CHECKMULTISIG) => {
+				self.0.pop();
+				self.push_opcode(opcodes::all::OP_CHECKMULTISIGVERIFY)
+			},
+			_ => self.push_opcode(opcodes::all::OP_VERIFY),
+		}
+	}
 
-    /// Converts the `Builder` into an unmodifiable `Script`
-    pub fn into_script(self) -> Script {
-        Script(self.0.into_boxed_slice())
-    }
+	/// Converts the `Builder` into an unmodifiable `Script`
+	pub fn into_script(self) -> Script {
+		Script(self.0.into_boxed_slice())
+	}
 }
 
 /// Adds an individual opcode to the script
 impl Default for Builder {
-    fn default() -> Builder { Builder::new() }
+	fn default() -> Builder {
+		Builder::new()
+	}
 }
 
 /// Creates a new script from an existing vector
 impl From<Vec<u8>> for Builder {
-    fn from(v: Vec<u8>) -> Builder {
-        let script = Script(v.into_boxed_slice());
-        let last_op = match script.instructions().last() {
-            Some(Ok(Instruction::Op(op))) => Some(op),
-            _ => None,
-        };
-        Builder(script.into_bytes(), last_op)
-    }
+	fn from(v: Vec<u8>) -> Builder {
+		let script = Script(v.into_boxed_slice());
+		let last_op = match script.instructions().last() {
+			Some(Ok(Instruction::Op(op))) => Some(op),
+			_ => None,
+		};
+		Builder(script.into_bytes(), last_op)
+	}
 }
 
 impl_index_newtype!(Builder, u8);
 
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Script {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where D: serde::Deserializer<'de>,
-    {
-        use core::fmt::Formatter;
-        use hashes::hex::FromHex;
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		use core::fmt::Formatter;
+		use hashes::hex::FromHex;
 
-        if deserializer.is_human_readable() {
+		if deserializer.is_human_readable() {
+			struct Visitor;
+			impl<'de> serde::de::Visitor<'de> for Visitor {
+				type Value = Script;
 
-            struct Visitor;
-            impl<'de> serde::de::Visitor<'de> for Visitor {
-                type Value = Script;
+				fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+					formatter.write_str("a script hex")
+				}
 
-                fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
-                    formatter.write_str("a script hex")
-                }
+				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+				where
+					E: serde::de::Error,
+				{
+					let v = Vec::from_hex(v).map_err(E::custom)?;
+					Ok(Script::from(v))
+				}
 
-                fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-                    where E: serde::de::Error,
-                {
-                    let v = Vec::from_hex(v).map_err(E::custom)?;
-                    Ok(Script::from(v))
-                }
+				fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+				where
+					E: serde::de::Error,
+				{
+					self.visit_str(v)
+				}
 
-                fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-                    where E: serde::de::Error,
-                {
-                    self.visit_str(v)
-                }
+				fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+				where
+					E: serde::de::Error,
+				{
+					self.visit_str(&v)
+				}
+			}
+			deserializer.deserialize_str(Visitor)
+		} else {
+			struct BytesVisitor;
 
-                fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-                    where E: serde::de::Error,
-                {
-                    self.visit_str(&v)
-                }
-            }
-            deserializer.deserialize_str(Visitor)
-        } else {
-            struct BytesVisitor;
+			impl<'de> serde::de::Visitor<'de> for BytesVisitor {
+				type Value = Script;
 
-            impl<'de> serde::de::Visitor<'de> for BytesVisitor {
-                type Value = Script;
+				fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+					formatter.write_str("a script Vec<u8>")
+				}
 
-                fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
-                    formatter.write_str("a script Vec<u8>")
-                }
-
-                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-                    where E: serde::de::Error,
-                {
-                    Ok(Script::from(v.to_vec()))
-                }
-            }
-            deserializer.deserialize_bytes(BytesVisitor)
-        }
-    }
+				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+				where
+					E: serde::de::Error,
+				{
+					Ok(Script::from(v.to_vec()))
+				}
+			}
+			deserializer.deserialize_bytes(BytesVisitor)
+		}
+	}
 }
 
 #[cfg(feature = "serde")]
 impl serde::Serialize for Script {
-    /// User-facing serialization for `Script`.
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        if serializer.is_human_readable() {
-            serializer.serialize_str(&format!("{:x}", self))
-        } else {
-            serializer.serialize_bytes(&self.as_bytes())
-        }
-    }
+	/// User-facing serialization for `Script`.
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		if serializer.is_human_readable() {
+			serializer.serialize_str(&format!("{:x}", self))
+		} else {
+			serializer.serialize_bytes(&self.as_bytes())
+		}
+	}
 }
 
 // Network serialization
 #[cfg(any())]
 impl Encodable for Script {
-    #[inline]
-    fn consensus_encode<S: io::Write>(
-        &self,
-        s: S,
-    ) -> Result<usize, io::Error> {
-        self.0.consensus_encode(s)
-    }
+	#[inline]
+	fn consensus_encode<S: io::Write>(&self, s: S) -> Result<usize, io::Error> {
+		self.0.consensus_encode(s)
+	}
 }
 
 #[cfg(any())]
 impl Decodable for Script {
-    #[inline]
-    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, encode::Error> {
-        Ok(Script(Decodable::consensus_decode(d)?))
-    }
+	#[inline]
+	fn consensus_decode<D: io::Read>(d: D) -> Result<Self, encode::Error> {
+		Ok(Script(Decodable::consensus_decode(d)?))
+	}
 }
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use super::build_scriptint;
+	use super::{build_scriptint, *};
 
-    use hex_literal::hex;
+	use hex_literal::hex;
 
-    #[test]
-    fn script() {
-        let mut comp = vec![];
-        let mut script = Builder::new();
-        assert_eq!(&script[..], &comp[..]);
+	#[test]
+	fn script() {
+		let mut comp = vec![];
+		let mut script = Builder::new();
+		assert_eq!(&script[..], &comp[..]);
 
-        // small ints
-        script = script.push_int(1);  comp.push(81u8); assert_eq!(&script[..], &comp[..]);
-        script = script.push_int(0);  comp.push(0u8);  assert_eq!(&script[..], &comp[..]);
-        script = script.push_int(4);  comp.push(84u8); assert_eq!(&script[..], &comp[..]);
-        script = script.push_int(-1); comp.push(79u8); assert_eq!(&script[..], &comp[..]);
-        // forced scriptint
-        script = script.push_scriptint(4); comp.extend([1u8, 4].iter().cloned()); assert_eq!(&script[..], &comp[..]);
-        // big ints
-        script = script.push_int(17); comp.extend([1u8, 17].iter().cloned()); assert_eq!(&script[..], &comp[..]);
-        script = script.push_int(10000); comp.extend([2u8, 16, 39].iter().cloned()); assert_eq!(&script[..], &comp[..]);
-        // notice the sign bit set here, hence the extra zero/128 at the end
-        script = script.push_int(10000000); comp.extend([4u8, 128, 150, 152, 0].iter().cloned()); assert_eq!(&script[..], &comp[..]);
-        script = script.push_int(-10000000); comp.extend([4u8, 128, 150, 152, 128].iter().cloned()); assert_eq!(&script[..], &comp[..]);
+		// small ints
+		script = script.push_int(1);
+		comp.push(81u8);
+		assert_eq!(&script[..], &comp[..]);
+		script = script.push_int(0);
+		comp.push(0u8);
+		assert_eq!(&script[..], &comp[..]);
+		script = script.push_int(4);
+		comp.push(84u8);
+		assert_eq!(&script[..], &comp[..]);
+		script = script.push_int(-1);
+		comp.push(79u8);
+		assert_eq!(&script[..], &comp[..]);
+		// forced scriptint
+		script = script.push_scriptint(4);
+		comp.extend([1u8, 4].iter().cloned());
+		assert_eq!(&script[..], &comp[..]);
+		// big ints
+		script = script.push_int(17);
+		comp.extend([1u8, 17].iter().cloned());
+		assert_eq!(&script[..], &comp[..]);
+		script = script.push_int(10000);
+		comp.extend([2u8, 16, 39].iter().cloned());
+		assert_eq!(&script[..], &comp[..]);
+		// notice the sign bit set here, hence the extra zero/128 at the end
+		script = script.push_int(10000000);
+		comp.extend([4u8, 128, 150, 152, 0].iter().cloned());
+		assert_eq!(&script[..], &comp[..]);
+		script = script.push_int(-10000000);
+		comp.extend([4u8, 128, 150, 152, 128].iter().cloned());
+		assert_eq!(&script[..], &comp[..]);
 
-        // data
-        script = script.push_slice("NRA4VR".as_bytes());
-        comp.extend([6u8, 78, 82, 65, 52, 86, 82].iter().cloned());
-        assert_eq!(&script[..], &comp[..]);
+		// data
+		script = script.push_slice("NRA4VR".as_bytes());
+		comp.extend([6u8, 78, 82, 65, 52, 86, 82].iter().cloned());
+		assert_eq!(&script[..], &comp[..]);
 
-        /*
-        // keys
-        let key = hex!("21032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af");
-        script = script.push_slice(&key);
-        comp.push(33u8);
-        comp.extend(&key);
-        assert_eq!(&script[..], &comp[..]);
-        let keystr = "41042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133";
-        let key = PublicKey::from_str(&keystr[2..]).unwrap();
-        script = script.push_key(&key); comp.extend(Vec::from_hex(keystr).unwrap().iter().cloned()); assert_eq!(&script[..], &comp[..]);
-        */
+		/*
+		// keys
+		let key = hex!("21032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af");
+		script = script.push_slice(&key);
+		comp.push(33u8);
+		comp.extend(&key);
+		assert_eq!(&script[..], &comp[..]);
+		let keystr = "41042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133";
+		let key = PublicKey::from_str(&keystr[2..]).unwrap();
+		script = script.push_key(&key); comp.extend(Vec::from_hex(keystr).unwrap().iter().cloned()); assert_eq!(&script[..], &comp[..]);
+		*/
 
-        // opcodes
-        script = script.push_opcode(opcodes::all::OP_CHECKSIG); comp.push(0xACu8); assert_eq!(&script[..], &comp[..]);
-        script = script.push_opcode(opcodes::all::OP_CHECKSIG); comp.push(0xACu8); assert_eq!(&script[..], &comp[..]);
-    }
+		// opcodes
+		script = script.push_opcode(opcodes::all::OP_CHECKSIG);
+		comp.push(0xACu8);
+		assert_eq!(&script[..], &comp[..]);
+		script = script.push_opcode(opcodes::all::OP_CHECKSIG);
+		comp.push(0xACu8);
+		assert_eq!(&script[..], &comp[..]);
+	}
 
-    #[test]
-    fn script_builder() {
-        // from txid 3bb5e6434c11fb93f64574af5d116736510717f2c595eb45b52c28e31622dfff which was in my mempool when I wrote the test
-        let script = Builder::new().push_opcode(opcodes::all::OP_DUP)
-                                   .push_opcode(opcodes::all::OP_HASH160)
-                                   .push_slice(&hex!("16e1ae70ff0fa102905d4af297f6912bda6cce19"))
-                                   .push_opcode(opcodes::all::OP_EQUALVERIFY)
-                                   .push_opcode(opcodes::all::OP_CHECKSIG)
-                                   .into_script();
-        assert_eq!(&format!("{:x}", script), "76a91416e1ae70ff0fa102905d4af297f6912bda6cce1988ac");
-    }
+	#[test]
+	fn script_builder() {
+		// from txid 3bb5e6434c11fb93f64574af5d116736510717f2c595eb45b52c28e31622dfff which was in
+		// my mempool when I wrote the test
+		let script = Builder::new()
+			.push_opcode(opcodes::all::OP_DUP)
+			.push_opcode(opcodes::all::OP_HASH160)
+			.push_slice(&hex!("16e1ae70ff0fa102905d4af297f6912bda6cce19"))
+			.push_opcode(opcodes::all::OP_EQUALVERIFY)
+			.push_opcode(opcodes::all::OP_CHECKSIG)
+			.into_script();
+		assert_eq!(&format!("{:x}", script), "76a91416e1ae70ff0fa102905d4af297f6912bda6cce1988ac");
+	}
 
-    #[cfg(any())]
-    #[test]
-    fn script_generators() {
-        let pubkey = PublicKey::from_str("0234e6a79c5359c613762d537e0e19d86c77c1666d8c9ab050f23acd198e97f93e").unwrap();
-        assert!(Script::new_p2pk(&pubkey).is_p2pk());
+	#[cfg(any())]
+	#[test]
+	fn script_generators() {
+		let pubkey = PublicKey::from_str(
+			"0234e6a79c5359c613762d537e0e19d86c77c1666d8c9ab050f23acd198e97f93e",
+		)
+		.unwrap();
+		assert!(Script::new_p2pk(&pubkey).is_p2pk());
 
-        let pubkey_hash = PubkeyHash::hash(&pubkey.serialize());
-        assert!(Script::new_p2pkh(&pubkey_hash).is_p2pkh());
+		let pubkey_hash = PubkeyHash::hash(&pubkey.serialize());
+		assert!(Script::new_p2pkh(&pubkey_hash).is_p2pkh());
 
-        let wpubkey_hash = WPubkeyHash::hash(&pubkey.serialize());
-        assert!(Script::new_v0_wpkh(&wpubkey_hash).is_v0_p2wpkh());
+		let wpubkey_hash = WPubkeyHash::hash(&pubkey.serialize());
+		assert!(Script::new_v0_wpkh(&wpubkey_hash).is_v0_p2wpkh());
 
-        let script = Builder::new().push_opcode(opcodes::all::OP_NUMEQUAL)
-                                   .push_verify()
-                                   .into_script();
-        let script_hash = ScriptHash::hash(&script.serialize());
-        let p2sh = Script::new_p2sh(&script_hash);
-        assert!(p2sh.is_p2sh());
-        assert_eq!(script.to_p2sh(), p2sh);
+		let script = Builder::new()
+			.push_opcode(opcodes::all::OP_NUMEQUAL)
+			.push_verify()
+			.into_script();
+		let script_hash = ScriptHash::hash(&script.serialize());
+		let p2sh = Script::new_p2sh(&script_hash);
+		assert!(p2sh.is_p2sh());
+		assert_eq!(script.to_p2sh(), p2sh);
 
-        let wscript_hash = WScriptHash::hash(&script.serialize());
-        let p2wsh = Script::new_v0_wsh(&wscript_hash);
-        assert!(p2wsh.is_v0_p2wsh());
-        assert_eq!(script.to_v0_p2wsh(), p2wsh);
+		let wscript_hash = WScriptHash::hash(&script.serialize());
+		let p2wsh = Script::new_v0_wsh(&wscript_hash);
+		assert!(p2wsh.is_v0_p2wsh());
+		assert_eq!(script.to_v0_p2wsh(), p2wsh);
 
-        // Test data are taken from the second output of
-        // 2ccb3a1f745eb4eefcf29391460250adda5fab78aaddb902d25d3cd97d9d8e61 transaction
-        let data = Vec::<u8>::from_hex("aa21a9ed20280f53f2d21663cac89e6bd2ad19edbabb048cda08e73ed19e9268d0afea2a").unwrap();
-        let op_return = Script::new_op_return(&data);
-        assert!(op_return.is_op_return());
-        assert_eq!(op_return.to_hex(), "6a24aa21a9ed20280f53f2d21663cac89e6bd2ad19edbabb048cda08e73ed19e9268d0afea2a");
-    }
+		// Test data are taken from the second output of
+		// 2ccb3a1f745eb4eefcf29391460250adda5fab78aaddb902d25d3cd97d9d8e61 transaction
+		let data = Vec::<u8>::from_hex(
+			"aa21a9ed20280f53f2d21663cac89e6bd2ad19edbabb048cda08e73ed19e9268d0afea2a",
+		)
+		.unwrap();
+		let op_return = Script::new_op_return(&data);
+		assert!(op_return.is_op_return());
+		assert_eq!(
+			op_return.to_hex(),
+			"6a24aa21a9ed20280f53f2d21663cac89e6bd2ad19edbabb048cda08e73ed19e9268d0afea2a"
+		);
+	}
 
-    #[test]
-    fn script_builder_verify() {
-        let simple = Builder::new()
-            .push_verify()
-            .into_script();
-        assert_eq!(format!("{:x}", simple), "69");
-        let simple2 = Builder::from(vec![])
-            .push_verify()
-            .into_script();
-        assert_eq!(format!("{:x}", simple2), "69");
+	#[test]
+	fn script_builder_verify() {
+		let simple = Builder::new().push_verify().into_script();
+		assert_eq!(format!("{:x}", simple), "69");
+		let simple2 = Builder::from(vec![]).push_verify().into_script();
+		assert_eq!(format!("{:x}", simple2), "69");
 
-        let nonverify = Builder::new()
-            .push_verify()
-            .push_verify()
-            .into_script();
-        assert_eq!(format!("{:x}", nonverify), "6969");
-        let nonverify2 = Builder::from(vec![0x69])
-            .push_verify()
-            .into_script();
-        assert_eq!(format!("{:x}", nonverify2), "6969");
+		let nonverify = Builder::new().push_verify().push_verify().into_script();
+		assert_eq!(format!("{:x}", nonverify), "6969");
+		let nonverify2 = Builder::from(vec![0x69]).push_verify().into_script();
+		assert_eq!(format!("{:x}", nonverify2), "6969");
 
-        let equal = Builder::new()
-            .push_opcode(opcodes::all::OP_EQUAL)
-            .push_verify()
-            .into_script();
-        assert_eq!(format!("{:x}", equal), "88");
-        let equal2 = Builder::from(vec![0x87])
-            .push_verify()
-            .into_script();
-        assert_eq!(format!("{:x}", equal2), "88");
+		let equal = Builder::new().push_opcode(opcodes::all::OP_EQUAL).push_verify().into_script();
+		assert_eq!(format!("{:x}", equal), "88");
+		let equal2 = Builder::from(vec![0x87]).push_verify().into_script();
+		assert_eq!(format!("{:x}", equal2), "88");
 
-        let numequal = Builder::new()
-            .push_opcode(opcodes::all::OP_NUMEQUAL)
-            .push_verify()
-            .into_script();
-        assert_eq!(format!("{:x}", numequal), "9d");
-        let numequal2 = Builder::from(vec![0x9c])
-            .push_verify()
-            .into_script();
-        assert_eq!(format!("{:x}", numequal2), "9d");
+		let numequal = Builder::new()
+			.push_opcode(opcodes::all::OP_NUMEQUAL)
+			.push_verify()
+			.into_script();
+		assert_eq!(format!("{:x}", numequal), "9d");
+		let numequal2 = Builder::from(vec![0x9c]).push_verify().into_script();
+		assert_eq!(format!("{:x}", numequal2), "9d");
 
-        let checksig = Builder::new()
-            .push_opcode(opcodes::all::OP_CHECKSIG)
-            .push_verify()
-            .into_script();
-        assert_eq!(format!("{:x}", checksig), "ad");
-        let checksig2 = Builder::from(vec![0xac])
-            .push_verify()
-            .into_script();
-        assert_eq!(format!("{:x}", checksig2), "ad");
+		let checksig = Builder::new()
+			.push_opcode(opcodes::all::OP_CHECKSIG)
+			.push_verify()
+			.into_script();
+		assert_eq!(format!("{:x}", checksig), "ad");
+		let checksig2 = Builder::from(vec![0xac]).push_verify().into_script();
+		assert_eq!(format!("{:x}", checksig2), "ad");
 
-        let checkmultisig = Builder::new()
-            .push_opcode(opcodes::all::OP_CHECKMULTISIG)
-            .push_verify()
-            .into_script();
-        assert_eq!(format!("{:x}", checkmultisig), "af");
-        let checkmultisig2 = Builder::from(vec![0xae])
-            .push_verify()
-            .into_script();
-        assert_eq!(format!("{:x}", checkmultisig2), "af");
+		let checkmultisig = Builder::new()
+			.push_opcode(opcodes::all::OP_CHECKMULTISIG)
+			.push_verify()
+			.into_script();
+		assert_eq!(format!("{:x}", checkmultisig), "af");
+		let checkmultisig2 = Builder::from(vec![0xae]).push_verify().into_script();
+		assert_eq!(format!("{:x}", checkmultisig2), "af");
 
-        let trick_slice = Builder::new()
-            .push_slice(&[0xae]) // OP_CHECKMULTISIG
-            .push_verify()
-            .into_script();
-        assert_eq!(format!("{:x}", trick_slice), "01ae69");
-        let trick_slice2 = Builder::from(vec![0x01, 0xae])
-            .push_verify()
-            .into_script();
-        assert_eq!(format!("{:x}", trick_slice2), "01ae69");
-   }
+		let trick_slice = Builder::new()
+			.push_slice(&[0xae]) // OP_CHECKMULTISIG
+			.push_verify()
+			.into_script();
+		assert_eq!(format!("{:x}", trick_slice), "01ae69");
+		let trick_slice2 = Builder::from(vec![0x01, 0xae]).push_verify().into_script();
+		assert_eq!(format!("{:x}", trick_slice2), "01ae69");
+	}
 
-    #[cfg(any())]
-    #[test]
-    fn script_serialize() {
-        let hex_script = Vec::from_hex("6c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52").unwrap();
-        let script: Result<Script, _> = deserialize(&hex_script);
-        assert!(script.is_ok());
-        assert_eq!(serialize(&script.unwrap()), hex_script);
-    }
+	#[cfg(any())]
+	#[test]
+	fn script_serialize() {
+		let hex_script = Vec::from_hex("6c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52").unwrap();
+		let script: Result<Script, _> = deserialize(&hex_script);
+		assert!(script.is_ok());
+		assert_eq!(serialize(&script.unwrap()), hex_script);
+	}
 
-    #[test]
-    fn scriptint_round_trip() {
-        assert_eq!(build_scriptint(-1), vec![0x81]);
-        assert_eq!(build_scriptint(255), vec![255, 0]);
-        assert_eq!(build_scriptint(256), vec![0, 1]);
-        assert_eq!(build_scriptint(257), vec![1, 1]);
-        assert_eq!(build_scriptint(511), vec![255, 1]);
-        for &i in [10, 100, 255, 256, 1000, 10000, 25000, 200000, 5000000, 1000000000,
-                             (1 << 31) - 1, -((1 << 31) - 1)].iter() {
-            assert_eq!(Ok(i), read_scriptint(&build_scriptint(i)));
-            assert_eq!(Ok(-i), read_scriptint(&build_scriptint(-i)));
-        }
-        assert!(read_scriptint(&build_scriptint(1 << 31)).is_err());
-        assert!(read_scriptint(&build_scriptint(-(1 << 31))).is_err());
-    }
+	#[test]
+	fn scriptint_round_trip() {
+		assert_eq!(build_scriptint(-1), vec![0x81]);
+		assert_eq!(build_scriptint(255), vec![255, 0]);
+		assert_eq!(build_scriptint(256), vec![0, 1]);
+		assert_eq!(build_scriptint(257), vec![1, 1]);
+		assert_eq!(build_scriptint(511), vec![255, 1]);
+		for &i in [
+			10,
+			100,
+			255,
+			256,
+			1000,
+			10000,
+			25000,
+			200000,
+			5000000,
+			1000000000,
+			(1 << 31) - 1,
+			-((1 << 31) - 1),
+		]
+		.iter()
+		{
+			assert_eq!(Ok(i), read_scriptint(&build_scriptint(i)));
+			assert_eq!(Ok(-i), read_scriptint(&build_scriptint(-i)));
+		}
+		assert!(read_scriptint(&build_scriptint(1 << 31)).is_err());
+		assert!(read_scriptint(&build_scriptint(-(1 << 31))).is_err());
+	}
 
-    #[cfg(any())]
-    #[test]
-    fn script_hashes() {
-        let script = hex_script!("410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac");
-        assert_eq!(script.script_hash().to_hex(), "8292bcfbef1884f73c813dfe9c82fd7e814291ea");
-        assert_eq!(script.wscript_hash().to_hex(), "3e1525eb183ad4f9b3c5fa3175bdca2a52e947b135bbb90383bf9f6408e2c324");
-    }
+	#[cfg(any())]
+	#[test]
+	fn script_hashes() {
+		let script = hex_script!("410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac");
+		assert_eq!(script.script_hash().to_hex(), "8292bcfbef1884f73c813dfe9c82fd7e814291ea");
+		assert_eq!(
+			script.wscript_hash().to_hex(),
+			"3e1525eb183ad4f9b3c5fa3175bdca2a52e947b135bbb90383bf9f6408e2c324"
+		);
+	}
 
-    #[test]
-    fn provably_unspendable_test() {
-        // p2pk
-        assert_eq!(hex_script!("410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac").is_provably_unspendable(), false);
-        assert_eq!(hex_script!("4104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac").is_provably_unspendable(), false);
-        // p2pkhash
-        assert_eq!(hex_script!("76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac").is_provably_unspendable(), false);
-        assert_eq!(hex_script!("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87").is_provably_unspendable(), true);
-    }
+	#[test]
+	fn provably_unspendable_test() {
+		// p2pk
+		assert_eq!(hex_script!("410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac").is_provably_unspendable(), false);
+		assert_eq!(hex_script!("4104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac").is_provably_unspendable(), false);
+		// p2pkhash
+		assert_eq!(
+			hex_script!("76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac")
+				.is_provably_unspendable(),
+			false
+		);
+		assert_eq!(
+			hex_script!("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87")
+				.is_provably_unspendable(),
+			true
+		);
+	}
 
-    #[test]
-    fn op_return_test() {
-        assert_eq!(hex_script!("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87").is_op_return(), true);
-        assert_eq!(hex_script!("76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac").is_op_return(), false);
-        assert_eq!(hex_script!("").is_op_return(), false);
-    }
+	#[test]
+	fn op_return_test() {
+		assert_eq!(
+			hex_script!("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87").is_op_return(),
+			true
+		);
+		assert_eq!(
+			hex_script!("76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac").is_op_return(),
+			false
+		);
+		assert_eq!(hex_script!("").is_op_return(), false);
+	}
 
-    #[test]
-    #[cfg(feature = "serde")]
-    fn script_json_serialize() {
-        use serde_json;
+	#[test]
+	#[cfg(feature = "serde")]
+	fn script_json_serialize() {
+		use serde_json;
 
-        let original = hex_script!("827651a0698faaa9a8a7a687");
-        let json = serde_json::to_value(&original).unwrap();
-        assert_eq!(json, serde_json::Value::String("827651a0698faaa9a8a7a687".to_owned()));
-        let des = serde_json::from_value(json).unwrap();
-        assert_eq!(original, des);
-    }
+		let original = hex_script!("827651a0698faaa9a8a7a687");
+		let json = serde_json::to_value(&original).unwrap();
+		assert_eq!(json, serde_json::Value::String("827651a0698faaa9a8a7a687".to_owned()));
+		let des = serde_json::from_value(json).unwrap();
+		assert_eq!(original, des);
+	}
 
-    #[test]
-    fn script_asm() {
-        assert_eq!(hex_script!("6363636363686868686800").asm(),
-                   "OP_IF OP_IF OP_IF OP_IF OP_IF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_0");
-        assert_eq!(hex_script!("6363636363686868686800").asm(),
-                   "OP_IF OP_IF OP_IF OP_IF OP_IF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_0");
-        assert_eq!(hex_script!("2102715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699ac").asm(),
+	#[test]
+	fn script_asm() {
+		assert_eq!(
+			hex_script!("6363636363686868686800").asm(),
+			"OP_IF OP_IF OP_IF OP_IF OP_IF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_0"
+		);
+		assert_eq!(
+			hex_script!("6363636363686868686800").asm(),
+			"OP_IF OP_IF OP_IF OP_IF OP_IF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_0"
+		);
+		assert_eq!(hex_script!("2102715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699ac").asm(),
                    "OP_PUSHBYTES_33 02715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699 OP_CHECKSIG");
-        // Elements Alpha peg-out transaction with some signatures removed for brevity. Mainly to test PUSHDATA1
-        assert_eq!(hex_script!("0047304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401004cf1552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae").asm(),
+		// Elements Alpha peg-out transaction with some signatures removed for brevity. Mainly to
+		// test PUSHDATA1
+		assert_eq!(hex_script!("0047304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401004cf1552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae").asm(),
                    "OP_0 OP_PUSHBYTES_71 304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401 OP_0 OP_PUSHDATA1 552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae");
-    }
-
-    #[test]
-    fn script_p2sh_p2p2k_template() {
-        // random outputs I picked out of the mempool
-        assert!(hex_script!("76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ac").is_p2pkh());
-        assert!(!hex_script!("76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ac").is_p2sh());
-        assert!(!hex_script!("76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ad").is_p2pkh());
-        assert!(!hex_script!("").is_p2pkh());
-        assert!(hex_script!("a914acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87").is_p2sh());
-        assert!(!hex_script!("a914acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87").is_p2pkh());
-        assert!(!hex_script!("a314acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87").is_p2sh());
-    }
-
-    #[test]
-    fn script_p2pk() {
-        assert!(hex_script!("21021aeaf2f8638a129a3156fbe7e5ef635226b0bafd495ff03afe2c843d7e3a4b51ac").is_p2pk());
-        assert!(hex_script!("410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac").is_p2pk());
-    }
-
-    #[cfg(any())]
-    #[test]
-    fn p2sh_p2wsh_conversion() {
-        // Test vectors taken from Core tests/data/script_tests.json
-        // bare p2wsh
-        let redeem_script = hex_script!("410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8ac");
-        let expected_witout = hex_script!("0020b95237b48faaa69eb078e1170be3b5cbb3fddf16d0a991e14ad274f7b33a4f64");
-        assert!(redeem_script.to_v0_p2wsh().is_v0_p2wsh());
-        assert_eq!(redeem_script.to_v0_p2wsh(), expected_witout);
-
-        // p2sh
-        let redeem_script = hex_script!("0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8");
-        let expected_p2shout = hex_script!("a91491b24bf9f5288532960ac687abb035127b1d28a587");
-        assert!(redeem_script.to_p2sh().is_p2sh());
-        assert_eq!(redeem_script.to_p2sh(), expected_p2shout);
-
-        // p2sh-p2wsh
-        let redeem_script = hex_script!("410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8ac");
-        let expected_witout = hex_script!("0020b95237b48faaa69eb078e1170be3b5cbb3fddf16d0a991e14ad274f7b33a4f64");
-        let expected_out = hex_script!("a914f386c2ba255cc56d20cfa6ea8b062f8b5994551887");
-        assert!(redeem_script.to_p2sh().is_p2sh());
-        assert!(redeem_script.to_p2sh().to_v0_p2wsh().is_v0_p2wsh());
-        assert_eq!(redeem_script.to_v0_p2wsh(), expected_witout);
-        assert_eq!(redeem_script.to_v0_p2wsh().to_p2sh(), expected_out);
-    }
-
-    #[test]
-    fn test_iterator() {
-        let zero = hex_script!("00");
-        let zeropush = hex_script!("0100");
-
-        let nonminimal = hex_script!("4c0169b2");      // PUSHDATA1 for no reason
-        let minimal = hex_script!("0169b2");           // minimal
-        let nonminimal_alt = hex_script!("026900b2");  // non-minimal number but minimal push (should be OK)
-
-        let v_zero: Result<Vec<Instruction>, Error> = zero.instructions_minimal().collect();
-        let v_zeropush: Result<Vec<Instruction>, Error> = zeropush.instructions_minimal().collect();
-
-        let v_min: Result<Vec<Instruction>, Error> = minimal.instructions_minimal().collect();
-        let v_nonmin: Result<Vec<Instruction>, Error> = nonminimal.instructions_minimal().collect();
-        let v_nonmin_alt: Result<Vec<Instruction>, Error> = nonminimal_alt.instructions_minimal().collect();
-        let slop_v_min: Result<Vec<Instruction>, Error> = minimal.instructions().collect();
-        let slop_v_nonmin: Result<Vec<Instruction>, Error> = nonminimal.instructions().collect();
-        let slop_v_nonmin_alt: Result<Vec<Instruction>, Error> = nonminimal_alt.instructions().collect();
-
-        assert_eq!(
-            v_zero.unwrap(),
-            vec![
-                Instruction::PushBytes(&[]),
-            ]
-        );
-        assert_eq!(
-            v_zeropush.unwrap(),
-            vec![
-                Instruction::PushBytes(&[0]),
-            ]
-        );
-
-        assert_eq!(
-            v_min.clone().unwrap(),
-            vec![
-                Instruction::PushBytes(&[105]),
-                Instruction::Op(opcodes::OP_NOP3),
-            ]
-        );
-
-        assert_eq!(
-            v_nonmin.err().unwrap(),
-            Error::NonMinimalPush
-        );
-
-        assert_eq!(
-            v_nonmin_alt.clone().unwrap(),
-            vec![
-                Instruction::PushBytes(&[105, 0]),
-                Instruction::Op(opcodes::OP_NOP3),
-            ]
-        );
-
-        assert_eq!(v_min.clone().unwrap(), slop_v_min.unwrap());
-        assert_eq!(v_min.unwrap(), slop_v_nonmin.unwrap());
-        assert_eq!(v_nonmin_alt.unwrap(), slop_v_nonmin_alt.unwrap());
-    }
+	}
 
 	#[test]
-    fn script_ord() {
-        let script_1 = Builder::new().push_slice(&[1,2,3,4]).into_script();
-        let script_2 = Builder::new().push_int(10).into_script();
-        let script_3 = Builder::new().push_int(15).into_script();
-        let script_4 = Builder::new().push_opcode(opcodes::all::OP_RETURN).into_script();
-
-        assert!(script_1 < script_2);
-        assert!(script_2 < script_3);
-        assert!(script_3 < script_4);
-
-        assert!(script_1 <= script_1);
-        assert!(script_1 >= script_1);
-
-        assert!(script_4 > script_3);
-        assert!(script_3 > script_2);
-        assert!(script_2 > script_1);
-    }
+	fn script_p2sh_p2p2k_template() {
+		// random outputs I picked out of the mempool
+		assert!(hex_script!("76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ac").is_p2pkh());
+		assert!(!hex_script!("76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ac").is_p2sh());
+		assert!(!hex_script!("76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ad").is_p2pkh());
+		assert!(!hex_script!("").is_p2pkh());
+		assert!(hex_script!("a914acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87").is_p2sh());
+		assert!(!hex_script!("a914acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87").is_p2pkh());
+		assert!(!hex_script!("a314acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87").is_p2sh());
+	}
 
 	#[test]
-	#[cfg(feature="bitcoinconsensus")]
-	fn test_bitcoinconsensus () {
+	fn script_p2pk() {
+		assert!(hex_script!(
+			"21021aeaf2f8638a129a3156fbe7e5ef635226b0bafd495ff03afe2c843d7e3a4b51ac"
+		)
+		.is_p2pk());
+		assert!(hex_script!("410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac").is_p2pk());
+	}
+
+	#[cfg(any())]
+	#[test]
+	fn p2sh_p2wsh_conversion() {
+		// Test vectors taken from Core tests/data/script_tests.json
+		// bare p2wsh
+		let redeem_script = hex_script!("410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8ac");
+		let expected_witout =
+			hex_script!("0020b95237b48faaa69eb078e1170be3b5cbb3fddf16d0a991e14ad274f7b33a4f64");
+		assert!(redeem_script.to_v0_p2wsh().is_v0_p2wsh());
+		assert_eq!(redeem_script.to_v0_p2wsh(), expected_witout);
+
+		// p2sh
+		let redeem_script = hex_script!("0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8");
+		let expected_p2shout = hex_script!("a91491b24bf9f5288532960ac687abb035127b1d28a587");
+		assert!(redeem_script.to_p2sh().is_p2sh());
+		assert_eq!(redeem_script.to_p2sh(), expected_p2shout);
+
+		// p2sh-p2wsh
+		let redeem_script = hex_script!("410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8ac");
+		let expected_witout =
+			hex_script!("0020b95237b48faaa69eb078e1170be3b5cbb3fddf16d0a991e14ad274f7b33a4f64");
+		let expected_out = hex_script!("a914f386c2ba255cc56d20cfa6ea8b062f8b5994551887");
+		assert!(redeem_script.to_p2sh().is_p2sh());
+		assert!(redeem_script.to_p2sh().to_v0_p2wsh().is_v0_p2wsh());
+		assert_eq!(redeem_script.to_v0_p2wsh(), expected_witout);
+		assert_eq!(redeem_script.to_v0_p2wsh().to_p2sh(), expected_out);
+	}
+
+	#[test]
+	fn test_iterator() {
+		let zero = hex_script!("00");
+		let zeropush = hex_script!("0100");
+
+		let nonminimal = hex_script!("4c0169b2"); // PUSHDATA1 for no reason
+		let minimal = hex_script!("0169b2"); // minimal
+		let nonminimal_alt = hex_script!("026900b2"); // non-minimal number but minimal push (should be OK)
+
+		let v_zero: Result<Vec<Instruction>, Error> = zero.instructions_minimal().collect();
+		let v_zeropush: Result<Vec<Instruction>, Error> = zeropush.instructions_minimal().collect();
+
+		let v_min: Result<Vec<Instruction>, Error> = minimal.instructions_minimal().collect();
+		let v_nonmin: Result<Vec<Instruction>, Error> = nonminimal.instructions_minimal().collect();
+		let v_nonmin_alt: Result<Vec<Instruction>, Error> =
+			nonminimal_alt.instructions_minimal().collect();
+		let slop_v_min: Result<Vec<Instruction>, Error> = minimal.instructions().collect();
+		let slop_v_nonmin: Result<Vec<Instruction>, Error> = nonminimal.instructions().collect();
+		let slop_v_nonmin_alt: Result<Vec<Instruction>, Error> =
+			nonminimal_alt.instructions().collect();
+
+		assert_eq!(v_zero.unwrap(), vec![Instruction::PushBytes(&[]),]);
+		assert_eq!(v_zeropush.unwrap(), vec![Instruction::PushBytes(&[0]),]);
+
+		assert_eq!(
+			v_min.clone().unwrap(),
+			vec![Instruction::PushBytes(&[105]), Instruction::Op(opcodes::OP_NOP3),]
+		);
+
+		assert_eq!(v_nonmin.err().unwrap(), Error::NonMinimalPush);
+
+		assert_eq!(
+			v_nonmin_alt.clone().unwrap(),
+			vec![Instruction::PushBytes(&[105, 0]), Instruction::Op(opcodes::OP_NOP3),]
+		);
+
+		assert_eq!(v_min.clone().unwrap(), slop_v_min.unwrap());
+		assert_eq!(v_min.unwrap(), slop_v_nonmin.unwrap());
+		assert_eq!(v_nonmin_alt.unwrap(), slop_v_nonmin_alt.unwrap());
+	}
+
+	#[test]
+	fn script_ord() {
+		let script_1 = Builder::new().push_slice(&[1, 2, 3, 4]).into_script();
+		let script_2 = Builder::new().push_int(10).into_script();
+		let script_3 = Builder::new().push_int(15).into_script();
+		let script_4 = Builder::new().push_opcode(opcodes::all::OP_RETURN).into_script();
+
+		assert!(script_1 < script_2);
+		assert!(script_2 < script_3);
+		assert!(script_3 < script_4);
+
+		assert!(script_1 <= script_1);
+		assert!(script_1 >= script_1);
+
+		assert!(script_4 > script_3);
+		assert!(script_3 > script_2);
+		assert!(script_2 > script_1);
+	}
+
+	#[test]
+	#[cfg(feature = "bitcoinconsensus")]
+	fn test_bitcoinconsensus() {
 		// a random segwit transaction from the blockchain using native segwit
-		let spent = Builder::from(Vec::from_hex("0020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d").unwrap()).into_script();
+		let spent = Builder::from(
+			Vec::from_hex("0020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d")
+				.unwrap(),
+		)
+		.into_script();
 		let spending = Vec::from_hex("010000000001011f97548fbbe7a0db7588a66e18d803d0089315aa7d4cc28360b6ec50ef36718a0100000000ffffffff02df1776000000000017a9146c002a686959067f4866b8fb493ad7970290ab728757d29f0000000000220020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d04004730440220565d170eed95ff95027a69b313758450ba84a01224e1f7f130dda46e94d13f8602207bdd20e307f062594022f12ed5017bbf4a055a06aea91c10110a0e3bb23117fc014730440220647d2dc5b15f60bc37dc42618a370b2a1490293f9e5c8464f53ec4fe1dfe067302203598773895b4b16d37485cbe21b337f4e4b650739880098c592553add7dd4355016952210375e00eb72e29da82b89367947f29ef34afb75e8654f6ea368e0acdfd92976b7c2103a1b26313f430c4b15bb1fdce663207659d8cac749a0e53d70eff01874496feff2103c96d495bfdd5ba4145e3e046fee45e84a8a48ad05bd8dbb395c011a32cf9f88053ae00000000").unwrap();
 		spent.verify(0, ::Amount::from_sat(18393430), spending.as_slice()).unwrap();
 	}
 
-    #[cfg(any())]
-    #[test]
-    fn defult_dust_value_tests() {
-        // Check that our dust_value() calculator correctly calculates the dust limit on common
-        // well-known scriptPubKey types.
-        let script_p2wpkh = Builder::new().push_int(0).push_slice(&[42; 20]).into_script();
-        assert!(script_p2wpkh.is_v0_p2wpkh());
-        assert_eq!(script_p2wpkh.dust_value(), ::Amount::from_sat(294));
+	#[cfg(any())]
+	#[test]
+	fn defult_dust_value_tests() {
+		// Check that our dust_value() calculator correctly calculates the dust limit on common
+		// well-known scriptPubKey types.
+		let script_p2wpkh = Builder::new().push_int(0).push_slice(&[42; 20]).into_script();
+		assert!(script_p2wpkh.is_v0_p2wpkh());
+		assert_eq!(script_p2wpkh.dust_value(), ::Amount::from_sat(294));
 
-        let script_p2pkh = Builder::new()
-            .push_opcode(opcodes::all::OP_DUP)
-            .push_opcode(opcodes::all::OP_HASH160)
-            .push_slice(&[42; 20])
-            .push_opcode(opcodes::all::OP_EQUALVERIFY)
-            .push_opcode(opcodes::all::OP_CHECKSIG)
-            .into_script();
-        assert!(script_p2pkh.is_p2pkh());
-        assert_eq!(script_p2pkh.dust_value(), ::Amount::from_sat(546));
-    }
+		let script_p2pkh = Builder::new()
+			.push_opcode(opcodes::all::OP_DUP)
+			.push_opcode(opcodes::all::OP_HASH160)
+			.push_slice(&[42; 20])
+			.push_opcode(opcodes::all::OP_EQUALVERIFY)
+			.push_opcode(opcodes::all::OP_CHECKSIG)
+			.into_script();
+		assert!(script_p2pkh.is_p2pkh());
+		assert_eq!(script_p2pkh.dust_value(), ::Amount::from_sat(546));
+	}
 
-    #[test]
-    #[cfg(feature = "serde")]
-    fn test_script_serde_human_and_not() {
-        let script = Script::from(vec![0u8, 1u8, 2u8]);
+	#[test]
+	#[cfg(feature = "serde")]
+	fn test_script_serde_human_and_not() {
+		let script = Script::from(vec![0u8, 1u8, 2u8]);
 
-        // Serialize
-        let json = ::serde_json::to_string(&script).unwrap();
-        assert_eq!(json, "\"000102\"");
-        let bincode = ::bincode::serialize(&script).unwrap();
-        assert_eq!(bincode, [3, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2]); // bincode adds u64 for length, serde_cbor use varint
+		// Serialize
+		let json = ::serde_json::to_string(&script).unwrap();
+		assert_eq!(json, "\"000102\"");
+		let bincode = ::bincode::serialize(&script).unwrap();
+		assert_eq!(bincode, [3, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2]); // bincode adds u64 for length, serde_cbor use varint
 
-        // Deserialize
-        assert_eq!(script, ::serde_json::from_str(&json).unwrap());
-        assert_eq!(script, ::bincode::deserialize(&bincode).unwrap());
-    }
-
+		// Deserialize
+		assert_eq!(script, ::serde_json::from_str(&json).unwrap());
+		assert_eq!(script, ::bincode::deserialize(&bincode).unwrap());
+	}
 }

--- a/libs/chainscript/src/script.rs
+++ b/libs/chainscript/src/script.rs
@@ -15,7 +15,7 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-//! Script
+//! Script-related types and functions
 //!
 //! Scripts define Bitcoin's digital signature scheme: a signature is formed
 //! from a script (the second half of which is defined by a coin to be spent,
@@ -200,7 +200,7 @@ impl Script {
 		Builder::new()
 			.push_opcode(opcodes::all::OP_DUP)
 			.push_opcode(opcodes::all::OP_HASH160)
-			.push_slice(&pubkey_hash[..])
+			.push_slice(pubkey_hash)
 			.push_opcode(opcodes::all::OP_EQUALVERIFY)
 			.push_opcode(opcodes::all::OP_CHECKSIG)
 			.into_script()
@@ -210,7 +210,7 @@ impl Script {
 	pub fn new_p2sh(script_hash: &ScriptHash) -> Script {
 		Builder::new()
 			.push_opcode(opcodes::all::OP_HASH160)
-			.push_slice(&script_hash[..])
+			.push_slice(script_hash)
 			.push_opcode(opcodes::all::OP_EQUAL)
 			.into_script()
 	}
@@ -621,7 +621,7 @@ impl Builder {
 	/// dedicated opcodes to push some small integers.
 	pub fn push_int(self, data: i64) -> Builder {
 		// We can special-case -1, 1-16
-		if data == -1 || (data >= 1 && data <= 16) {
+		if data == -1 || (1..=16).contains(&data) {
 			let opcode = opcodes::All::from((data - 1 + opcodes::OP_TRUE.into_u8() as i64) as u8);
 			self.push_opcode(opcode)
 		}

--- a/libs/chainscript/src/script.rs
+++ b/libs/chainscript/src/script.rs
@@ -41,41 +41,41 @@ type ScriptHash = [u8];
 pub struct Script(Box<[u8]>);
 
 impl AsRef<[u8]> for Script {
-	fn as_ref(&self) -> &[u8] {
-		&self.0
-	}
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
 }
 
 impl fmt::Debug for Script {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		f.write_str("Script(")?;
-		self.fmt_asm(f)?;
-		f.write_str(")")
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("Script(")?;
+        self.fmt_asm(f)?;
+        f.write_str(")")
+    }
 }
 
 impl fmt::Display for Script {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		fmt::Debug::fmt(self, f)
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
 }
 
 impl fmt::LowerHex for Script {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		for &ch in self.0.iter() {
-			write!(f, "{:02x}", ch)?;
-		}
-		Ok(())
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for &ch in self.0.iter() {
+            write!(f, "{:02x}", ch)?;
+        }
+        Ok(())
+    }
 }
 
 impl fmt::UpperHex for Script {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		for &ch in self.0.iter() {
-			write!(f, "{:02X}", ch)?;
-		}
-		Ok(())
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for &ch in self.0.iter() {
+            write!(f, "{:02X}", ch)?;
+        }
+        Ok(())
+    }
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -84,30 +84,30 @@ pub struct Builder(Vec<u8>, Option<opcodes::All>);
 display_from_debug!(Builder);
 /// Helper to encode an integer in script format
 pub fn build_scriptint(n: i64) -> Vec<u8> {
-	if n == 0 {
-		return vec![]
-	}
+    if n == 0 {
+        return vec![];
+    }
 
-	let neg = n < 0;
+    let neg = n < 0;
 
-	let mut abs = if neg { -n } else { n } as usize;
-	let mut v = vec![];
-	while abs > 0xFF {
-		v.push((abs & 0xFF) as u8);
-		abs >>= 8;
-	}
-	// If the number's value causes the sign bit to be set, we need an extra
-	// byte to get the correct value and correct sign bit
-	if abs & 0x80 != 0 {
-		v.push(abs as u8);
-		v.push(if neg { 0x80u8 } else { 0u8 });
-	}
-	// Otherwise we just set the sign bit ourselves
-	else {
-		abs |= if neg { 0x80 } else { 0 };
-		v.push(abs as u8);
-	}
-	v
+    let mut abs = if neg { -n } else { n } as usize;
+    let mut v = vec![];
+    while abs > 0xFF {
+        v.push((abs & 0xFF) as u8);
+        abs >>= 8;
+    }
+    // If the number's value causes the sign bit to be set, we need an extra
+    // byte to get the correct value and correct sign bit
+    if abs & 0x80 != 0 {
+        v.push(abs as u8);
+        v.push(if neg { 0x80u8 } else { 0u8 });
+    }
+    // Otherwise we just set the sign bit ourselves
+    else {
+        abs |= if neg { 0x80 } else { 0 };
+        v.push(abs as u8);
+    }
+    v
 }
 
 /// Helper to decode an integer in script format
@@ -125,152 +125,152 @@ pub fn build_scriptint(n: i64) -> Vec<u8> {
 /// simply say, anything in excess of 32 bits is no longer a number.
 /// This is basically a ranged type implementation.
 pub fn read_scriptint(v: &[u8]) -> Result<i64, Error> {
-	let len = v.len();
-	if len == 0 {
-		return Ok(0)
-	}
-	if len > 4 {
-		return Err(Error::NumericOverflow)
-	}
+    let len = v.len();
+    if len == 0 {
+        return Ok(0);
+    }
+    if len > 4 {
+        return Err(Error::NumericOverflow);
+    }
 
-	let (mut ret, sh) = v.iter().fold((0, 0), |(acc, sh), n| (acc + ((*n as i64) << sh), sh + 8));
-	if v[len - 1] & 0x80 != 0 {
-		ret &= (1 << (sh - 1)) - 1;
-		ret = -ret;
-	}
-	Ok(ret)
+    let (mut ret, sh) = v.iter().fold((0, 0), |(acc, sh), n| (acc + ((*n as i64) << sh), sh + 8));
+    if v[len - 1] & 0x80 != 0 {
+        ret &= (1 << (sh - 1)) - 1;
+        ret = -ret;
+    }
+    Ok(ret)
 }
 
 /// This is like "`read_scriptint` then map 0 to false and everything
 /// else as true", except that the overflow rules don't apply.
 #[inline]
 pub fn read_scriptbool(v: &[u8]) -> bool {
-	!(v.is_empty() ||
-		((v[v.len() - 1] == 0 || v[v.len() - 1] == 0x80) &&
-			v.iter().rev().skip(1).all(|&w| w == 0)))
+    !(v.is_empty()
+        || ((v[v.len() - 1] == 0 || v[v.len() - 1] == 0x80)
+            && v.iter().rev().skip(1).all(|&w| w == 0)))
 }
 
 /// Read a script-encoded unsigned integer
 pub fn read_uint(data: &[u8], size: usize) -> Result<usize, Error> {
-	if data.len() < size {
-		Err(Error::EarlyEndOfScript)
-	} else {
-		let mut ret = 0;
-		for (i, item) in data.iter().take(size).enumerate() {
-			ret += (*item as usize) << (i * 8);
-		}
-		Ok(ret)
-	}
+    if data.len() < size {
+        Err(Error::EarlyEndOfScript)
+    } else {
+        let mut ret = 0;
+        for (i, item) in data.iter().take(size).enumerate() {
+            ret += (*item as usize) << (i * 8);
+        }
+        Ok(ret)
+    }
 }
 
 impl Script {
-	/// Creates a new empty script
-	pub fn new() -> Script {
-		Script(vec![].into_boxed_slice())
-	}
+    /// Creates a new empty script
+    pub fn new() -> Script {
+        Script(vec![].into_boxed_slice())
+    }
 
-	/// Generates P2PK-type of scriptPubkey
-	pub fn new_p2pk(pubkey: &[u8]) -> Script {
-		Builder::new()
-			.push_slice(pubkey)
-			.push_opcode(opcodes::all::OP_CHECKSIG)
-			.into_script()
-	}
+    /// Generates P2PK-type of scriptPubkey
+    pub fn new_p2pk(pubkey: &[u8]) -> Script {
+        Builder::new()
+            .push_slice(pubkey)
+            .push_opcode(opcodes::all::OP_CHECKSIG)
+            .into_script()
+    }
 
-	/// Generates P2PKH-type of scriptPubkey
-	pub fn new_p2pkh(pubkey_hash: &PubkeyHash) -> Script {
-		Builder::new()
-			.push_opcode(opcodes::all::OP_DUP)
-			.push_opcode(opcodes::all::OP_HASH160)
-			.push_slice(pubkey_hash)
-			.push_opcode(opcodes::all::OP_EQUALVERIFY)
-			.push_opcode(opcodes::all::OP_CHECKSIG)
-			.into_script()
-	}
+    /// Generates P2PKH-type of scriptPubkey
+    pub fn new_p2pkh(pubkey_hash: &PubkeyHash) -> Script {
+        Builder::new()
+            .push_opcode(opcodes::all::OP_DUP)
+            .push_opcode(opcodes::all::OP_HASH160)
+            .push_slice(pubkey_hash)
+            .push_opcode(opcodes::all::OP_EQUALVERIFY)
+            .push_opcode(opcodes::all::OP_CHECKSIG)
+            .into_script()
+    }
 
-	/// Generates P2SH-type of scriptPubkey with a given hash of the redeem script
-	pub fn new_p2sh(script_hash: &ScriptHash) -> Script {
-		Builder::new()
-			.push_opcode(opcodes::all::OP_HASH160)
-			.push_slice(script_hash)
-			.push_opcode(opcodes::all::OP_EQUAL)
-			.into_script()
-	}
+    /// Generates P2SH-type of scriptPubkey with a given hash of the redeem script
+    pub fn new_p2sh(script_hash: &ScriptHash) -> Script {
+        Builder::new()
+            .push_opcode(opcodes::all::OP_HASH160)
+            .push_slice(script_hash)
+            .push_opcode(opcodes::all::OP_EQUAL)
+            .into_script()
+    }
 
-	/// Generates OP_RETURN-type of scriptPubkey for a given data
-	pub fn new_op_return(data: &[u8]) -> Script {
-		Builder::new()
-			.push_opcode(opcodes::all::OP_RETURN)
-			.push_slice(data)
-			.into_script()
-	}
+    /// Generates OP_RETURN-type of scriptPubkey for a given data
+    pub fn new_op_return(data: &[u8]) -> Script {
+        Builder::new()
+            .push_opcode(opcodes::all::OP_RETURN)
+            .push_slice(data)
+            .into_script()
+    }
 
-	/// The length in bytes of the script
-	pub fn len(&self) -> usize {
-		self.0.len()
-	}
+    /// The length in bytes of the script
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
 
-	/// Whether the script is the empty script
-	pub fn is_empty(&self) -> bool {
-		self.0.is_empty()
-	}
+    /// Whether the script is the empty script
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 
-	/// Returns the script data
-	pub fn as_bytes(&self) -> &[u8] {
-		&*self.0
-	}
+    /// Returns the script data
+    pub fn as_bytes(&self) -> &[u8] {
+        &*self.0
+    }
 
-	/// Returns a copy of the script data
-	pub fn to_bytes(&self) -> Vec<u8> {
-		self.0.clone().into_vec()
-	}
+    /// Returns a copy of the script data
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0.clone().into_vec()
+    }
 
-	/// Convert the script into a byte vector
-	pub fn into_bytes(self) -> Vec<u8> {
-		self.0.into_vec()
-	}
+    /// Convert the script into a byte vector
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0.into_vec()
+    }
 
-	/// Checks whether a script pubkey is a p2sh output
-	#[inline]
-	pub fn is_p2sh(&self) -> bool {
-		self.0.len() == 23 &&
-			self.0[0] == opcodes::all::OP_HASH160.into_u8() &&
-			self.0[1] == opcodes::all::OP_PUSHBYTES_20.into_u8() &&
-			self.0[22] == opcodes::all::OP_EQUAL.into_u8()
-	}
+    /// Checks whether a script pubkey is a p2sh output
+    #[inline]
+    pub fn is_p2sh(&self) -> bool {
+        self.0.len() == 23
+            && self.0[0] == opcodes::all::OP_HASH160.into_u8()
+            && self.0[1] == opcodes::all::OP_PUSHBYTES_20.into_u8()
+            && self.0[22] == opcodes::all::OP_EQUAL.into_u8()
+    }
 
-	/// Checks whether a script pubkey is a p2pkh output
-	#[inline]
-	pub fn is_p2pkh(&self) -> bool {
-		self.0.len() == 25 &&
-			self.0[0] == opcodes::all::OP_DUP.into_u8() &&
-			self.0[1] == opcodes::all::OP_HASH160.into_u8() &&
-			self.0[2] == opcodes::all::OP_PUSHBYTES_20.into_u8() &&
-			self.0[23] == opcodes::all::OP_EQUALVERIFY.into_u8() &&
-			self.0[24] == opcodes::all::OP_CHECKSIG.into_u8()
-	}
+    /// Checks whether a script pubkey is a p2pkh output
+    #[inline]
+    pub fn is_p2pkh(&self) -> bool {
+        self.0.len() == 25
+            && self.0[0] == opcodes::all::OP_DUP.into_u8()
+            && self.0[1] == opcodes::all::OP_HASH160.into_u8()
+            && self.0[2] == opcodes::all::OP_PUSHBYTES_20.into_u8()
+            && self.0[23] == opcodes::all::OP_EQUALVERIFY.into_u8()
+            && self.0[24] == opcodes::all::OP_CHECKSIG.into_u8()
+    }
 
-	/// Checks whether a script pubkey is a p2pk output
-	#[inline]
-	pub fn is_p2pk(&self) -> bool {
-		(self.0.len() == 67 &&
-			self.0[0] == opcodes::all::OP_PUSHBYTES_65.into_u8() &&
-			self.0[66] == opcodes::all::OP_CHECKSIG.into_u8()) ||
-			(self.0.len() == 35 &&
-				self.0[0] == opcodes::all::OP_PUSHBYTES_33.into_u8() &&
-				self.0[34] == opcodes::all::OP_CHECKSIG.into_u8())
-	}
+    /// Checks whether a script pubkey is a p2pk output
+    #[inline]
+    pub fn is_p2pk(&self) -> bool {
+        (self.0.len() == 67
+            && self.0[0] == opcodes::all::OP_PUSHBYTES_65.into_u8()
+            && self.0[66] == opcodes::all::OP_CHECKSIG.into_u8())
+            || (self.0.len() == 35
+                && self.0[0] == opcodes::all::OP_PUSHBYTES_33.into_u8()
+                && self.0[34] == opcodes::all::OP_CHECKSIG.into_u8())
+    }
 
-	/// Checks whether a script pubkey is a Segregated Witness (segwit) program.
-	#[inline]
-	pub fn is_witness_program(&self) -> bool {
-		// A scriptPubKey (or redeemScript as defined in BIP16/P2SH) that consists of a 1-byte
-		// push opcode (for 0 to 16) followed by a data push between 2 and 40 bytes gets a new
-		// special meaning. The value of the first push is called the "version byte". The following
-		// byte vector pushed is called the "witness program".
-		let min_vernum: u8 = opcodes::all::OP_PUSHNUM_1.into_u8();
-		let max_vernum: u8 = opcodes::all::OP_PUSHNUM_16.into_u8();
-		self.0.len() >= 4
+    /// Checks whether a script pubkey is a Segregated Witness (segwit) program.
+    #[inline]
+    pub fn is_witness_program(&self) -> bool {
+        // A scriptPubKey (or redeemScript as defined in BIP16/P2SH) that consists of a 1-byte
+        // push opcode (for 0 to 16) followed by a data push between 2 and 40 bytes gets a new
+        // special meaning. The value of the first push is called the "version byte". The following
+        // byte vector pushed is called the "witness program".
+        let min_vernum: u8 = opcodes::all::OP_PUSHNUM_1.into_u8();
+        let max_vernum: u8 = opcodes::all::OP_PUSHNUM_16.into_u8();
+        self.0.len() >= 4
             && self.0.len() <= 42
             // Version 0 or PUSHNUM_1-PUSHNUM_16
             && (self.0[0] == 0 || self.0[0] >= min_vernum && self.0[0] <= max_vernum)
@@ -279,139 +279,139 @@ impl Script {
             && self.0[1] <= opcodes::all::OP_PUSHBYTES_40.into_u8()
             // Check that the rest of the script has the correct size
             && self.0.len() - 2 == self.0[1] as usize
-	}
+    }
 
-	/// Checks whether a script pubkey is a p2wsh output
-	#[inline]
-	pub fn is_v0_p2wsh(&self) -> bool {
-		self.0.len() == 34 &&
-			self.0[0] == opcodes::all::OP_PUSHBYTES_0.into_u8() &&
-			self.0[1] == opcodes::all::OP_PUSHBYTES_32.into_u8()
-	}
+    /// Checks whether a script pubkey is a p2wsh output
+    #[inline]
+    pub fn is_v0_p2wsh(&self) -> bool {
+        self.0.len() == 34
+            && self.0[0] == opcodes::all::OP_PUSHBYTES_0.into_u8()
+            && self.0[1] == opcodes::all::OP_PUSHBYTES_32.into_u8()
+    }
 
-	/// Checks whether a script pubkey is a p2wpkh output
-	#[inline]
-	pub fn is_v0_p2wpkh(&self) -> bool {
-		self.0.len() == 22 &&
-			self.0[0] == opcodes::all::OP_PUSHBYTES_0.into_u8() &&
-			self.0[1] == opcodes::all::OP_PUSHBYTES_20.into_u8()
-	}
+    /// Checks whether a script pubkey is a p2wpkh output
+    #[inline]
+    pub fn is_v0_p2wpkh(&self) -> bool {
+        self.0.len() == 22
+            && self.0[0] == opcodes::all::OP_PUSHBYTES_0.into_u8()
+            && self.0[1] == opcodes::all::OP_PUSHBYTES_20.into_u8()
+    }
 
-	/// Check if this is an OP_RETURN output
-	pub fn is_op_return(&self) -> bool {
-		!self.0.is_empty() && (opcodes::All::from(self.0[0]) == opcodes::all::OP_RETURN)
-	}
+    /// Check if this is an OP_RETURN output
+    pub fn is_op_return(&self) -> bool {
+        !self.0.is_empty() && (opcodes::All::from(self.0[0]) == opcodes::all::OP_RETURN)
+    }
 
-	/// Whether a script can be proven to have no satisfying input
-	pub fn is_provably_unspendable(&self) -> bool {
-		!self.0.is_empty() &&
-			(opcodes::All::from(self.0[0]).classify() == opcodes::Class::ReturnOp ||
-				opcodes::All::from(self.0[0]).classify() == opcodes::Class::IllegalOp)
-	}
+    /// Whether a script can be proven to have no satisfying input
+    pub fn is_provably_unspendable(&self) -> bool {
+        !self.0.is_empty()
+            && (opcodes::All::from(self.0[0]).classify() == opcodes::Class::ReturnOp
+                || opcodes::All::from(self.0[0]).classify() == opcodes::Class::IllegalOp)
+    }
 
-	/// Iterate over the script in the form of `Instruction`s, which are an enum covering
-	/// opcodes, datapushes and errors. At most one error will be returned and then the
-	/// iterator will end. To instead iterate over the script as sequence of bytes, treat
-	/// it as a slice using `script[..]` or convert it to a vector using `into_bytes()`.
-	///
-	/// To force minimal pushes, use [Self::instructions_minimal].
-	pub fn instructions(&self) -> Instructions {
-		self.instructions_iter(false)
-	}
+    /// Iterate over the script in the form of `Instruction`s, which are an enum covering
+    /// opcodes, datapushes and errors. At most one error will be returned and then the
+    /// iterator will end. To instead iterate over the script as sequence of bytes, treat
+    /// it as a slice using `script[..]` or convert it to a vector using `into_bytes()`.
+    ///
+    /// To force minimal pushes, use [Self::instructions_minimal].
+    pub fn instructions(&self) -> Instructions {
+        self.instructions_iter(false)
+    }
 
-	/// Iterate over the script in the form of `Instruction`s while enforcing
-	/// minimal pushes.
-	pub fn instructions_minimal(&self) -> Instructions {
-		self.instructions_iter(true)
-	}
+    /// Iterate over the script in the form of `Instruction`s while enforcing
+    /// minimal pushes.
+    pub fn instructions_minimal(&self) -> Instructions {
+        self.instructions_iter(true)
+    }
 
-	/// See [Script::instructions] and [Script::instructions_minimal].
-	pub fn instructions_iter(&self, enforce_minimal: bool) -> Instructions {
-		Instructions::new(&self.0[..], enforce_minimal)
-	}
+    /// See [Script::instructions] and [Script::instructions_minimal].
+    pub fn instructions_iter(&self, enforce_minimal: bool) -> Instructions {
+        Instructions::new(&self.0[..], enforce_minimal)
+    }
 
-	/// Write the assembly decoding of the script bytes to the formatter.
-	pub fn bytes_to_asm_fmt(script: &[u8], f: &mut dyn fmt::Write) -> fmt::Result {
-		let mut index = 0;
-		while index < script.len() {
-			let opcode = opcodes::All::from(script[index]);
-			index += 1;
+    /// Write the assembly decoding of the script bytes to the formatter.
+    pub fn bytes_to_asm_fmt(script: &[u8], f: &mut dyn fmt::Write) -> fmt::Result {
+        let mut index = 0;
+        while index < script.len() {
+            let opcode = opcodes::All::from(script[index]);
+            index += 1;
 
-			let data_len = if let opcodes::Class::PushBytes(n) = opcode.classify() {
-				n as usize
-			} else {
-				match opcode.classify() {
-					opcodes::Class::PushData(push_opc) => {
-						if script.len() < index + push_opc.data_size_bytes() {
-							f.write_str("<unexpected end>")?;
-							break
-						}
-						match read_uint(&script[index..], 1) {
-							Ok(n) => {
-								index += push_opc.data_size_bytes();
-								n as usize
-							},
-							Err(_) => {
-								f.write_str("<bad length>")?;
-								break
-							},
-						}
-					},
-					_ => 0,
-				}
-			};
+            let data_len = if let opcodes::Class::PushBytes(n) = opcode.classify() {
+                n as usize
+            } else {
+                match opcode.classify() {
+                    opcodes::Class::PushData(push_opc) => {
+                        if script.len() < index + push_opc.data_size_bytes() {
+                            f.write_str("<unexpected end>")?;
+                            break;
+                        }
+                        match read_uint(&script[index..], 1) {
+                            Ok(n) => {
+                                index += push_opc.data_size_bytes();
+                                n as usize
+                            }
+                            Err(_) => {
+                                f.write_str("<bad length>")?;
+                                break;
+                            }
+                        }
+                    }
+                    _ => 0,
+                }
+            };
 
-			if index > 1 {
-				f.write_str(" ")?;
-			}
-			// Write the opcode
-			if opcode == opcodes::all::OP_PUSHBYTES_0 {
-				f.write_str("OP_0")?;
-			} else {
-				write!(f, "{:?}", opcode)?;
-			}
-			// Write any pushdata
-			if data_len > 0 {
-				f.write_str(" ")?;
-				if index + data_len <= script.len() {
-					for ch in &script[index..index + data_len] {
-						write!(f, "{:02x}", ch)?;
-					}
-					index += data_len;
-				} else {
-					f.write_str("<push past end>")?;
-					break
-				}
-			}
-		}
-		Ok(())
-	}
+            if index > 1 {
+                f.write_str(" ")?;
+            }
+            // Write the opcode
+            if opcode == opcodes::all::OP_PUSHBYTES_0 {
+                f.write_str("OP_0")?;
+            } else {
+                write!(f, "{:?}", opcode)?;
+            }
+            // Write any pushdata
+            if data_len > 0 {
+                f.write_str(" ")?;
+                if index + data_len <= script.len() {
+                    for ch in &script[index..index + data_len] {
+                        write!(f, "{:02x}", ch)?;
+                    }
+                    index += data_len;
+                } else {
+                    f.write_str("<push past end>")?;
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
 
-	/// Write the assembly decoding of the script to the formatter.
-	pub fn fmt_asm(&self, f: &mut dyn fmt::Write) -> fmt::Result {
-		Script::bytes_to_asm_fmt(self.as_ref(), f)
-	}
+    /// Write the assembly decoding of the script to the formatter.
+    pub fn fmt_asm(&self, f: &mut dyn fmt::Write) -> fmt::Result {
+        Script::bytes_to_asm_fmt(self.as_ref(), f)
+    }
 
-	/// Create an assembly decoding of the script in the given byte slice.
-	#[cfg(feature = "std")]
-	pub fn bytes_to_asm(script: &[u8]) -> String {
-		let mut buf = String::new();
-		Script::bytes_to_asm_fmt(script, &mut buf).unwrap();
-		buf
-	}
+    /// Create an assembly decoding of the script in the given byte slice.
+    #[cfg(feature = "std")]
+    pub fn bytes_to_asm(script: &[u8]) -> String {
+        let mut buf = String::new();
+        Script::bytes_to_asm_fmt(script, &mut buf).unwrap();
+        buf
+    }
 
-	/// Get the assembly decoding of the script.
-	#[cfg(feature = "std")]
-	pub fn asm(&self) -> String {
-		Script::bytes_to_asm(self.as_ref())
-	}
+    /// Get the assembly decoding of the script.
+    #[cfg(feature = "std")]
+    pub fn asm(&self) -> String {
+        Script::bytes_to_asm(self.as_ref())
+    }
 }
 
 /// Creates a new script from an existing vector
 impl From<Vec<u8>> for Script {
-	fn from(v: Vec<u8>) -> Script {
-		Script(v.into_boxed_slice())
-	}
+    fn from(v: Vec<u8>) -> Script {
+        Script(v.into_boxed_slice())
+    }
 }
 
 impl_index_newtype!(Script, u8);
@@ -419,614 +419,625 @@ impl_index_newtype!(Script, u8);
 /// A "parsed opcode" which allows iterating over a Script in a more sensible way
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Instruction<'a> {
-	/// Push a bunch of data
-	PushBytes(&'a [u8]),
-	/// Some non-push opcode
-	Op(opcodes::All),
+    /// Push a bunch of data
+    PushBytes(&'a [u8]),
+    /// Some non-push opcode
+    Op(opcodes::All),
 }
 
 /// Iterator over a script returning parsed opcodes
 pub struct Instructions<'a> {
-	data: &'a [u8],
-	cur_subscript: &'a [u8],
-	enforce_minimal: bool,
+    data: &'a [u8],
+    cur_subscript: &'a [u8],
+    enforce_minimal: bool,
 }
 
 impl<'a> Instructions<'a> {
-	fn new(data: &'a [u8], enforce_minimal: bool) -> Self {
-		Instructions { data, cur_subscript: data, enforce_minimal }
-	}
+    fn new(data: &'a [u8], enforce_minimal: bool) -> Self {
+        Instructions {
+            data,
+            cur_subscript: data,
+            enforce_minimal,
+        }
+    }
 
-	// Kill iterator so that it does not return an infinite stream of errors
-	// and return an error.
-	fn kill(&mut self, e: Error) -> Option<<Self as Iterator>::Item> {
-		self.data = &[];
-		Some(Err(e))
-	}
+    // Kill iterator so that it does not return an infinite stream of errors
+    // and return an error.
+    fn kill(&mut self, e: Error) -> Option<<Self as Iterator>::Item> {
+        self.data = &[];
+        Some(Err(e))
+    }
 
-	// Extract the script remainder
-	pub fn subscript(&self) -> &'a [u8] {
-		self.cur_subscript
-	}
+    // Extract the script remainder
+    pub fn subscript(&self) -> &'a [u8] {
+        self.cur_subscript
+    }
 }
 
 impl<'a> Iterator for Instructions<'a> {
-	type Item = Result<Instruction<'a>, Error>;
+    type Item = Result<Instruction<'a>, Error>;
 
-	fn next(&mut self) -> Option<Result<Instruction<'a>, Error>> {
-		self.cur_subscript = self.data;
-		if self.data.is_empty() {
-			return None
-		}
+    fn next(&mut self) -> Option<Result<Instruction<'a>, Error>> {
+        self.cur_subscript = self.data;
+        if self.data.is_empty() {
+            return None;
+        }
 
-		match opcodes::All::from(self.data[0]).classify() {
-			opcodes::Class::PushBytes(n) => {
-				let n = n as usize;
-				if self.data.len() < n + 1 {
-					return self.kill(Error::EarlyEndOfScript)
-				}
-				if self.enforce_minimal &&
-					n == 1 && (self.data[1] == 0x81 || (self.data[1] > 0 && self.data[1] <= 16))
-				{
-					return self.kill(Error::NonMinimalPush)
-				}
-				let ret = Some(Ok(Instruction::PushBytes(&self.data[1..n + 1])));
-				self.data = &self.data[n + 1..];
-				ret
-			},
-			opcodes::Class::PushData(push_op) => {
-				let size_bytes = push_op.data_size_bytes();
-				let data = self.data;
-				if data.len() < size_bytes + 1 {
-					return self.kill(Error::EarlyEndOfScript)
-				}
-				let n = match read_uint(&data[1..], size_bytes) {
-					Ok(n) => n,
-					Err(e) => return self.kill(e),
-				};
-				let data = &data[(size_bytes + 1)..];
-				if data.len() < n {
-					return self.kill(Error::EarlyEndOfScript)
-				}
-				if self.enforce_minimal && n < push_op.data_size_min() {
-					return self.kill(Error::NonMinimalPush)
-				}
-				let (push, rest) = data.split_at(n);
-				self.data = rest;
-				Some(Ok(Instruction::PushBytes(push)))
-			},
-			// Everything else we can push right through
-			_ => {
-				let ret = Some(Ok(Instruction::Op(opcodes::All::from(self.data[0]))));
-				self.data = &self.data[1..];
-				ret
-			},
-		}
-	}
+        match opcodes::All::from(self.data[0]).classify() {
+            opcodes::Class::PushBytes(n) => {
+                let n = n as usize;
+                if self.data.len() < n + 1 {
+                    return self.kill(Error::EarlyEndOfScript);
+                }
+                if self.enforce_minimal
+                    && n == 1
+                    && (self.data[1] == 0x81 || (self.data[1] > 0 && self.data[1] <= 16))
+                {
+                    return self.kill(Error::NonMinimalPush);
+                }
+                let ret = Some(Ok(Instruction::PushBytes(&self.data[1..n + 1])));
+                self.data = &self.data[n + 1..];
+                ret
+            }
+            opcodes::Class::PushData(push_op) => {
+                let size_bytes = push_op.data_size_bytes();
+                let data = self.data;
+                if data.len() < size_bytes + 1 {
+                    return self.kill(Error::EarlyEndOfScript);
+                }
+                let n = match read_uint(&data[1..], size_bytes) {
+                    Ok(n) => n,
+                    Err(e) => return self.kill(e),
+                };
+                let data = &data[(size_bytes + 1)..];
+                if data.len() < n {
+                    return self.kill(Error::EarlyEndOfScript);
+                }
+                if self.enforce_minimal && n < push_op.data_size_min() {
+                    return self.kill(Error::NonMinimalPush);
+                }
+                let (push, rest) = data.split_at(n);
+                self.data = rest;
+                Some(Ok(Instruction::PushBytes(push)))
+            }
+            // Everything else we can push right through
+            _ => {
+                let ret = Some(Ok(Instruction::Op(opcodes::All::from(self.data[0]))));
+                self.data = &self.data[1..];
+                ret
+            }
+        }
+    }
 }
 
 impl Builder {
-	/// Creates a new empty script
-	pub fn new() -> Self {
-		Builder(vec![], None)
-	}
+    /// Creates a new empty script
+    pub fn new() -> Self {
+        Builder(vec![], None)
+    }
 
-	/// The length in bytes of the script
-	pub fn len(&self) -> usize {
-		self.0.len()
-	}
+    /// The length in bytes of the script
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
 
-	/// Whether the script is the empty script
-	pub fn is_empty(&self) -> bool {
-		self.0.is_empty()
-	}
+    /// Whether the script is the empty script
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 
-	/// Adds instructions to push an integer onto the stack. Integers are
-	/// encoded as little-endian signed-magnitude numbers, but there are
-	/// dedicated opcodes to push some small integers.
-	pub fn push_int(self, data: i64) -> Builder {
-		// We can special-case -1, 1-16
-		if data == -1 || (1..=16).contains(&data) {
-			let opcode = opcodes::All::from((data - 1 + opcodes::OP_TRUE.into_u8() as i64) as u8);
-			self.push_opcode(opcode)
-		}
-		// We can also special-case zero
-		else if data == 0 {
-			self.push_opcode(opcodes::OP_FALSE)
-		}
-		// Otherwise encode it as data
-		else {
-			self.push_scriptint(data)
-		}
-	}
+    /// Adds instructions to push an integer onto the stack. Integers are
+    /// encoded as little-endian signed-magnitude numbers, but there are
+    /// dedicated opcodes to push some small integers.
+    pub fn push_int(self, data: i64) -> Builder {
+        // We can special-case -1, 1-16
+        if data == -1 || (1..=16).contains(&data) {
+            let opcode = opcodes::All::from((data - 1 + opcodes::OP_TRUE.into_u8() as i64) as u8);
+            self.push_opcode(opcode)
+        }
+        // We can also special-case zero
+        else if data == 0 {
+            self.push_opcode(opcodes::OP_FALSE)
+        }
+        // Otherwise encode it as data
+        else {
+            self.push_scriptint(data)
+        }
+    }
 
-	/// Adds instructions to push an integer onto the stack, using the explicit
-	/// encoding regardless of the availability of dedicated opcodes.
-	pub fn push_scriptint(self, data: i64) -> Builder {
-		self.push_slice(&build_scriptint(data))
-	}
+    /// Adds instructions to push an integer onto the stack, using the explicit
+    /// encoding regardless of the availability of dedicated opcodes.
+    pub fn push_scriptint(self, data: i64) -> Builder {
+        self.push_slice(&build_scriptint(data))
+    }
 
-	/// Adds instructions to push some arbitrary data onto the stack
-	pub fn push_slice(mut self, data: &[u8]) -> Builder {
-		// Start with a PUSH opcode
-		match data.len() as u64 {
-			n if n < opcodes::PushData::OP_PUSHDATA1 as u64 => {
-				self.0.push(n as u8);
-			},
-			n if n < 0x100 => {
-				self.0.push(opcodes::PushData::OP_PUSHDATA1 as u8);
-				self.0.push(n as u8);
-			},
-			n if n < 0x10000 => {
-				self.0.push(opcodes::PushData::OP_PUSHDATA2 as u8);
-				self.0.push((n % 0x100) as u8);
-				self.0.push((n / 0x100) as u8);
-			},
-			n if n < 0x100000000 => {
-				self.0.push(opcodes::PushData::OP_PUSHDATA4 as u8);
-				self.0.push((n % 0x100) as u8);
-				self.0.push(((n / 0x100) % 0x100) as u8);
-				self.0.push(((n / 0x10000) % 0x100) as u8);
-				self.0.push((n / 0x1000000) as u8);
-			},
-			_ => panic!("tried to put a 4bn+ sized object into a script!"),
-		}
-		// Then push the raw bytes
-		self.0.extend(data.iter().cloned());
-		self.1 = None;
-		self
-	}
+    /// Adds instructions to push some arbitrary data onto the stack
+    pub fn push_slice(mut self, data: &[u8]) -> Builder {
+        // Start with a PUSH opcode
+        match data.len() as u64 {
+            n if n < opcodes::PushData::OP_PUSHDATA1 as u64 => {
+                self.0.push(n as u8);
+            }
+            n if n < 0x100 => {
+                self.0.push(opcodes::PushData::OP_PUSHDATA1 as u8);
+                self.0.push(n as u8);
+            }
+            n if n < 0x10000 => {
+                self.0.push(opcodes::PushData::OP_PUSHDATA2 as u8);
+                self.0.push((n % 0x100) as u8);
+                self.0.push((n / 0x100) as u8);
+            }
+            n if n < 0x100000000 => {
+                self.0.push(opcodes::PushData::OP_PUSHDATA4 as u8);
+                self.0.push((n % 0x100) as u8);
+                self.0.push(((n / 0x100) % 0x100) as u8);
+                self.0.push(((n / 0x10000) % 0x100) as u8);
+                self.0.push((n / 0x1000000) as u8);
+            }
+            _ => panic!("tried to put a 4bn+ sized object into a script!"),
+        }
+        // Then push the raw bytes
+        self.0.extend(data.iter().cloned());
+        self.1 = None;
+        self
+    }
 
-	/// Adds a single opcode to the script
-	pub fn push_opcode(mut self, data: opcodes::All) -> Builder {
-		self.0.push(data.into_u8());
-		self.1 = Some(data);
-		self
-	}
+    /// Adds a single opcode to the script
+    pub fn push_opcode(mut self, data: opcodes::All) -> Builder {
+        self.0.push(data.into_u8());
+        self.1 = Some(data);
+        self
+    }
 
-	/// Adds an `OP_VERIFY` to the script, unless the most-recently-added
-	/// opcode has an alternate `VERIFY` form, in which case that opcode
-	/// is replaced. e.g. `OP_CHECKSIG` will become `OP_CHECKSIGVERIFY`.
-	pub fn push_verify(mut self) -> Builder {
-		match self.1 {
-			Some(opcodes::all::OP_EQUAL) => {
-				self.0.pop();
-				self.push_opcode(opcodes::all::OP_EQUALVERIFY)
-			},
-			Some(opcodes::all::OP_NUMEQUAL) => {
-				self.0.pop();
-				self.push_opcode(opcodes::all::OP_NUMEQUALVERIFY)
-			},
-			Some(opcodes::all::OP_CHECKSIG) => {
-				self.0.pop();
-				self.push_opcode(opcodes::all::OP_CHECKSIGVERIFY)
-			},
-			Some(opcodes::all::OP_CHECKMULTISIG) => {
-				self.0.pop();
-				self.push_opcode(opcodes::all::OP_CHECKMULTISIGVERIFY)
-			},
-			_ => self.push_opcode(opcodes::all::OP_VERIFY),
-		}
-	}
+    /// Adds an `OP_VERIFY` to the script, unless the most-recently-added
+    /// opcode has an alternate `VERIFY` form, in which case that opcode
+    /// is replaced. e.g. `OP_CHECKSIG` will become `OP_CHECKSIGVERIFY`.
+    pub fn push_verify(mut self) -> Builder {
+        match self.1 {
+            Some(opcodes::all::OP_EQUAL) => {
+                self.0.pop();
+                self.push_opcode(opcodes::all::OP_EQUALVERIFY)
+            }
+            Some(opcodes::all::OP_NUMEQUAL) => {
+                self.0.pop();
+                self.push_opcode(opcodes::all::OP_NUMEQUALVERIFY)
+            }
+            Some(opcodes::all::OP_CHECKSIG) => {
+                self.0.pop();
+                self.push_opcode(opcodes::all::OP_CHECKSIGVERIFY)
+            }
+            Some(opcodes::all::OP_CHECKMULTISIG) => {
+                self.0.pop();
+                self.push_opcode(opcodes::all::OP_CHECKMULTISIGVERIFY)
+            }
+            _ => self.push_opcode(opcodes::all::OP_VERIFY),
+        }
+    }
 
-	/// Converts the `Builder` into an unmodifiable `Script`
-	pub fn into_script(self) -> Script {
-		Script(self.0.into_boxed_slice())
-	}
+    /// Converts the `Builder` into an unmodifiable `Script`
+    pub fn into_script(self) -> Script {
+        Script(self.0.into_boxed_slice())
+    }
 }
 
 /// Adds an individual opcode to the script
 impl Default for Builder {
-	fn default() -> Builder {
-		Builder::new()
-	}
+    fn default() -> Builder {
+        Builder::new()
+    }
 }
 
 /// Creates a new script from an existing vector
 impl From<Vec<u8>> for Builder {
-	fn from(v: Vec<u8>) -> Builder {
-		let script = Script(v.into_boxed_slice());
-		let last_op = match script.instructions().last() {
-			Some(Ok(Instruction::Op(op))) => Some(op),
-			_ => None,
-		};
-		Builder(script.into_bytes(), last_op)
-	}
+    fn from(v: Vec<u8>) -> Builder {
+        let script = Script(v.into_boxed_slice());
+        let last_op = match script.instructions().last() {
+            Some(Ok(Instruction::Op(op))) => Some(op),
+            _ => None,
+        };
+        Builder(script.into_bytes(), last_op)
+    }
 }
 
 impl_index_newtype!(Builder, u8);
 
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Script {
-	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-	where
-		D: serde::Deserializer<'de>,
-	{
-		use core::fmt::Formatter;
-		use hashes::hex::FromHex;
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use core::fmt::Formatter;
+        use hashes::hex::FromHex;
 
-		if deserializer.is_human_readable() {
-			struct Visitor;
-			impl<'de> serde::de::Visitor<'de> for Visitor {
-				type Value = Script;
+        if deserializer.is_human_readable() {
+            struct Visitor;
+            impl<'de> serde::de::Visitor<'de> for Visitor {
+                type Value = Script;
 
-				fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
-					formatter.write_str("a script hex")
-				}
+                fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                    formatter.write_str("a script hex")
+                }
 
-				fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-				where
-					E: serde::de::Error,
-				{
-					let v = Vec::from_hex(v).map_err(E::custom)?;
-					Ok(Script::from(v))
-				}
+                fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    let v = Vec::from_hex(v).map_err(E::custom)?;
+                    Ok(Script::from(v))
+                }
 
-				fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-				where
-					E: serde::de::Error,
-				{
-					self.visit_str(v)
-				}
+                fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    self.visit_str(v)
+                }
 
-				fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-				where
-					E: serde::de::Error,
-				{
-					self.visit_str(&v)
-				}
-			}
-			deserializer.deserialize_str(Visitor)
-		} else {
-			struct BytesVisitor;
+                fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    self.visit_str(&v)
+                }
+            }
+            deserializer.deserialize_str(Visitor)
+        } else {
+            struct BytesVisitor;
 
-			impl<'de> serde::de::Visitor<'de> for BytesVisitor {
-				type Value = Script;
+            impl<'de> serde::de::Visitor<'de> for BytesVisitor {
+                type Value = Script;
 
-				fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
-					formatter.write_str("a script Vec<u8>")
-				}
+                fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                    formatter.write_str("a script Vec<u8>")
+                }
 
-				fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-				where
-					E: serde::de::Error,
-				{
-					Ok(Script::from(v.to_vec()))
-				}
-			}
-			deserializer.deserialize_bytes(BytesVisitor)
-		}
-	}
+                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    Ok(Script::from(v.to_vec()))
+                }
+            }
+            deserializer.deserialize_bytes(BytesVisitor)
+        }
+    }
 }
 
 #[cfg(feature = "serde")]
 impl serde::Serialize for Script {
-	/// User-facing serialization for `Script`.
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		if serializer.is_human_readable() {
-			serializer.serialize_str(&format!("{:x}", self))
-		} else {
-			serializer.serialize_bytes(&self.as_bytes())
-		}
-	}
+    /// User-facing serialization for `Script`.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&format!("{:x}", self))
+        } else {
+            serializer.serialize_bytes(&self.as_bytes())
+        }
+    }
 }
 
 #[cfg(test)]
 mod test {
-	use super::{build_scriptint, *};
+    use super::{build_scriptint, *};
 
-	use hex_literal::hex;
+    use hex_literal::hex;
 
-	#[test]
-	fn script() {
-		let mut comp = vec![];
-		let mut script = Builder::new();
-		assert_eq!(&script[..], &comp[..]);
+    #[test]
+    fn script() {
+        let mut comp = vec![];
+        let mut script = Builder::new();
+        assert_eq!(&script[..], &comp[..]);
 
-		// small ints
-		script = script.push_int(1);
-		comp.push(81u8);
-		assert_eq!(&script[..], &comp[..]);
-		script = script.push_int(0);
-		comp.push(0u8);
-		assert_eq!(&script[..], &comp[..]);
-		script = script.push_int(4);
-		comp.push(84u8);
-		assert_eq!(&script[..], &comp[..]);
-		script = script.push_int(-1);
-		comp.push(79u8);
-		assert_eq!(&script[..], &comp[..]);
-		// forced scriptint
-		script = script.push_scriptint(4);
-		comp.extend([1u8, 4].iter().cloned());
-		assert_eq!(&script[..], &comp[..]);
-		// big ints
-		script = script.push_int(17);
-		comp.extend([1u8, 17].iter().cloned());
-		assert_eq!(&script[..], &comp[..]);
-		script = script.push_int(10000);
-		comp.extend([2u8, 16, 39].iter().cloned());
-		assert_eq!(&script[..], &comp[..]);
-		// notice the sign bit set here, hence the extra zero/128 at the end
-		script = script.push_int(10000000);
-		comp.extend([4u8, 128, 150, 152, 0].iter().cloned());
-		assert_eq!(&script[..], &comp[..]);
-		script = script.push_int(-10000000);
-		comp.extend([4u8, 128, 150, 152, 128].iter().cloned());
-		assert_eq!(&script[..], &comp[..]);
+        // small ints
+        script = script.push_int(1);
+        comp.push(81u8);
+        assert_eq!(&script[..], &comp[..]);
+        script = script.push_int(0);
+        comp.push(0u8);
+        assert_eq!(&script[..], &comp[..]);
+        script = script.push_int(4);
+        comp.push(84u8);
+        assert_eq!(&script[..], &comp[..]);
+        script = script.push_int(-1);
+        comp.push(79u8);
+        assert_eq!(&script[..], &comp[..]);
+        // forced scriptint
+        script = script.push_scriptint(4);
+        comp.extend([1u8, 4].iter().cloned());
+        assert_eq!(&script[..], &comp[..]);
+        // big ints
+        script = script.push_int(17);
+        comp.extend([1u8, 17].iter().cloned());
+        assert_eq!(&script[..], &comp[..]);
+        script = script.push_int(10000);
+        comp.extend([2u8, 16, 39].iter().cloned());
+        assert_eq!(&script[..], &comp[..]);
+        // notice the sign bit set here, hence the extra zero/128 at the end
+        script = script.push_int(10000000);
+        comp.extend([4u8, 128, 150, 152, 0].iter().cloned());
+        assert_eq!(&script[..], &comp[..]);
+        script = script.push_int(-10000000);
+        comp.extend([4u8, 128, 150, 152, 128].iter().cloned());
+        assert_eq!(&script[..], &comp[..]);
 
-		// data
-		script = script.push_slice("NRA4VR".as_bytes());
-		comp.extend([6u8, 78, 82, 65, 52, 86, 82].iter().cloned());
-		assert_eq!(&script[..], &comp[..]);
+        // data
+        script = script.push_slice("NRA4VR".as_bytes());
+        comp.extend([6u8, 78, 82, 65, 52, 86, 82].iter().cloned());
+        assert_eq!(&script[..], &comp[..]);
 
-		/*
-		// keys
-		let key = hex!("21032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af");
-		script = script.push_slice(&key);
-		comp.push(33u8);
-		comp.extend(&key);
-		assert_eq!(&script[..], &comp[..]);
-		let keystr = "41042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133";
-		let key = PublicKey::from_str(&keystr[2..]).unwrap();
-		script = script.push_key(&key); comp.extend(Vec::from_hex(keystr).unwrap().iter().cloned()); assert_eq!(&script[..], &comp[..]);
-		*/
+        /*
+        // keys
+        let key = hex!("21032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af");
+        script = script.push_slice(&key);
+        comp.push(33u8);
+        comp.extend(&key);
+        assert_eq!(&script[..], &comp[..]);
+        let keystr = "41042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133";
+        let key = PublicKey::from_str(&keystr[2..]).unwrap();
+        script = script.push_key(&key); comp.extend(Vec::from_hex(keystr).unwrap().iter().cloned()); assert_eq!(&script[..], &comp[..]);
+        */
 
-		// opcodes
-		script = script.push_opcode(opcodes::all::OP_CHECKSIG);
-		comp.push(0xACu8);
-		assert_eq!(&script[..], &comp[..]);
-		script = script.push_opcode(opcodes::all::OP_CHECKSIG);
-		comp.push(0xACu8);
-		assert_eq!(&script[..], &comp[..]);
-	}
+        // opcodes
+        script = script.push_opcode(opcodes::all::OP_CHECKSIG);
+        comp.push(0xACu8);
+        assert_eq!(&script[..], &comp[..]);
+        script = script.push_opcode(opcodes::all::OP_CHECKSIG);
+        comp.push(0xACu8);
+        assert_eq!(&script[..], &comp[..]);
+    }
 
-	#[test]
-	fn script_builder() {
-		// from txid 3bb5e6434c11fb93f64574af5d116736510717f2c595eb45b52c28e31622dfff which was in
-		// my mempool when I wrote the test
-		let script = Builder::new()
-			.push_opcode(opcodes::all::OP_DUP)
-			.push_opcode(opcodes::all::OP_HASH160)
-			.push_slice(&hex!("16e1ae70ff0fa102905d4af297f6912bda6cce19"))
-			.push_opcode(opcodes::all::OP_EQUALVERIFY)
-			.push_opcode(opcodes::all::OP_CHECKSIG)
-			.into_script();
-		assert_eq!(&format!("{:x}", script), "76a91416e1ae70ff0fa102905d4af297f6912bda6cce1988ac");
-	}
+    #[test]
+    fn script_builder() {
+        // from txid 3bb5e6434c11fb93f64574af5d116736510717f2c595eb45b52c28e31622dfff which was in
+        // my mempool when I wrote the test
+        let script = Builder::new()
+            .push_opcode(opcodes::all::OP_DUP)
+            .push_opcode(opcodes::all::OP_HASH160)
+            .push_slice(&hex!("16e1ae70ff0fa102905d4af297f6912bda6cce19"))
+            .push_opcode(opcodes::all::OP_EQUALVERIFY)
+            .push_opcode(opcodes::all::OP_CHECKSIG)
+            .into_script();
+        assert_eq!(
+            &format!("{:x}", script),
+            "76a91416e1ae70ff0fa102905d4af297f6912bda6cce1988ac"
+        );
+    }
 
-	#[test]
-	fn script_builder_verify() {
-		let simple = Builder::new().push_verify().into_script();
-		assert_eq!(format!("{:x}", simple), "69");
-		let simple2 = Builder::from(vec![]).push_verify().into_script();
-		assert_eq!(format!("{:x}", simple2), "69");
+    #[test]
+    fn script_builder_verify() {
+        let simple = Builder::new().push_verify().into_script();
+        assert_eq!(format!("{:x}", simple), "69");
+        let simple2 = Builder::from(vec![]).push_verify().into_script();
+        assert_eq!(format!("{:x}", simple2), "69");
 
-		let nonverify = Builder::new().push_verify().push_verify().into_script();
-		assert_eq!(format!("{:x}", nonverify), "6969");
-		let nonverify2 = Builder::from(vec![0x69]).push_verify().into_script();
-		assert_eq!(format!("{:x}", nonverify2), "6969");
+        let nonverify = Builder::new().push_verify().push_verify().into_script();
+        assert_eq!(format!("{:x}", nonverify), "6969");
+        let nonverify2 = Builder::from(vec![0x69]).push_verify().into_script();
+        assert_eq!(format!("{:x}", nonverify2), "6969");
 
-		let equal = Builder::new().push_opcode(opcodes::all::OP_EQUAL).push_verify().into_script();
-		assert_eq!(format!("{:x}", equal), "88");
-		let equal2 = Builder::from(vec![0x87]).push_verify().into_script();
-		assert_eq!(format!("{:x}", equal2), "88");
+        let equal = Builder::new().push_opcode(opcodes::all::OP_EQUAL).push_verify().into_script();
+        assert_eq!(format!("{:x}", equal), "88");
+        let equal2 = Builder::from(vec![0x87]).push_verify().into_script();
+        assert_eq!(format!("{:x}", equal2), "88");
 
-		let numequal = Builder::new()
-			.push_opcode(opcodes::all::OP_NUMEQUAL)
-			.push_verify()
-			.into_script();
-		assert_eq!(format!("{:x}", numequal), "9d");
-		let numequal2 = Builder::from(vec![0x9c]).push_verify().into_script();
-		assert_eq!(format!("{:x}", numequal2), "9d");
+        let numequal = Builder::new()
+            .push_opcode(opcodes::all::OP_NUMEQUAL)
+            .push_verify()
+            .into_script();
+        assert_eq!(format!("{:x}", numequal), "9d");
+        let numequal2 = Builder::from(vec![0x9c]).push_verify().into_script();
+        assert_eq!(format!("{:x}", numequal2), "9d");
 
-		let checksig = Builder::new()
-			.push_opcode(opcodes::all::OP_CHECKSIG)
-			.push_verify()
-			.into_script();
-		assert_eq!(format!("{:x}", checksig), "ad");
-		let checksig2 = Builder::from(vec![0xac]).push_verify().into_script();
-		assert_eq!(format!("{:x}", checksig2), "ad");
+        let checksig = Builder::new()
+            .push_opcode(opcodes::all::OP_CHECKSIG)
+            .push_verify()
+            .into_script();
+        assert_eq!(format!("{:x}", checksig), "ad");
+        let checksig2 = Builder::from(vec![0xac]).push_verify().into_script();
+        assert_eq!(format!("{:x}", checksig2), "ad");
 
-		let checkmultisig = Builder::new()
-			.push_opcode(opcodes::all::OP_CHECKMULTISIG)
-			.push_verify()
-			.into_script();
-		assert_eq!(format!("{:x}", checkmultisig), "af");
-		let checkmultisig2 = Builder::from(vec![0xae]).push_verify().into_script();
-		assert_eq!(format!("{:x}", checkmultisig2), "af");
+        let checkmultisig = Builder::new()
+            .push_opcode(opcodes::all::OP_CHECKMULTISIG)
+            .push_verify()
+            .into_script();
+        assert_eq!(format!("{:x}", checkmultisig), "af");
+        let checkmultisig2 = Builder::from(vec![0xae]).push_verify().into_script();
+        assert_eq!(format!("{:x}", checkmultisig2), "af");
 
-		let trick_slice = Builder::new()
-			.push_slice(&[0xae]) // OP_CHECKMULTISIG
-			.push_verify()
-			.into_script();
-		assert_eq!(format!("{:x}", trick_slice), "01ae69");
-		let trick_slice2 = Builder::from(vec![0x01, 0xae]).push_verify().into_script();
-		assert_eq!(format!("{:x}", trick_slice2), "01ae69");
-	}
+        let trick_slice = Builder::new()
+            .push_slice(&[0xae]) // OP_CHECKMULTISIG
+            .push_verify()
+            .into_script();
+        assert_eq!(format!("{:x}", trick_slice), "01ae69");
+        let trick_slice2 = Builder::from(vec![0x01, 0xae]).push_verify().into_script();
+        assert_eq!(format!("{:x}", trick_slice2), "01ae69");
+    }
 
-	#[test]
-	fn scriptint_round_trip() {
-		assert_eq!(build_scriptint(-1), vec![0x81]);
-		assert_eq!(build_scriptint(255), vec![255, 0]);
-		assert_eq!(build_scriptint(256), vec![0, 1]);
-		assert_eq!(build_scriptint(257), vec![1, 1]);
-		assert_eq!(build_scriptint(511), vec![255, 1]);
-		for &i in [
-			10,
-			100,
-			255,
-			256,
-			1000,
-			10000,
-			25000,
-			200000,
-			5000000,
-			1000000000,
-			(1 << 31) - 1,
-			-((1 << 31) - 1),
-		]
-		.iter()
-		{
-			assert_eq!(Ok(i), read_scriptint(&build_scriptint(i)));
-			assert_eq!(Ok(-i), read_scriptint(&build_scriptint(-i)));
-		}
-		assert!(read_scriptint(&build_scriptint(1 << 31)).is_err());
-		assert!(read_scriptint(&build_scriptint(-(1 << 31))).is_err());
-	}
+    #[test]
+    fn scriptint_round_trip() {
+        assert_eq!(build_scriptint(-1), vec![0x81]);
+        assert_eq!(build_scriptint(255), vec![255, 0]);
+        assert_eq!(build_scriptint(256), vec![0, 1]);
+        assert_eq!(build_scriptint(257), vec![1, 1]);
+        assert_eq!(build_scriptint(511), vec![255, 1]);
+        for &i in [
+            10,
+            100,
+            255,
+            256,
+            1000,
+            10000,
+            25000,
+            200000,
+            5000000,
+            1000000000,
+            (1 << 31) - 1,
+            -((1 << 31) - 1),
+        ]
+        .iter()
+        {
+            assert_eq!(Ok(i), read_scriptint(&build_scriptint(i)));
+            assert_eq!(Ok(-i), read_scriptint(&build_scriptint(-i)));
+        }
+        assert!(read_scriptint(&build_scriptint(1 << 31)).is_err());
+        assert!(read_scriptint(&build_scriptint(-(1 << 31))).is_err());
+    }
 
-	#[test]
-	fn provably_unspendable_test() {
-		// p2pk
-		assert_eq!(hex_script!("410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac").is_provably_unspendable(), false);
-		assert_eq!(hex_script!("4104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac").is_provably_unspendable(), false);
-		// p2pkhash
-		assert_eq!(
-			hex_script!("76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac")
-				.is_provably_unspendable(),
-			false
-		);
-		assert_eq!(
-			hex_script!("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87")
-				.is_provably_unspendable(),
-			true
-		);
-	}
+    #[test]
+    fn provably_unspendable_test() {
+        // p2pk
+        assert_eq!(hex_script!("410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac").is_provably_unspendable(), false);
+        assert_eq!(hex_script!("4104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac").is_provably_unspendable(), false);
+        // p2pkhash
+        assert_eq!(
+            hex_script!("76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac")
+                .is_provably_unspendable(),
+            false
+        );
+        assert_eq!(
+            hex_script!("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87")
+                .is_provably_unspendable(),
+            true
+        );
+    }
 
-	#[test]
-	fn op_return_test() {
-		assert_eq!(
-			hex_script!("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87").is_op_return(),
-			true
-		);
-		assert_eq!(
-			hex_script!("76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac").is_op_return(),
-			false
-		);
-		assert_eq!(hex_script!("").is_op_return(), false);
-	}
+    #[test]
+    fn op_return_test() {
+        assert_eq!(
+            hex_script!("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87").is_op_return(),
+            true
+        );
+        assert_eq!(
+            hex_script!("76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac").is_op_return(),
+            false
+        );
+        assert_eq!(hex_script!("").is_op_return(), false);
+    }
 
-	#[test]
-	#[cfg(feature = "serde")]
-	fn script_json_serialize() {
-		use serde_json;
+    #[test]
+    #[cfg(feature = "serde")]
+    fn script_json_serialize() {
+        use serde_json;
 
-		let original = hex_script!("827651a0698faaa9a8a7a687");
-		let json = serde_json::to_value(&original).unwrap();
-		assert_eq!(json, serde_json::Value::String("827651a0698faaa9a8a7a687".to_owned()));
-		let des = serde_json::from_value(json).unwrap();
-		assert_eq!(original, des);
-	}
+        let original = hex_script!("827651a0698faaa9a8a7a687");
+        let json = serde_json::to_value(&original).unwrap();
+        assert_eq!(
+            json,
+            serde_json::Value::String("827651a0698faaa9a8a7a687".to_owned())
+        );
+        let des = serde_json::from_value(json).unwrap();
+        assert_eq!(original, des);
+    }
 
-	#[test]
-	fn script_asm() {
-		assert_eq!(
-			hex_script!("6363636363686868686800").asm(),
-			"OP_IF OP_IF OP_IF OP_IF OP_IF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_0"
-		);
-		assert_eq!(
-			hex_script!("6363636363686868686800").asm(),
-			"OP_IF OP_IF OP_IF OP_IF OP_IF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_0"
-		);
-		assert_eq!(hex_script!("2102715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699ac").asm(),
+    #[test]
+    fn script_asm() {
+        assert_eq!(
+            hex_script!("6363636363686868686800").asm(),
+            "OP_IF OP_IF OP_IF OP_IF OP_IF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_0"
+        );
+        assert_eq!(
+            hex_script!("6363636363686868686800").asm(),
+            "OP_IF OP_IF OP_IF OP_IF OP_IF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_0"
+        );
+        assert_eq!(hex_script!("2102715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699ac").asm(),
                    "OP_PUSHBYTES_33 02715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699 OP_CHECKSIG");
-		// Elements Alpha peg-out transaction with some signatures removed for brevity. Mainly to
-		// test PUSHDATA1
-		assert_eq!(hex_script!("0047304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401004cf1552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae").asm(),
+        // Elements Alpha peg-out transaction with some signatures removed for brevity. Mainly to
+        // test PUSHDATA1
+        assert_eq!(hex_script!("0047304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401004cf1552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae").asm(),
                    "OP_0 OP_PUSHBYTES_71 304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401 OP_0 OP_PUSHDATA1 552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae");
-	}
+    }
 
-	#[test]
-	fn script_p2sh_p2p2k_template() {
-		// random outputs I picked out of the mempool
-		assert!(hex_script!("76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ac").is_p2pkh());
-		assert!(!hex_script!("76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ac").is_p2sh());
-		assert!(!hex_script!("76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ad").is_p2pkh());
-		assert!(!hex_script!("").is_p2pkh());
-		assert!(hex_script!("a914acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87").is_p2sh());
-		assert!(!hex_script!("a914acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87").is_p2pkh());
-		assert!(!hex_script!("a314acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87").is_p2sh());
-	}
+    #[test]
+    fn script_p2sh_p2p2k_template() {
+        // random outputs I picked out of the mempool
+        assert!(hex_script!("76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ac").is_p2pkh());
+        assert!(!hex_script!("76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ac").is_p2sh());
+        assert!(!hex_script!("76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ad").is_p2pkh());
+        assert!(!hex_script!("").is_p2pkh());
+        assert!(hex_script!("a914acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87").is_p2sh());
+        assert!(!hex_script!("a914acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87").is_p2pkh());
+        assert!(!hex_script!("a314acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87").is_p2sh());
+    }
 
-	#[test]
-	fn script_p2pk() {
-		assert!(hex_script!(
-			"21021aeaf2f8638a129a3156fbe7e5ef635226b0bafd495ff03afe2c843d7e3a4b51ac"
-		)
-		.is_p2pk());
-		assert!(hex_script!("410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac").is_p2pk());
-	}
+    #[test]
+    fn script_p2pk() {
+        assert!(hex_script!(
+            "21021aeaf2f8638a129a3156fbe7e5ef635226b0bafd495ff03afe2c843d7e3a4b51ac"
+        )
+        .is_p2pk());
+        assert!(hex_script!("410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac").is_p2pk());
+    }
 
-	#[test]
-	fn test_iterator() {
-		let zero = hex_script!("00");
-		let zeropush = hex_script!("0100");
+    #[test]
+    fn test_iterator() {
+        let zero = hex_script!("00");
+        let zeropush = hex_script!("0100");
 
-		let nonminimal = hex_script!("4c0169b2"); // PUSHDATA1 for no reason
-		let minimal = hex_script!("0169b2"); // minimal
-		let nonminimal_alt = hex_script!("026900b2"); // non-minimal number but minimal push (should be OK)
+        let nonminimal = hex_script!("4c0169b2"); // PUSHDATA1 for no reason
+        let minimal = hex_script!("0169b2"); // minimal
+        let nonminimal_alt = hex_script!("026900b2"); // non-minimal number but minimal push (should be OK)
 
-		let v_zero: Result<Vec<Instruction>, Error> = zero.instructions_minimal().collect();
-		let v_zeropush: Result<Vec<Instruction>, Error> = zeropush.instructions_minimal().collect();
+        let v_zero: Result<Vec<Instruction>, Error> = zero.instructions_minimal().collect();
+        let v_zeropush: Result<Vec<Instruction>, Error> = zeropush.instructions_minimal().collect();
 
-		let v_min: Result<Vec<Instruction>, Error> = minimal.instructions_minimal().collect();
-		let v_nonmin: Result<Vec<Instruction>, Error> = nonminimal.instructions_minimal().collect();
-		let v_nonmin_alt: Result<Vec<Instruction>, Error> =
-			nonminimal_alt.instructions_minimal().collect();
-		let slop_v_min: Result<Vec<Instruction>, Error> = minimal.instructions().collect();
-		let slop_v_nonmin: Result<Vec<Instruction>, Error> = nonminimal.instructions().collect();
-		let slop_v_nonmin_alt: Result<Vec<Instruction>, Error> =
-			nonminimal_alt.instructions().collect();
+        let v_min: Result<Vec<Instruction>, Error> = minimal.instructions_minimal().collect();
+        let v_nonmin: Result<Vec<Instruction>, Error> = nonminimal.instructions_minimal().collect();
+        let v_nonmin_alt: Result<Vec<Instruction>, Error> =
+            nonminimal_alt.instructions_minimal().collect();
+        let slop_v_min: Result<Vec<Instruction>, Error> = minimal.instructions().collect();
+        let slop_v_nonmin: Result<Vec<Instruction>, Error> = nonminimal.instructions().collect();
+        let slop_v_nonmin_alt: Result<Vec<Instruction>, Error> =
+            nonminimal_alt.instructions().collect();
 
-		assert_eq!(v_zero.unwrap(), vec![Instruction::PushBytes(&[]),]);
-		assert_eq!(v_zeropush.unwrap(), vec![Instruction::PushBytes(&[0]),]);
+        assert_eq!(v_zero.unwrap(), vec![Instruction::PushBytes(&[]),]);
+        assert_eq!(v_zeropush.unwrap(), vec![Instruction::PushBytes(&[0]),]);
 
-		assert_eq!(
-			v_min.clone().unwrap(),
-			vec![Instruction::PushBytes(&[105]), Instruction::Op(opcodes::OP_NOP3),]
-		);
+        assert_eq!(
+            v_min.clone().unwrap(),
+            vec![Instruction::PushBytes(&[105]), Instruction::Op(opcodes::OP_NOP3),]
+        );
 
-		assert_eq!(v_nonmin.err().unwrap(), Error::NonMinimalPush);
+        assert_eq!(v_nonmin.err().unwrap(), Error::NonMinimalPush);
 
-		assert_eq!(
-			v_nonmin_alt.clone().unwrap(),
-			vec![Instruction::PushBytes(&[105, 0]), Instruction::Op(opcodes::OP_NOP3),]
-		);
+        assert_eq!(
+            v_nonmin_alt.clone().unwrap(),
+            vec![Instruction::PushBytes(&[105, 0]), Instruction::Op(opcodes::OP_NOP3),]
+        );
 
-		assert_eq!(v_min.clone().unwrap(), slop_v_min.unwrap());
-		assert_eq!(v_min.unwrap(), slop_v_nonmin.unwrap());
-		assert_eq!(v_nonmin_alt.unwrap(), slop_v_nonmin_alt.unwrap());
-	}
+        assert_eq!(v_min.clone().unwrap(), slop_v_min.unwrap());
+        assert_eq!(v_min.unwrap(), slop_v_nonmin.unwrap());
+        assert_eq!(v_nonmin_alt.unwrap(), slop_v_nonmin_alt.unwrap());
+    }
 
-	#[test]
-	fn script_ord() {
-		let script_1 = Builder::new().push_slice(&[1, 2, 3, 4]).into_script();
-		let script_2 = Builder::new().push_int(10).into_script();
-		let script_3 = Builder::new().push_int(15).into_script();
-		let script_4 = Builder::new().push_opcode(opcodes::all::OP_RETURN).into_script();
+    #[test]
+    fn script_ord() {
+        let script_1 = Builder::new().push_slice(&[1, 2, 3, 4]).into_script();
+        let script_2 = Builder::new().push_int(10).into_script();
+        let script_3 = Builder::new().push_int(15).into_script();
+        let script_4 = Builder::new().push_opcode(opcodes::all::OP_RETURN).into_script();
 
-		assert!(script_1 < script_2);
-		assert!(script_2 < script_3);
-		assert!(script_3 < script_4);
+        assert!(script_1 < script_2);
+        assert!(script_2 < script_3);
+        assert!(script_3 < script_4);
 
-		assert!(script_1 <= script_1);
-		assert!(script_1 >= script_1);
+        assert!(script_1 <= script_1);
+        assert!(script_1 >= script_1);
 
-		assert!(script_4 > script_3);
-		assert!(script_3 > script_2);
-		assert!(script_2 > script_1);
-	}
+        assert!(script_4 > script_3);
+        assert!(script_3 > script_2);
+        assert!(script_2 > script_1);
+    }
 
-	use proptest::prelude::*;
+    use proptest::prelude::*;
 
-	proptest! {
-		#[test]
-		fn prop_scriptint_roundtrip(x: i32) {
-			let y = read_scriptint(&build_scriptint(x as i64));
-			prop_assert_eq!(Ok(x as i64), y);
-		}
-	}
+    proptest! {
+        #[test]
+        fn prop_scriptint_roundtrip(x: i32) {
+            let y = read_scriptint(&build_scriptint(x as i64));
+            prop_assert_eq!(Ok(x as i64), y);
+        }
+    }
 }

--- a/libs/chainscript/src/script.rs
+++ b/libs/chainscript/src/script.rs
@@ -30,7 +30,7 @@ use sp_std::prelude::*;
 
 use core::{default::Default, fmt};
 
-use crate::opcodes;
+use crate::{error::Error, opcodes};
 
 // TODO this needs better types
 type PubkeyHash = [u8];
@@ -100,60 +100,6 @@ impl ::sp_std::str::FromStr for Script {
 /// An object which can be used to construct a script piece by piece
 pub struct Builder(Vec<u8>, Option<opcodes::All>);
 display_from_debug!(Builder);
-
-/// Ways that a script might fail. Not everything is split up as
-/// much as it could be; patches welcome if more detailed errors
-/// would help you.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
-pub enum Error {
-	/// Something did a non-minimal push; for more information see
-	/// `https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#Push_operators`
-	NonMinimalPush,
-	/// Some opcode expected a parameter, but it was missing or truncated
-	EarlyEndOfScript,
-	/// Tried to read an array off the stack as a number when it was more than 4 bytes
-	NumericOverflow,
-	#[cfg(feature = "bitcoinconsensus")]
-	/// Error validating the script with bitcoinconsensus library
-	BitcoinConsensus(bitcoinconsensus::Error),
-	#[cfg(feature = "bitcoinconsensus")]
-	/// Can not find the spent output
-	UnknownSpentOutput(OutPoint),
-	#[cfg(feature = "bitcoinconsensus")]
-	/// Can not serialize the spending transaction
-	SerializationError,
-}
-
-impl fmt::Display for Error {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		let str = match *self {
-			Error::NonMinimalPush => "non-minimal datapush",
-			Error::EarlyEndOfScript => "unexpected end of script",
-			Error::NumericOverflow => "numeric overflow (number on stack larger than 4 bytes)",
-			#[cfg(feature = "bitcoinconsensus")]
-			Error::BitcoinConsensus(ref _n) => "bitcoinconsensus verification failed",
-			#[cfg(feature = "bitcoinconsensus")]
-			Error::UnknownSpentOutput(ref _point) => "unknown spent output Transaction::verify()",
-			#[cfg(feature = "bitcoinconsensus")]
-			Error::SerializationError =>
-				"can not serialize the spending transaction in Transaction::verify()",
-		};
-		f.write_str(str)
-	}
-}
-
-#[cfg(feature = "std")]
-impl ::std::error::Error for Error {}
-
-#[cfg(feature = "bitcoinconsensus")]
-#[doc(hidden)]
-impl From<bitcoinconsensus::Error> for Error {
-	fn from(err: bitcoinconsensus::Error) -> Error {
-		match err {
-			_ => Error::BitcoinConsensus(err),
-		}
-	}
-}
 /// Helper to encode an integer in script format
 fn build_scriptint(n: i64) -> Vec<u8> {
 	if n == 0 {

--- a/libs/chainscript/src/script.rs
+++ b/libs/chainscript/src/script.rs
@@ -428,7 +428,6 @@ pub enum Instruction<'a> {
 /// Iterator over a script returning parsed opcodes
 pub struct Instructions<'a> {
     data: &'a [u8],
-    cur_subscript: &'a [u8],
     enforce_minimal: bool,
 }
 
@@ -436,7 +435,6 @@ impl<'a> Instructions<'a> {
     fn new(data: &'a [u8], enforce_minimal: bool) -> Self {
         Instructions {
             data,
-            cur_subscript: data,
             enforce_minimal,
         }
     }
@@ -448,9 +446,8 @@ impl<'a> Instructions<'a> {
         Some(Err(e))
     }
 
-    // Extract the script remainder
     pub fn subscript(&self) -> &'a [u8] {
-        self.cur_subscript
+        self.data
     }
 }
 
@@ -458,7 +455,6 @@ impl<'a> Iterator for Instructions<'a> {
     type Item = Result<Instruction<'a>, Error>;
 
     fn next(&mut self) -> Option<Result<Instruction<'a>, Error>> {
-        self.cur_subscript = self.data;
         if self.data.is_empty() {
             return None;
         }

--- a/libs/chainscript/src/script.rs
+++ b/libs/chainscript/src/script.rs
@@ -1,0 +1,1310 @@
+// Rust Bitcoin Library
+// Written in 2014 by
+//     Andrew Poelstra <apoelstra@wpsoftware.net>
+//
+// Modified in 2021 by
+//   Lukas Kuklinek <lukas.kuklinek@mintlayer.org>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! Script
+//!
+//! Scripts define Bitcoin's digital signature scheme: a signature is formed
+//! from a script (the second half of which is defined by a coin to be spent,
+//! and the first half provided by the spending transaction), and is valid
+//! iff the script leaves `TRUE` on the stack after being evaluated.
+//! Bitcoin's script is a stack-based assembly language similar in spirit to
+//! Forth.
+//!
+//! This module provides the structures and functions needed to support scripts.
+//!
+
+use sp_std::prelude::*;
+
+use core::{fmt, default::Default};
+
+use crate::opcodes;
+
+// TODO this needs better types
+type PubkeyHash = [u8];
+type ScriptHash = [u8];
+
+#[derive(Clone, Default, PartialOrd, Ord, PartialEq, Eq, Hash)]
+/// A Bitcoin script
+pub struct Script(Box<[u8]>);
+
+impl AsRef<[u8]> for Script {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for Script {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("Script(")?;
+        self.fmt_asm(f)?;
+        f.write_str(")")
+    }
+}
+
+impl fmt::Display for Script {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl fmt::LowerHex for Script {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for &ch in self.0.iter() {
+            write!(f, "{:02x}", ch)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::UpperHex for Script {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for &ch in self.0.iter() {
+            write!(f, "{:02X}", ch)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(any())]
+impl hex::FromHex for Script {
+    fn from_byte_iter<I>(iter: I) -> Result<Self, hex::Error>
+        where I: Iterator<Item=Result<u8, hex::Error>> +
+            ExactSizeIterator +
+            DoubleEndedIterator,
+    {
+        Vec::from_byte_iter(iter).map(|v| Script(Box::<[u8]>::from(v)))
+    }
+}
+
+#[cfg(any())]
+impl ::sp_std::str::FromStr for Script {
+    type Err = hex::Error;
+    fn from_str(s: &str) -> Result<Self, hex::Error> {
+        hex::FromHex::from_hex(s)
+    }
+}
+
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+/// An object which can be used to construct a script piece by piece
+pub struct Builder(Vec<u8>, Option<opcodes::All>);
+display_from_debug!(Builder);
+
+/// Ways that a script might fail. Not everything is split up as
+/// much as it could be; patches welcome if more detailed errors
+/// would help you.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
+pub enum Error {
+    /// Something did a non-minimal push; for more information see
+    /// `https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#Push_operators`
+    NonMinimalPush,
+    /// Some opcode expected a parameter, but it was missing or truncated
+    EarlyEndOfScript,
+    /// Tried to read an array off the stack as a number when it was more than 4 bytes
+    NumericOverflow,
+    #[cfg(feature="bitcoinconsensus")]
+    /// Error validating the script with bitcoinconsensus library
+    BitcoinConsensus(bitcoinconsensus::Error),
+    #[cfg(feature="bitcoinconsensus")]
+    /// Can not find the spent output
+    UnknownSpentOutput(OutPoint),
+    #[cfg(feature="bitcoinconsensus")]
+    /// Can not serialize the spending transaction
+    SerializationError
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let str = match *self {
+            Error::NonMinimalPush => "non-minimal datapush",
+            Error::EarlyEndOfScript => "unexpected end of script",
+            Error::NumericOverflow => "numeric overflow (number on stack larger than 4 bytes)",
+            #[cfg(feature="bitcoinconsensus")]
+            Error::BitcoinConsensus(ref _n) => "bitcoinconsensus verification failed",
+            #[cfg(feature="bitcoinconsensus")]
+            Error::UnknownSpentOutput(ref _point) => "unknown spent output Transaction::verify()",
+            #[cfg(feature="bitcoinconsensus")]
+            Error::SerializationError => "can not serialize the spending transaction in Transaction::verify()",
+        };
+        f.write_str(str)
+    }
+}
+
+#[cfg(feature = "std")]
+impl ::std::error::Error for Error {}
+
+#[cfg(feature="bitcoinconsensus")]
+#[doc(hidden)]
+impl From<bitcoinconsensus::Error> for Error {
+    fn from(err: bitcoinconsensus::Error) -> Error {
+        match err {
+            _ => Error::BitcoinConsensus(err)
+        }
+    }
+}
+/// Helper to encode an integer in script format
+fn build_scriptint(n: i64) -> Vec<u8> {
+    if n == 0 { return vec![] }
+
+    let neg = n < 0;
+
+    let mut abs = if neg { -n } else { n } as usize;
+    let mut v = vec![];
+    while abs > 0xFF {
+        v.push((abs & 0xFF) as u8);
+        abs >>= 8;
+    }
+    // If the number's value causes the sign bit to be set, we need an extra
+    // byte to get the correct value and correct sign bit
+    if abs & 0x80 != 0 {
+        v.push(abs as u8);
+        v.push(if neg { 0x80u8 } else { 0u8 });
+    }
+    // Otherwise we just set the sign bit ourselves
+    else {
+        abs |= if neg { 0x80 } else { 0 };
+        v.push(abs as u8);
+    }
+    v
+}
+
+/// Helper to decode an integer in script format
+/// Notice that this fails on overflow: the result is the same as in
+/// bitcoind, that only 4-byte signed-magnitude values may be read as
+/// numbers. They can be added or subtracted (and a long time ago,
+/// multiplied and divided), and this may result in numbers which
+/// can't be written out in 4 bytes or less. This is ok! The number
+/// just can't be read as a number again.
+/// This is a bit crazy and subtle, but it makes sense: you can load
+/// 32-bit numbers and do anything with them, which back when mult/div
+/// was allowed, could result in up to a 64-bit number. We don't want
+/// overflow since that's surprising --- and we don't want numbers that
+/// don't fit in 64 bits (for efficiency on modern processors) so we
+/// simply say, anything in excess of 32 bits is no longer a number.
+/// This is basically a ranged type implementation.
+pub fn read_scriptint(v: &[u8]) -> Result<i64, Error> {
+    let len = v.len();
+    if len == 0 { return Ok(0); }
+    if len > 4 { return Err(Error::NumericOverflow); }
+
+    let (mut ret, sh) = v.iter()
+                         .fold((0, 0), |(acc, sh), n| (acc + ((*n as i64) << sh), sh + 8));
+    if v[len - 1] & 0x80 != 0 {
+        ret &= (1 << (sh - 1)) - 1;
+        ret = -ret;
+    }
+    Ok(ret)
+}
+
+/// This is like "`read_scriptint` then map 0 to false and everything
+/// else as true", except that the overflow rules don't apply.
+#[inline]
+pub fn read_scriptbool(v: &[u8]) -> bool {
+    !(v.is_empty() ||
+        ((v[v.len() - 1] == 0 || v[v.len() - 1] == 0x80) &&
+         v.iter().rev().skip(1).all(|&w| w == 0)))
+}
+
+/// Read a script-encoded unsigned integer
+pub fn read_uint(data: &[u8], size: usize) -> Result<usize, Error> {
+    if data.len() < size {
+        Err(Error::EarlyEndOfScript)
+    } else {
+        let mut ret = 0;
+        for (i, item) in data.iter().take(size).enumerate() {
+            ret += (*item as usize) << (i * 8);
+        }
+        Ok(ret)
+    }
+}
+
+impl Script {
+    /// Creates a new empty script
+    pub fn new() -> Script { Script(vec![].into_boxed_slice()) }
+
+    /// Generates P2PK-type of scriptPubkey
+    pub fn new_p2pk(pubkey: &[u8]) -> Script {
+        Builder::new()
+            .push_slice(pubkey)
+            .push_opcode(opcodes::all::OP_CHECKSIG)
+            .into_script()
+    }
+
+    /// Generates P2PKH-type of scriptPubkey
+    pub fn new_p2pkh(pubkey_hash: &PubkeyHash) -> Script {
+        Builder::new()
+            .push_opcode(opcodes::all::OP_DUP)
+            .push_opcode(opcodes::all::OP_HASH160)
+            .push_slice(&pubkey_hash[..])
+            .push_opcode(opcodes::all::OP_EQUALVERIFY)
+            .push_opcode(opcodes::all::OP_CHECKSIG)
+            .into_script()
+    }
+
+    /// Generates P2SH-type of scriptPubkey with a given hash of the redeem script
+    pub fn new_p2sh(script_hash: &ScriptHash) -> Script {
+        Builder::new()
+            .push_opcode(opcodes::all::OP_HASH160)
+            .push_slice(&script_hash[..])
+            .push_opcode(opcodes::all::OP_EQUAL)
+            .into_script()
+    }
+
+    /// Generates P2WPKH-type of scriptPubkey
+    #[cfg(any())]
+    pub fn new_v0_wpkh(pubkey_hash: &WPubkeyHash) -> Script {
+        Script::new_witness_program(::bech32::u5::try_from_u8(0).unwrap(), &pubkey_hash.to_vec())
+    }
+
+    /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script
+    #[cfg(any())]
+    pub fn new_v0_wsh(script_hash: &WScriptHash) -> Script {
+        Script::new_witness_program(::bech32::u5::try_from_u8(0).unwrap(), &script_hash.to_vec())
+    }
+
+    /// Generates P2WSH-type of scriptPubkey with a given hash of the redeem script
+    #[cfg(any())]
+    pub fn new_witness_program(ver: ::bech32::u5, program: &[u8]) -> Script {
+        let mut verop = ver.to_u8();
+        assert!(verop <= 16, "incorrect witness version provided: {}", verop);
+        if verop > 0 {
+            verop = 0x50 + verop;
+        }
+        Builder::new()
+            .push_opcode(verop.into())
+            .push_slice(&program)
+            .into_script()
+    }
+
+    /// Generates OP_RETURN-type of scriptPubkey for a given data
+    pub fn new_op_return(data: &[u8]) -> Script {
+        Builder::new()
+            .push_opcode(opcodes::all::OP_RETURN)
+            .push_slice(data)
+            .into_script()
+    }
+
+    /// Returns 160-bit hash of the script
+    #[cfg(any())]
+    pub fn script_hash(&self) -> ScriptHash {
+        ScriptHash::hash(&self.as_bytes())
+    }
+
+    /// Returns 256-bit hash of the script for P2WSH outputs
+    #[cfg(any())]
+    pub fn wscript_hash(&self) -> WScriptHash {
+        WScriptHash::hash(&self.as_bytes())
+    }
+
+    /// The length in bytes of the script
+    pub fn len(&self) -> usize { self.0.len() }
+
+    /// Whether the script is the empty script
+    pub fn is_empty(&self) -> bool { self.0.is_empty() }
+
+    /// Returns the script data
+    pub fn as_bytes(&self) -> &[u8] { &*self.0 }
+
+    /// Returns a copy of the script data
+    pub fn to_bytes(&self) -> Vec<u8> { self.0.clone().into_vec() }
+
+    /// Convert the script into a byte vector
+    pub fn into_bytes(self) -> Vec<u8> { self.0.into_vec() }
+
+    /// Compute the P2SH output corresponding to this redeem script
+    #[cfg(any())]
+    pub fn to_p2sh(&self) -> Script {
+        Script::new_p2sh(&self.script_hash())
+    }
+
+    /// Compute the P2WSH output corresponding to this witnessScript (aka the "witness redeem
+    /// script")
+    #[cfg(any())]
+    pub fn to_v0_p2wsh(&self) -> Script {
+        Script::new_v0_wsh(&self.wscript_hash())
+    }
+
+    /// Checks whether a script pubkey is a p2sh output
+    #[inline]
+    pub fn is_p2sh(&self) -> bool {
+        self.0.len() == 23 &&
+        self.0[0] == opcodes::all::OP_HASH160.into_u8() &&
+        self.0[1] == opcodes::all::OP_PUSHBYTES_20.into_u8() &&
+        self.0[22] == opcodes::all::OP_EQUAL.into_u8()
+    }
+
+    /// Checks whether a script pubkey is a p2pkh output
+    #[inline]
+    pub fn is_p2pkh(&self) -> bool {
+        self.0.len() == 25 &&
+        self.0[0] == opcodes::all::OP_DUP.into_u8() &&
+        self.0[1] == opcodes::all::OP_HASH160.into_u8() &&
+        self.0[2] == opcodes::all::OP_PUSHBYTES_20.into_u8() &&
+        self.0[23] == opcodes::all::OP_EQUALVERIFY.into_u8() &&
+        self.0[24] == opcodes::all::OP_CHECKSIG.into_u8()
+    }
+
+    /// Checks whether a script pubkey is a p2pk output
+    #[inline]
+    pub fn is_p2pk(&self) -> bool {
+        (self.0.len() == 67 &&
+            self.0[0] == opcodes::all::OP_PUSHBYTES_65.into_u8() &&
+            self.0[66] == opcodes::all::OP_CHECKSIG.into_u8())
+     || (self.0.len() == 35 &&
+            self.0[0] == opcodes::all::OP_PUSHBYTES_33.into_u8() &&
+            self.0[34] == opcodes::all::OP_CHECKSIG.into_u8())
+    }
+
+    /// Checks whether a script pubkey is a Segregated Witness (segwit) program.
+    #[inline]
+    pub fn is_witness_program(&self) -> bool {
+        // A scriptPubKey (or redeemScript as defined in BIP16/P2SH) that consists of a 1-byte
+        // push opcode (for 0 to 16) followed by a data push between 2 and 40 bytes gets a new
+        // special meaning. The value of the first push is called the "version byte". The following
+        // byte vector pushed is called the "witness program".
+        let min_vernum: u8 = opcodes::all::OP_PUSHNUM_1.into_u8();
+        let max_vernum: u8 = opcodes::all::OP_PUSHNUM_16.into_u8();
+        self.0.len() >= 4
+            && self.0.len() <= 42
+            // Version 0 or PUSHNUM_1-PUSHNUM_16
+            && (self.0[0] == 0 || self.0[0] >= min_vernum && self.0[0] <= max_vernum)
+            // Second byte push opcode 2-40 bytes
+            && self.0[1] >= opcodes::all::OP_PUSHBYTES_2.into_u8()
+            && self.0[1] <= opcodes::all::OP_PUSHBYTES_40.into_u8()
+            // Check that the rest of the script has the correct size
+            && self.0.len() - 2 == self.0[1] as usize
+    }
+
+    /// Checks whether a script pubkey is a p2wsh output
+    #[inline]
+    pub fn is_v0_p2wsh(&self) -> bool {
+        self.0.len() == 34 &&
+        self.0[0] == opcodes::all::OP_PUSHBYTES_0.into_u8() &&
+        self.0[1] == opcodes::all::OP_PUSHBYTES_32.into_u8()
+    }
+
+    /// Checks whether a script pubkey is a p2wpkh output
+    #[inline]
+    pub fn is_v0_p2wpkh(&self) -> bool {
+        self.0.len() == 22 &&
+            self.0[0] == opcodes::all::OP_PUSHBYTES_0.into_u8() &&
+            self.0[1] == opcodes::all::OP_PUSHBYTES_20.into_u8()
+    }
+
+    /// Check if this is an OP_RETURN output
+    pub fn is_op_return (&self) -> bool {
+        !self.0.is_empty() && (opcodes::All::from(self.0[0]) == opcodes::all::OP_RETURN)
+    }
+
+    /// Whether a script can be proven to have no satisfying input
+    pub fn is_provably_unspendable(&self) -> bool {
+        !self.0.is_empty() && (opcodes::All::from(self.0[0]).classify() == opcodes::Class::ReturnOp ||
+                               opcodes::All::from(self.0[0]).classify() == opcodes::Class::IllegalOp)
+    }
+
+    /// Iterate over the script in the form of `Instruction`s, which are an enum covering
+    /// opcodes, datapushes and errors. At most one error will be returned and then the
+    /// iterator will end. To instead iterate over the script as sequence of bytes, treat
+    /// it as a slice using `script[..]` or convert it to a vector using `into_bytes()`.
+    ///
+    /// To force minimal pushes, use [Self::instructions_minimal].
+    pub fn instructions(&self) -> Instructions {
+        Instructions {
+            data: &self.0[..],
+            enforce_minimal: false,
+        }
+    }
+
+    /// Iterate over the script in the form of `Instruction`s while enforcing
+    /// minimal pushes.
+    pub fn instructions_minimal(&self) -> Instructions {
+        Instructions {
+            data: &self.0[..],
+            enforce_minimal: true,
+        }
+    }
+
+    #[cfg(feature="bitcoinconsensus")]
+    /// Shorthand for [Self::verify_with_flags] with flag [bitcoinconsensus::VERIFY_ALL]
+    pub fn verify (&self, index: usize, amount: ::Amount, spending: &[u8]) -> Result<(), Error> {
+        self.verify_with_flags(index, amount, spending, ::bitcoinconsensus::VERIFY_ALL)
+    }
+
+    #[cfg(feature="bitcoinconsensus")]
+    /// Verify spend of an input script
+    /// # Parameters
+    ///  * `index` - the input index in spending which is spending this transaction
+    ///  * `amount` - the amount this script guards
+    ///  * `spending` - the transaction that attempts to spend the output holding this script
+    ///  * `flags` - verification flags, see [bitcoinconsensus::VERIFY_ALL] and similar
+    pub fn verify_with_flags<F: Into<u32>>(&self, index: usize, amount: ::Amount, spending: &[u8], flags: F) -> Result<(), Error> {
+        Ok(bitcoinconsensus::verify_with_flags (&self.0[..], amount.as_sat(), spending, index, flags.into())?)
+    }
+
+    /// Write the assembly decoding of the script bytes to the formatter.
+    pub fn bytes_to_asm_fmt(script: &[u8], f: &mut dyn fmt::Write) -> fmt::Result {
+        let mut index = 0;
+        while index < script.len() {
+            let opcode = opcodes::All::from(script[index]);
+            index += 1;
+
+            let data_len = if let opcodes::Class::PushBytes(n) = opcode.classify() {
+                n as usize
+            } else {
+                match opcode {
+                    opcodes::all::OP_PUSHDATA1 => {
+                        if script.len() < index + 1 {
+                            f.write_str("<unexpected end>")?;
+                            break;
+                        }
+                        match read_uint(&script[index..], 1) {
+                            Ok(n) => { index += 1; n as usize }
+                            Err(_) => { f.write_str("<bad length>")?; break; }
+                        }
+                    }
+                    opcodes::all::OP_PUSHDATA2 => {
+                        if script.len() < index + 2 {
+                            f.write_str("<unexpected end>")?;
+                            break;
+                        }
+                        match read_uint(&script[index..], 2) {
+                            Ok(n) => { index += 2; n as usize }
+                            Err(_) => { f.write_str("<bad length>")?; break; }
+                        }
+                    }
+                    opcodes::all::OP_PUSHDATA4 => {
+                        if script.len() < index + 4 {
+                            f.write_str("<unexpected end>")?;
+                            break;
+                        }
+                        match read_uint(&script[index..], 4) {
+                            Ok(n) => { index += 4; n as usize }
+                            Err(_) => { f.write_str("<bad length>")?; break; }
+                        }
+                    }
+                    _ => 0
+                }
+            };
+
+            if index > 1 { f.write_str(" ")?; }
+            // Write the opcode
+            if opcode == opcodes::all::OP_PUSHBYTES_0 {
+                f.write_str("OP_0")?;
+            } else {
+                write!(f, "{:?}", opcode)?;
+            }
+            // Write any pushdata
+            if data_len > 0 {
+                f.write_str(" ")?;
+                if index + data_len <= script.len() {
+                    for ch in &script[index..index + data_len] {
+                            write!(f, "{:02x}", ch)?;
+                    }
+                    index += data_len;
+                } else {
+                    f.write_str("<push past end>")?;
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Write the assembly decoding of the script to the formatter.
+    pub fn fmt_asm(&self, f: &mut dyn fmt::Write) -> fmt::Result {
+        Script::bytes_to_asm_fmt(self.as_ref(), f)
+    }
+
+    /// Create an assembly decoding of the script in the given byte slice.
+    #[cfg(feature = "std")]
+    pub fn bytes_to_asm(script: &[u8]) -> String {
+        let mut buf = String::new();
+        Script::bytes_to_asm_fmt(script, &mut buf).unwrap();
+        buf
+    }
+
+    /// Get the assembly decoding of the script.
+    #[cfg(feature = "std")]
+    pub fn asm(&self) -> String {
+        Script::bytes_to_asm(self.as_ref())
+    }
+}
+
+/// Creates a new script from an existing vector
+impl From<Vec<u8>> for Script {
+    fn from(v: Vec<u8>) -> Script { Script(v.into_boxed_slice()) }
+}
+
+impl_index_newtype!(Script, u8);
+
+/// A "parsed opcode" which allows iterating over a Script in a more sensible way
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Instruction<'a> {
+    /// Push a bunch of data
+    PushBytes(&'a [u8]),
+    /// Some non-push opcode
+    Op(opcodes::All),
+}
+
+/// Iterator over a script returning parsed opcodes
+pub struct Instructions<'a> {
+    data: &'a [u8],
+    enforce_minimal: bool,
+}
+
+impl<'a> Iterator for Instructions<'a> {
+    type Item = Result<Instruction<'a>, Error>;
+
+    fn next(&mut self) -> Option<Result<Instruction<'a>, Error>> {
+        if self.data.is_empty() {
+            return None;
+        }
+
+        match opcodes::All::from(self.data[0]).classify() {
+            opcodes::Class::PushBytes(n) => {
+                let n = n as usize;
+                if self.data.len() < n + 1 {
+                    self.data = &[];  // Kill iterator so that it does not return an infinite stream of errors
+                    return Some(Err(Error::EarlyEndOfScript));
+                }
+                if self.enforce_minimal {
+                    if n == 1 && (self.data[1] == 0x81 || (self.data[1] > 0 && self.data[1] <= 16)) {
+                        self.data = &[];
+                        return Some(Err(Error::NonMinimalPush));
+                    }
+                }
+                let ret = Some(Ok(Instruction::PushBytes(&self.data[1..n+1])));
+                self.data = &self.data[n + 1..];
+                ret
+            }
+            opcodes::Class::Ordinary(opcodes::Ordinary::OP_PUSHDATA1) => {
+                if self.data.len() < 2 {
+                    self.data = &[];
+                    return Some(Err(Error::EarlyEndOfScript));
+                }
+                let n = match read_uint(&self.data[1..], 1) {
+                    Ok(n) => n,
+                    Err(e) => {
+                        self.data = &[];
+                        return Some(Err(e));
+                    }
+                };
+                if self.data.len() < n + 2 {
+                    self.data = &[];
+                    return Some(Err(Error::EarlyEndOfScript));
+                }
+                if self.enforce_minimal && n < 76 {
+                    self.data = &[];
+                    return Some(Err(Error::NonMinimalPush));
+                }
+                let ret = Some(Ok(Instruction::PushBytes(&self.data[2..n+2])));
+                self.data = &self.data[n + 2..];
+                ret
+            }
+            opcodes::Class::Ordinary(opcodes::Ordinary::OP_PUSHDATA2) => {
+                if self.data.len() < 3 {
+                    self.data = &[];
+                    return Some(Err(Error::EarlyEndOfScript));
+                }
+                let n = match read_uint(&self.data[1..], 2) {
+                    Ok(n) => n,
+                    Err(e) => {
+                        self.data = &[];
+                        return Some(Err(e));
+                    }
+                };
+                if self.enforce_minimal && n < 0x100 {
+                    self.data = &[];
+                    return Some(Err(Error::NonMinimalPush));
+                }
+                if self.data.len() < n + 3 {
+                    self.data = &[];
+                    return Some(Err(Error::EarlyEndOfScript));
+                }
+                let ret = Some(Ok(Instruction::PushBytes(&self.data[3..n + 3])));
+                self.data = &self.data[n + 3..];
+                ret
+            }
+            opcodes::Class::Ordinary(opcodes::Ordinary::OP_PUSHDATA4) => {
+                if self.data.len() < 5 {
+                    self.data = &[];
+                    return Some(Err(Error::EarlyEndOfScript));
+                }
+                let n = match read_uint(&self.data[1..], 4) {
+                    Ok(n) => n,
+                    Err(e) => {
+                        self.data = &[];
+                        return Some(Err(e));
+                    }
+                };
+                if self.enforce_minimal && n < 0x10000 {
+                    self.data = &[];
+                    return Some(Err(Error::NonMinimalPush));
+                }
+                if self.data.len() < n + 5 {
+                    self.data = &[];
+                    return Some(Err(Error::EarlyEndOfScript));
+                }
+                let ret = Some(Ok(Instruction::PushBytes(&self.data[5..n + 5])));
+                self.data = &self.data[n + 5..];
+                ret
+            }
+            // Everything else we can push right through
+            _ => {
+                let ret = Some(Ok(Instruction::Op(opcodes::All::from(self.data[0]))));
+                self.data = &self.data[1..];
+                ret
+            }
+        }
+    }
+}
+
+impl Builder {
+    /// Creates a new empty script
+    pub fn new() -> Self {
+        Builder(vec![], None)
+    }
+
+    /// The length in bytes of the script
+    pub fn len(&self) -> usize { self.0.len() }
+
+    /// Whether the script is the empty script
+    pub fn is_empty(&self) -> bool { self.0.is_empty() }
+
+    /// Adds instructions to push an integer onto the stack. Integers are
+    /// encoded as little-endian signed-magnitude numbers, but there are
+    /// dedicated opcodes to push some small integers.
+    pub fn push_int(self, data: i64) -> Builder {
+        // We can special-case -1, 1-16
+        if data == -1 || (data >= 1 && data <= 16) {
+            let opcode = opcodes::All::from(
+                (data - 1 + opcodes::OP_TRUE.into_u8() as i64) as u8
+            );
+            self.push_opcode(opcode)
+        }
+        // We can also special-case zero
+        else if data == 0 {
+            self.push_opcode(opcodes::OP_FALSE)
+        }
+        // Otherwise encode it as data
+        else { self.push_scriptint(data) }
+    }
+
+    /// Adds instructions to push an integer onto the stack, using the explicit
+    /// encoding regardless of the availability of dedicated opcodes.
+    pub fn push_scriptint(self, data: i64) -> Builder {
+        self.push_slice(&build_scriptint(data))
+    }
+
+    /// Adds instructions to push some arbitrary data onto the stack
+    pub fn push_slice(mut self, data: &[u8]) -> Builder {
+        // Start with a PUSH opcode
+        match data.len() as u64 {
+            n if n < opcodes::Ordinary::OP_PUSHDATA1 as u64 => { self.0.push(n as u8); },
+            n if n < 0x100 => {
+                self.0.push(opcodes::Ordinary::OP_PUSHDATA1.into_u8());
+                self.0.push(n as u8);
+            },
+            n if n < 0x10000 => {
+                self.0.push(opcodes::Ordinary::OP_PUSHDATA2.into_u8());
+                self.0.push((n % 0x100) as u8);
+                self.0.push((n / 0x100) as u8);
+            },
+            n if n < 0x100000000 => {
+                self.0.push(opcodes::Ordinary::OP_PUSHDATA4.into_u8());
+                self.0.push((n % 0x100) as u8);
+                self.0.push(((n / 0x100) % 0x100) as u8);
+                self.0.push(((n / 0x10000) % 0x100) as u8);
+                self.0.push((n / 0x1000000) as u8);
+            }
+            _ => panic!("tried to put a 4bn+ sized object into a script!")
+        }
+        // Then push the raw bytes
+        self.0.extend(data.iter().cloned());
+        self.1 = None;
+        self
+    }
+
+    /// Pushes a public key
+    #[cfg(any())]
+    pub fn push_key(self, key: &PublicKey) -> Builder {
+        if key.compressed {
+            self.push_slice(&key.key.serialize()[..])
+        } else {
+            self.push_slice(&key.key.serialize_uncompressed()[..])
+        }
+    }
+
+    /// Adds a single opcode to the script
+    pub fn push_opcode(mut self, data: opcodes::All) -> Builder {
+        self.0.push(data.into_u8());
+        self.1 = Some(data);
+        self
+    }
+
+    /// Adds an `OP_VERIFY` to the script, unless the most-recently-added
+    /// opcode has an alternate `VERIFY` form, in which case that opcode
+    /// is replaced. e.g. `OP_CHECKSIG` will become `OP_CHECKSIGVERIFY`.
+    pub fn push_verify(mut self) -> Builder {
+        match self.1 {
+            Some(opcodes::all::OP_EQUAL) => {
+                self.0.pop();
+                self.push_opcode(opcodes::all::OP_EQUALVERIFY)
+            },
+            Some(opcodes::all::OP_NUMEQUAL) => {
+                self.0.pop();
+                self.push_opcode(opcodes::all::OP_NUMEQUALVERIFY)
+            },
+            Some(opcodes::all::OP_CHECKSIG) => {
+                self.0.pop();
+                self.push_opcode(opcodes::all::OP_CHECKSIGVERIFY)
+            },
+            Some(opcodes::all::OP_CHECKMULTISIG) => {
+                self.0.pop();
+                self.push_opcode(opcodes::all::OP_CHECKMULTISIGVERIFY)
+            },
+            _ => self.push_opcode(opcodes::all::OP_VERIFY),
+        }
+    }
+
+    /// Converts the `Builder` into an unmodifiable `Script`
+    pub fn into_script(self) -> Script {
+        Script(self.0.into_boxed_slice())
+    }
+}
+
+/// Adds an individual opcode to the script
+impl Default for Builder {
+    fn default() -> Builder { Builder::new() }
+}
+
+/// Creates a new script from an existing vector
+impl From<Vec<u8>> for Builder {
+    fn from(v: Vec<u8>) -> Builder {
+        let script = Script(v.into_boxed_slice());
+        let last_op = match script.instructions().last() {
+            Some(Ok(Instruction::Op(op))) => Some(op),
+            _ => None,
+        };
+        Builder(script.into_bytes(), last_op)
+    }
+}
+
+impl_index_newtype!(Builder, u8);
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Script {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where D: serde::Deserializer<'de>,
+    {
+        use core::fmt::Formatter;
+        use hashes::hex::FromHex;
+
+        if deserializer.is_human_readable() {
+
+            struct Visitor;
+            impl<'de> serde::de::Visitor<'de> for Visitor {
+                type Value = Script;
+
+                fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                    formatter.write_str("a script hex")
+                }
+
+                fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                    where E: serde::de::Error,
+                {
+                    let v = Vec::from_hex(v).map_err(E::custom)?;
+                    Ok(Script::from(v))
+                }
+
+                fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+                    where E: serde::de::Error,
+                {
+                    self.visit_str(v)
+                }
+
+                fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+                    where E: serde::de::Error,
+                {
+                    self.visit_str(&v)
+                }
+            }
+            deserializer.deserialize_str(Visitor)
+        } else {
+            struct BytesVisitor;
+
+            impl<'de> serde::de::Visitor<'de> for BytesVisitor {
+                type Value = Script;
+
+                fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                    formatter.write_str("a script Vec<u8>")
+                }
+
+                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                    where E: serde::de::Error,
+                {
+                    Ok(Script::from(v.to_vec()))
+                }
+            }
+            deserializer.deserialize_bytes(BytesVisitor)
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Script {
+    /// User-facing serialization for `Script`.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&format!("{:x}", self))
+        } else {
+            serializer.serialize_bytes(&self.as_bytes())
+        }
+    }
+}
+
+// Network serialization
+#[cfg(any())]
+impl Encodable for Script {
+    #[inline]
+    fn consensus_encode<S: io::Write>(
+        &self,
+        s: S,
+    ) -> Result<usize, io::Error> {
+        self.0.consensus_encode(s)
+    }
+}
+
+#[cfg(any())]
+impl Decodable for Script {
+    #[inline]
+    fn consensus_decode<D: io::Read>(d: D) -> Result<Self, encode::Error> {
+        Ok(Script(Decodable::consensus_decode(d)?))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use super::build_scriptint;
+
+    use hex_literal::hex;
+
+    #[test]
+    fn script() {
+        let mut comp = vec![];
+        let mut script = Builder::new();
+        assert_eq!(&script[..], &comp[..]);
+
+        // small ints
+        script = script.push_int(1);  comp.push(81u8); assert_eq!(&script[..], &comp[..]);
+        script = script.push_int(0);  comp.push(0u8);  assert_eq!(&script[..], &comp[..]);
+        script = script.push_int(4);  comp.push(84u8); assert_eq!(&script[..], &comp[..]);
+        script = script.push_int(-1); comp.push(79u8); assert_eq!(&script[..], &comp[..]);
+        // forced scriptint
+        script = script.push_scriptint(4); comp.extend([1u8, 4].iter().cloned()); assert_eq!(&script[..], &comp[..]);
+        // big ints
+        script = script.push_int(17); comp.extend([1u8, 17].iter().cloned()); assert_eq!(&script[..], &comp[..]);
+        script = script.push_int(10000); comp.extend([2u8, 16, 39].iter().cloned()); assert_eq!(&script[..], &comp[..]);
+        // notice the sign bit set here, hence the extra zero/128 at the end
+        script = script.push_int(10000000); comp.extend([4u8, 128, 150, 152, 0].iter().cloned()); assert_eq!(&script[..], &comp[..]);
+        script = script.push_int(-10000000); comp.extend([4u8, 128, 150, 152, 128].iter().cloned()); assert_eq!(&script[..], &comp[..]);
+
+        // data
+        script = script.push_slice("NRA4VR".as_bytes());
+        comp.extend([6u8, 78, 82, 65, 52, 86, 82].iter().cloned());
+        assert_eq!(&script[..], &comp[..]);
+
+        /*
+        // keys
+        let key = hex!("21032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af");
+        script = script.push_slice(&key);
+        comp.push(33u8);
+        comp.extend(&key);
+        assert_eq!(&script[..], &comp[..]);
+        let keystr = "41042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133";
+        let key = PublicKey::from_str(&keystr[2..]).unwrap();
+        script = script.push_key(&key); comp.extend(Vec::from_hex(keystr).unwrap().iter().cloned()); assert_eq!(&script[..], &comp[..]);
+        */
+
+        // opcodes
+        script = script.push_opcode(opcodes::all::OP_CHECKSIG); comp.push(0xACu8); assert_eq!(&script[..], &comp[..]);
+        script = script.push_opcode(opcodes::all::OP_CHECKSIG); comp.push(0xACu8); assert_eq!(&script[..], &comp[..]);
+    }
+
+    #[test]
+    fn script_builder() {
+        // from txid 3bb5e6434c11fb93f64574af5d116736510717f2c595eb45b52c28e31622dfff which was in my mempool when I wrote the test
+        let script = Builder::new().push_opcode(opcodes::all::OP_DUP)
+                                   .push_opcode(opcodes::all::OP_HASH160)
+                                   .push_slice(&hex!("16e1ae70ff0fa102905d4af297f6912bda6cce19"))
+                                   .push_opcode(opcodes::all::OP_EQUALVERIFY)
+                                   .push_opcode(opcodes::all::OP_CHECKSIG)
+                                   .into_script();
+        assert_eq!(&format!("{:x}", script), "76a91416e1ae70ff0fa102905d4af297f6912bda6cce1988ac");
+    }
+
+    #[cfg(any())]
+    #[test]
+    fn script_generators() {
+        let pubkey = PublicKey::from_str("0234e6a79c5359c613762d537e0e19d86c77c1666d8c9ab050f23acd198e97f93e").unwrap();
+        assert!(Script::new_p2pk(&pubkey).is_p2pk());
+
+        let pubkey_hash = PubkeyHash::hash(&pubkey.serialize());
+        assert!(Script::new_p2pkh(&pubkey_hash).is_p2pkh());
+
+        let wpubkey_hash = WPubkeyHash::hash(&pubkey.serialize());
+        assert!(Script::new_v0_wpkh(&wpubkey_hash).is_v0_p2wpkh());
+
+        let script = Builder::new().push_opcode(opcodes::all::OP_NUMEQUAL)
+                                   .push_verify()
+                                   .into_script();
+        let script_hash = ScriptHash::hash(&script.serialize());
+        let p2sh = Script::new_p2sh(&script_hash);
+        assert!(p2sh.is_p2sh());
+        assert_eq!(script.to_p2sh(), p2sh);
+
+        let wscript_hash = WScriptHash::hash(&script.serialize());
+        let p2wsh = Script::new_v0_wsh(&wscript_hash);
+        assert!(p2wsh.is_v0_p2wsh());
+        assert_eq!(script.to_v0_p2wsh(), p2wsh);
+
+        // Test data are taken from the second output of
+        // 2ccb3a1f745eb4eefcf29391460250adda5fab78aaddb902d25d3cd97d9d8e61 transaction
+        let data = Vec::<u8>::from_hex("aa21a9ed20280f53f2d21663cac89e6bd2ad19edbabb048cda08e73ed19e9268d0afea2a").unwrap();
+        let op_return = Script::new_op_return(&data);
+        assert!(op_return.is_op_return());
+        assert_eq!(op_return.to_hex(), "6a24aa21a9ed20280f53f2d21663cac89e6bd2ad19edbabb048cda08e73ed19e9268d0afea2a");
+    }
+
+    #[test]
+    fn script_builder_verify() {
+        let simple = Builder::new()
+            .push_verify()
+            .into_script();
+        assert_eq!(format!("{:x}", simple), "69");
+        let simple2 = Builder::from(vec![])
+            .push_verify()
+            .into_script();
+        assert_eq!(format!("{:x}", simple2), "69");
+
+        let nonverify = Builder::new()
+            .push_verify()
+            .push_verify()
+            .into_script();
+        assert_eq!(format!("{:x}", nonverify), "6969");
+        let nonverify2 = Builder::from(vec![0x69])
+            .push_verify()
+            .into_script();
+        assert_eq!(format!("{:x}", nonverify2), "6969");
+
+        let equal = Builder::new()
+            .push_opcode(opcodes::all::OP_EQUAL)
+            .push_verify()
+            .into_script();
+        assert_eq!(format!("{:x}", equal), "88");
+        let equal2 = Builder::from(vec![0x87])
+            .push_verify()
+            .into_script();
+        assert_eq!(format!("{:x}", equal2), "88");
+
+        let numequal = Builder::new()
+            .push_opcode(opcodes::all::OP_NUMEQUAL)
+            .push_verify()
+            .into_script();
+        assert_eq!(format!("{:x}", numequal), "9d");
+        let numequal2 = Builder::from(vec![0x9c])
+            .push_verify()
+            .into_script();
+        assert_eq!(format!("{:x}", numequal2), "9d");
+
+        let checksig = Builder::new()
+            .push_opcode(opcodes::all::OP_CHECKSIG)
+            .push_verify()
+            .into_script();
+        assert_eq!(format!("{:x}", checksig), "ad");
+        let checksig2 = Builder::from(vec![0xac])
+            .push_verify()
+            .into_script();
+        assert_eq!(format!("{:x}", checksig2), "ad");
+
+        let checkmultisig = Builder::new()
+            .push_opcode(opcodes::all::OP_CHECKMULTISIG)
+            .push_verify()
+            .into_script();
+        assert_eq!(format!("{:x}", checkmultisig), "af");
+        let checkmultisig2 = Builder::from(vec![0xae])
+            .push_verify()
+            .into_script();
+        assert_eq!(format!("{:x}", checkmultisig2), "af");
+
+        let trick_slice = Builder::new()
+            .push_slice(&[0xae]) // OP_CHECKMULTISIG
+            .push_verify()
+            .into_script();
+        assert_eq!(format!("{:x}", trick_slice), "01ae69");
+        let trick_slice2 = Builder::from(vec![0x01, 0xae])
+            .push_verify()
+            .into_script();
+        assert_eq!(format!("{:x}", trick_slice2), "01ae69");
+   }
+
+    #[cfg(any())]
+    #[test]
+    fn script_serialize() {
+        let hex_script = Vec::from_hex("6c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52").unwrap();
+        let script: Result<Script, _> = deserialize(&hex_script);
+        assert!(script.is_ok());
+        assert_eq!(serialize(&script.unwrap()), hex_script);
+    }
+
+    #[test]
+    fn scriptint_round_trip() {
+        assert_eq!(build_scriptint(-1), vec![0x81]);
+        assert_eq!(build_scriptint(255), vec![255, 0]);
+        assert_eq!(build_scriptint(256), vec![0, 1]);
+        assert_eq!(build_scriptint(257), vec![1, 1]);
+        assert_eq!(build_scriptint(511), vec![255, 1]);
+        for &i in [10, 100, 255, 256, 1000, 10000, 25000, 200000, 5000000, 1000000000,
+                             (1 << 31) - 1, -((1 << 31) - 1)].iter() {
+            assert_eq!(Ok(i), read_scriptint(&build_scriptint(i)));
+            assert_eq!(Ok(-i), read_scriptint(&build_scriptint(-i)));
+        }
+        assert!(read_scriptint(&build_scriptint(1 << 31)).is_err());
+        assert!(read_scriptint(&build_scriptint(-(1 << 31))).is_err());
+    }
+
+    #[cfg(any())]
+    #[test]
+    fn script_hashes() {
+        let script = hex_script!("410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac");
+        assert_eq!(script.script_hash().to_hex(), "8292bcfbef1884f73c813dfe9c82fd7e814291ea");
+        assert_eq!(script.wscript_hash().to_hex(), "3e1525eb183ad4f9b3c5fa3175bdca2a52e947b135bbb90383bf9f6408e2c324");
+    }
+
+    #[test]
+    fn provably_unspendable_test() {
+        // p2pk
+        assert_eq!(hex_script!("410446ef0102d1ec5240f0d061a4246c1bdef63fc3dbab7733052fbbf0ecd8f41fc26bf049ebb4f9527f374280259e7cfa99c48b0e3f39c51347a19a5819651503a5ac").is_provably_unspendable(), false);
+        assert_eq!(hex_script!("4104ea1feff861b51fe3f5f8a3b12d0f4712db80e919548a80839fc47c6a21e66d957e9c5d8cd108c7a2d2324bad71f9904ac0ae7336507d785b17a2c115e427a32fac").is_provably_unspendable(), false);
+        // p2pkhash
+        assert_eq!(hex_script!("76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac").is_provably_unspendable(), false);
+        assert_eq!(hex_script!("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87").is_provably_unspendable(), true);
+    }
+
+    #[test]
+    fn op_return_test() {
+        assert_eq!(hex_script!("6aa9149eb21980dc9d413d8eac27314938b9da920ee53e87").is_op_return(), true);
+        assert_eq!(hex_script!("76a914ee61d57ab51b9d212335b1dba62794ac20d2bcf988ac").is_op_return(), false);
+        assert_eq!(hex_script!("").is_op_return(), false);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn script_json_serialize() {
+        use serde_json;
+
+        let original = hex_script!("827651a0698faaa9a8a7a687");
+        let json = serde_json::to_value(&original).unwrap();
+        assert_eq!(json, serde_json::Value::String("827651a0698faaa9a8a7a687".to_owned()));
+        let des = serde_json::from_value(json).unwrap();
+        assert_eq!(original, des);
+    }
+
+    #[test]
+    fn script_asm() {
+        assert_eq!(hex_script!("6363636363686868686800").asm(),
+                   "OP_IF OP_IF OP_IF OP_IF OP_IF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_0");
+        assert_eq!(hex_script!("6363636363686868686800").asm(),
+                   "OP_IF OP_IF OP_IF OP_IF OP_IF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_ENDIF OP_0");
+        assert_eq!(hex_script!("2102715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699ac").asm(),
+                   "OP_PUSHBYTES_33 02715e91d37d239dea832f1460e91e368115d8ca6cc23a7da966795abad9e3b699 OP_CHECKSIG");
+        // Elements Alpha peg-out transaction with some signatures removed for brevity. Mainly to test PUSHDATA1
+        assert_eq!(hex_script!("0047304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401004cf1552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae").asm(),
+                   "OP_0 OP_PUSHBYTES_71 304402202457e78cc1b7f50d0543863c27de75d07982bde8359b9e3316adec0aec165f2f02200203fd331c4e4a4a02f48cf1c291e2c0d6b2f7078a784b5b3649fca41f8794d401 OP_0 OP_PUSHDATA1 552103244e602b46755f24327142a0517288cebd159eccb6ccf41ea6edf1f601e9af952103bbbacc302d19d29dbfa62d23f37944ae19853cf260c745c2bea739c95328fcb721039227e83246bd51140fe93538b2301c9048be82ef2fb3c7fc5d78426ed6f609ad210229bf310c379b90033e2ecb07f77ecf9b8d59acb623ab7be25a0caed539e2e6472103703e2ed676936f10b3ce9149fa2d4a32060fb86fa9a70a4efe3f21d7ab90611921031e9b7c6022400a6bb0424bbcde14cff6c016b91ee3803926f3440abf5c146d05210334667f975f55a8455d515a2ef1c94fdfa3315f12319a14515d2a13d82831f62f57ae");
+    }
+
+    #[test]
+    fn script_p2sh_p2p2k_template() {
+        // random outputs I picked out of the mempool
+        assert!(hex_script!("76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ac").is_p2pkh());
+        assert!(!hex_script!("76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ac").is_p2sh());
+        assert!(!hex_script!("76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ad").is_p2pkh());
+        assert!(!hex_script!("").is_p2pkh());
+        assert!(hex_script!("a914acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87").is_p2sh());
+        assert!(!hex_script!("a914acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87").is_p2pkh());
+        assert!(!hex_script!("a314acc91e6fef5c7f24e5c8b3f11a664aa8f1352ffd87").is_p2sh());
+    }
+
+    #[test]
+    fn script_p2pk() {
+        assert!(hex_script!("21021aeaf2f8638a129a3156fbe7e5ef635226b0bafd495ff03afe2c843d7e3a4b51ac").is_p2pk());
+        assert!(hex_script!("410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac").is_p2pk());
+    }
+
+    #[cfg(any())]
+    #[test]
+    fn p2sh_p2wsh_conversion() {
+        // Test vectors taken from Core tests/data/script_tests.json
+        // bare p2wsh
+        let redeem_script = hex_script!("410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8ac");
+        let expected_witout = hex_script!("0020b95237b48faaa69eb078e1170be3b5cbb3fddf16d0a991e14ad274f7b33a4f64");
+        assert!(redeem_script.to_v0_p2wsh().is_v0_p2wsh());
+        assert_eq!(redeem_script.to_v0_p2wsh(), expected_witout);
+
+        // p2sh
+        let redeem_script = hex_script!("0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8");
+        let expected_p2shout = hex_script!("a91491b24bf9f5288532960ac687abb035127b1d28a587");
+        assert!(redeem_script.to_p2sh().is_p2sh());
+        assert_eq!(redeem_script.to_p2sh(), expected_p2shout);
+
+        // p2sh-p2wsh
+        let redeem_script = hex_script!("410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8ac");
+        let expected_witout = hex_script!("0020b95237b48faaa69eb078e1170be3b5cbb3fddf16d0a991e14ad274f7b33a4f64");
+        let expected_out = hex_script!("a914f386c2ba255cc56d20cfa6ea8b062f8b5994551887");
+        assert!(redeem_script.to_p2sh().is_p2sh());
+        assert!(redeem_script.to_p2sh().to_v0_p2wsh().is_v0_p2wsh());
+        assert_eq!(redeem_script.to_v0_p2wsh(), expected_witout);
+        assert_eq!(redeem_script.to_v0_p2wsh().to_p2sh(), expected_out);
+    }
+
+    #[test]
+    fn test_iterator() {
+        let zero = hex_script!("00");
+        let zeropush = hex_script!("0100");
+
+        let nonminimal = hex_script!("4c0169b2");      // PUSHDATA1 for no reason
+        let minimal = hex_script!("0169b2");           // minimal
+        let nonminimal_alt = hex_script!("026900b2");  // non-minimal number but minimal push (should be OK)
+
+        let v_zero: Result<Vec<Instruction>, Error> = zero.instructions_minimal().collect();
+        let v_zeropush: Result<Vec<Instruction>, Error> = zeropush.instructions_minimal().collect();
+
+        let v_min: Result<Vec<Instruction>, Error> = minimal.instructions_minimal().collect();
+        let v_nonmin: Result<Vec<Instruction>, Error> = nonminimal.instructions_minimal().collect();
+        let v_nonmin_alt: Result<Vec<Instruction>, Error> = nonminimal_alt.instructions_minimal().collect();
+        let slop_v_min: Result<Vec<Instruction>, Error> = minimal.instructions().collect();
+        let slop_v_nonmin: Result<Vec<Instruction>, Error> = nonminimal.instructions().collect();
+        let slop_v_nonmin_alt: Result<Vec<Instruction>, Error> = nonminimal_alt.instructions().collect();
+
+        assert_eq!(
+            v_zero.unwrap(),
+            vec![
+                Instruction::PushBytes(&[]),
+            ]
+        );
+        assert_eq!(
+            v_zeropush.unwrap(),
+            vec![
+                Instruction::PushBytes(&[0]),
+            ]
+        );
+
+        assert_eq!(
+            v_min.clone().unwrap(),
+            vec![
+                Instruction::PushBytes(&[105]),
+                Instruction::Op(opcodes::OP_NOP3),
+            ]
+        );
+
+        assert_eq!(
+            v_nonmin.err().unwrap(),
+            Error::NonMinimalPush
+        );
+
+        assert_eq!(
+            v_nonmin_alt.clone().unwrap(),
+            vec![
+                Instruction::PushBytes(&[105, 0]),
+                Instruction::Op(opcodes::OP_NOP3),
+            ]
+        );
+
+        assert_eq!(v_min.clone().unwrap(), slop_v_min.unwrap());
+        assert_eq!(v_min.unwrap(), slop_v_nonmin.unwrap());
+        assert_eq!(v_nonmin_alt.unwrap(), slop_v_nonmin_alt.unwrap());
+    }
+
+	#[test]
+    fn script_ord() {
+        let script_1 = Builder::new().push_slice(&[1,2,3,4]).into_script();
+        let script_2 = Builder::new().push_int(10).into_script();
+        let script_3 = Builder::new().push_int(15).into_script();
+        let script_4 = Builder::new().push_opcode(opcodes::all::OP_RETURN).into_script();
+
+        assert!(script_1 < script_2);
+        assert!(script_2 < script_3);
+        assert!(script_3 < script_4);
+
+        assert!(script_1 <= script_1);
+        assert!(script_1 >= script_1);
+
+        assert!(script_4 > script_3);
+        assert!(script_3 > script_2);
+        assert!(script_2 > script_1);
+    }
+
+	#[test]
+	#[cfg(feature="bitcoinconsensus")]
+	fn test_bitcoinconsensus () {
+		// a random segwit transaction from the blockchain using native segwit
+		let spent = Builder::from(Vec::from_hex("0020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d").unwrap()).into_script();
+		let spending = Vec::from_hex("010000000001011f97548fbbe7a0db7588a66e18d803d0089315aa7d4cc28360b6ec50ef36718a0100000000ffffffff02df1776000000000017a9146c002a686959067f4866b8fb493ad7970290ab728757d29f0000000000220020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d04004730440220565d170eed95ff95027a69b313758450ba84a01224e1f7f130dda46e94d13f8602207bdd20e307f062594022f12ed5017bbf4a055a06aea91c10110a0e3bb23117fc014730440220647d2dc5b15f60bc37dc42618a370b2a1490293f9e5c8464f53ec4fe1dfe067302203598773895b4b16d37485cbe21b337f4e4b650739880098c592553add7dd4355016952210375e00eb72e29da82b89367947f29ef34afb75e8654f6ea368e0acdfd92976b7c2103a1b26313f430c4b15bb1fdce663207659d8cac749a0e53d70eff01874496feff2103c96d495bfdd5ba4145e3e046fee45e84a8a48ad05bd8dbb395c011a32cf9f88053ae00000000").unwrap();
+		spent.verify(0, ::Amount::from_sat(18393430), spending.as_slice()).unwrap();
+	}
+
+    #[cfg(any())]
+    #[test]
+    fn defult_dust_value_tests() {
+        // Check that our dust_value() calculator correctly calculates the dust limit on common
+        // well-known scriptPubKey types.
+        let script_p2wpkh = Builder::new().push_int(0).push_slice(&[42; 20]).into_script();
+        assert!(script_p2wpkh.is_v0_p2wpkh());
+        assert_eq!(script_p2wpkh.dust_value(), ::Amount::from_sat(294));
+
+        let script_p2pkh = Builder::new()
+            .push_opcode(opcodes::all::OP_DUP)
+            .push_opcode(opcodes::all::OP_HASH160)
+            .push_slice(&[42; 20])
+            .push_opcode(opcodes::all::OP_EQUALVERIFY)
+            .push_opcode(opcodes::all::OP_CHECKSIG)
+            .into_script();
+        assert!(script_p2pkh.is_p2pkh());
+        assert_eq!(script_p2pkh.dust_value(), ::Amount::from_sat(546));
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_script_serde_human_and_not() {
+        let script = Script::from(vec![0u8, 1u8, 2u8]);
+
+        // Serialize
+        let json = ::serde_json::to_string(&script).unwrap();
+        assert_eq!(json, "\"000102\"");
+        let bincode = ::bincode::serialize(&script).unwrap();
+        assert_eq!(bincode, [3, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2]); // bincode adds u64 for length, serde_cbor use varint
+
+        // Deserialize
+        assert_eq!(script, ::serde_json::from_str(&json).unwrap());
+        assert_eq!(script, ::bincode::deserialize(&bincode).unwrap());
+    }
+
+}

--- a/libs/chainscript/src/script.rs
+++ b/libs/chainscript/src/script.rs
@@ -578,6 +578,15 @@ impl Builder {
         self
     }
 
+    /// Adds instructions to push some arbitrary data onto the stack in minimal encoding
+    pub fn push_slice_minimal(self, data: &[u8]) -> Builder {
+        match data {
+            [129] => self.push_int(-1),
+            [x] if (1..=16).contains(x) => self.push_int(*x as i64),
+            _ => self.push_slice(data),
+        }
+    }
+
     /// Adds a single opcode to the script
     pub fn push_opcode(mut self, data: opcodes::All) -> Builder {
         self.0.push(data.into_u8());

--- a/libs/chainscript/src/script.rs
+++ b/libs/chainscript/src/script.rs
@@ -26,9 +26,9 @@
 //!
 //! This module provides the structures and functions needed to support scripts.
 
-use sp_std::prelude::*;
-
+use codec::{Decode, Encode};
 use core::{default::Default, fmt};
+use sp_std::prelude::*;
 
 use crate::{error::Error, opcodes};
 
@@ -36,9 +36,15 @@ use crate::{error::Error, opcodes};
 type PubkeyHash = [u8];
 type ScriptHash = [u8];
 
-#[derive(Clone, Default, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(Clone, Default, PartialOrd, Ord, PartialEq, Eq, Hash, Encode)]
 /// A Bitcoin script
 pub struct Script(Box<[u8]>);
+
+impl Decode for Script {
+    fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
+        Vec::decode(input).map(Script::from)
+    }
+}
 
 impl AsRef<[u8]> for Script {
     fn as_ref(&self) -> &[u8] {

--- a/libs/chainscript/src/script.rs
+++ b/libs/chainscript/src/script.rs
@@ -101,7 +101,7 @@ impl ::sp_std::str::FromStr for Script {
 pub struct Builder(Vec<u8>, Option<opcodes::All>);
 display_from_debug!(Builder);
 /// Helper to encode an integer in script format
-fn build_scriptint(n: i64) -> Vec<u8> {
+pub fn build_scriptint(n: i64) -> Vec<u8> {
 	if n == 0 {
 		return vec![]
 	}
@@ -1341,5 +1341,15 @@ mod test {
 		// Deserialize
 		assert_eq!(script, ::serde_json::from_str(&json).unwrap());
 		assert_eq!(script, ::bincode::deserialize(&bincode).unwrap());
+	}
+
+	use proptest::prelude::*;
+
+	proptest! {
+		#[test]
+		fn prop_scriptint_roundtrip(x: i32) {
+			let y = read_scriptint(&build_scriptint(x as i64));
+			prop_assert_eq!(Ok(x as i64), y);
+		}
 	}
 }

--- a/libs/chainscript/src/util.rs
+++ b/libs/chainscript/src/util.rs
@@ -84,28 +84,6 @@ macro_rules! hex_script {
 	};
 }
 
-/// Check given condition and return an error if not satisfied.
-///
-/// This is useful for exiting a function if given boolean condition is not met. See the example
-/// below.
-///
-/// ```
-/// use chainscript::util::check;
-///
-/// fn div2(x: i32) -> Result<i32, &'static str> {
-///     check(x >= 0, "number has to be positive")?;
-///     check((x & 1) == 0, "number has to be even")?;
-///     Ok(x / 2)
-/// }
-///
-/// assert!(div2(3).is_err());
-/// assert!(div2(-5).is_err());
-/// assert_eq!(div2(8), Ok(4));
-/// ```
-pub fn check<E>(c: bool, e: E) -> Result<(), E> {
-	c.then(|| ()).ok_or(e)
-}
-
 // Export some hash functions.
 pub use sp_io::hashing::sha2_256 as sha256;
 

--- a/libs/chainscript/src/util.rs
+++ b/libs/chainscript/src/util.rs
@@ -1,4 +1,21 @@
-//use hex_literal::hex;
+// Copyright (c) 2021 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): L. Kuklinek
+
+//! Various uncategorised utilities
 
 /// Implements standard indexing methods for a given wrapper type
 macro_rules! impl_index_newtype {

--- a/libs/chainscript/src/util.rs
+++ b/libs/chainscript/src/util.rs
@@ -2,67 +2,67 @@
 
 /// Implements standard indexing methods for a given wrapper type
 macro_rules! impl_index_newtype {
-    ($thing:ident, $ty:ty) => {
+	($thing:ident, $ty:ty) => {
+		impl ::core::ops::Index<usize> for $thing {
+			type Output = $ty;
 
-        impl ::core::ops::Index<usize> for $thing {
-            type Output = $ty;
+			#[inline]
+			fn index(&self, index: usize) -> &$ty {
+				&self.0[index]
+			}
+		}
 
-            #[inline]
-            fn index(&self, index: usize) -> &$ty {
-                &self.0[index]
-            }
-        }
+		impl ::core::ops::Index<::core::ops::Range<usize>> for $thing {
+			type Output = [$ty];
 
-        impl ::core::ops::Index<::core::ops::Range<usize>> for $thing {
-            type Output = [$ty];
+			#[inline]
+			fn index(&self, index: ::core::ops::Range<usize>) -> &[$ty] {
+				&self.0[index]
+			}
+		}
 
-            #[inline]
-            fn index(&self, index: ::core::ops::Range<usize>) -> &[$ty] {
-                &self.0[index]
-            }
-        }
+		impl ::core::ops::Index<::core::ops::RangeTo<usize>> for $thing {
+			type Output = [$ty];
 
-        impl ::core::ops::Index<::core::ops::RangeTo<usize>> for $thing {
-            type Output = [$ty];
+			#[inline]
+			fn index(&self, index: ::core::ops::RangeTo<usize>) -> &[$ty] {
+				&self.0[index]
+			}
+		}
 
-            #[inline]
-            fn index(&self, index: ::core::ops::RangeTo<usize>) -> &[$ty] {
-                &self.0[index]
-            }
-        }
+		impl ::core::ops::Index<::core::ops::RangeFrom<usize>> for $thing {
+			type Output = [$ty];
 
-        impl ::core::ops::Index<::core::ops::RangeFrom<usize>> for $thing {
-            type Output = [$ty];
+			#[inline]
+			fn index(&self, index: ::core::ops::RangeFrom<usize>) -> &[$ty] {
+				&self.0[index]
+			}
+		}
 
-            #[inline]
-            fn index(&self, index: ::core::ops::RangeFrom<usize>) -> &[$ty] {
-                &self.0[index]
-            }
-        }
+		impl ::core::ops::Index<::core::ops::RangeFull> for $thing {
+			type Output = [$ty];
 
-        impl ::core::ops::Index<::core::ops::RangeFull> for $thing {
-            type Output = [$ty];
-
-            #[inline]
-            fn index(&self, _: ::core::ops::RangeFull) -> &[$ty] {
-                &self.0[..]
-            }
-        }
-
-    }
+			#[inline]
+			fn index(&self, _: ::core::ops::RangeFull) -> &[$ty] {
+				&self.0[..]
+			}
+		}
+	};
 }
 
 macro_rules! display_from_debug {
-    ($thing:ident) => {
-        impl ::core::fmt::Display for $thing {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> Result<(), ::core::fmt::Error> {
-                ::core::fmt::Debug::fmt(self, f)
-            }
-        }
-    }
+	($thing:ident) => {
+		impl ::core::fmt::Display for $thing {
+			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> Result<(), ::core::fmt::Error> {
+				::core::fmt::Debug::fmt(self, f)
+			}
+		}
+	};
 }
 
 #[cfg(test)]
 macro_rules! hex_script {
-    ($s:expr) => (Script::from(Vec::from(hex!($s))));
+	($s:expr) => {
+		Script::from(Vec::from(hex!($s)))
+	};
 }

--- a/libs/chainscript/src/util.rs
+++ b/libs/chainscript/src/util.rs
@@ -66,3 +66,46 @@ macro_rules! hex_script {
 		Script::from(Vec::from(hex!($s)))
 	};
 }
+
+/// Check given condition and return an error if not satisfied.
+///
+/// This is useful for exiting a function if given boolean condition is not met. See the example
+/// below.
+///
+/// ```
+/// use chainscript::util::check;
+///
+/// fn div2(x: i32) -> Result<i32, &'static str> {
+///     check(x >= 0, "number has to be positive")?;
+///     check((x & 1) == 0, "number has to be even")?;
+///     Ok(x / 2)
+/// }
+///
+/// assert!(div2(3).is_err());
+/// assert!(div2(-5).is_err());
+/// assert_eq!(div2(8), Ok(4));
+/// ```
+pub fn check<E>(c: bool, e: E) -> Result<(), E> {
+	c.then(|| ()).ok_or(e)
+}
+
+// Export some hash functions.
+pub use sp_io::hashing::sha2_256 as sha256;
+
+pub fn sha1(data: &[u8]) -> [u8; 20] {
+	use sha1::{Digest, Sha1};
+	Sha1::digest(data).into()
+}
+
+pub fn ripemd160(data: &[u8]) -> [u8; 20] {
+	use ripemd160::{Digest, Ripemd160};
+	Ripemd160::digest(data).into()
+}
+
+pub fn hash256(data: &[u8]) -> [u8; 32] {
+	sha256(&sha256(data))
+}
+
+pub fn hash160(data: &[u8]) -> [u8; 20] {
+	ripemd160(&sha256(data))
+}

--- a/libs/chainscript/src/util.rs
+++ b/libs/chainscript/src/util.rs
@@ -1,0 +1,68 @@
+//use hex_literal::hex;
+
+/// Implements standard indexing methods for a given wrapper type
+macro_rules! impl_index_newtype {
+    ($thing:ident, $ty:ty) => {
+
+        impl ::core::ops::Index<usize> for $thing {
+            type Output = $ty;
+
+            #[inline]
+            fn index(&self, index: usize) -> &$ty {
+                &self.0[index]
+            }
+        }
+
+        impl ::core::ops::Index<::core::ops::Range<usize>> for $thing {
+            type Output = [$ty];
+
+            #[inline]
+            fn index(&self, index: ::core::ops::Range<usize>) -> &[$ty] {
+                &self.0[index]
+            }
+        }
+
+        impl ::core::ops::Index<::core::ops::RangeTo<usize>> for $thing {
+            type Output = [$ty];
+
+            #[inline]
+            fn index(&self, index: ::core::ops::RangeTo<usize>) -> &[$ty] {
+                &self.0[index]
+            }
+        }
+
+        impl ::core::ops::Index<::core::ops::RangeFrom<usize>> for $thing {
+            type Output = [$ty];
+
+            #[inline]
+            fn index(&self, index: ::core::ops::RangeFrom<usize>) -> &[$ty] {
+                &self.0[index]
+            }
+        }
+
+        impl ::core::ops::Index<::core::ops::RangeFull> for $thing {
+            type Output = [$ty];
+
+            #[inline]
+            fn index(&self, _: ::core::ops::RangeFull) -> &[$ty] {
+                &self.0[..]
+            }
+        }
+
+    }
+}
+
+macro_rules! display_from_debug {
+    ($thing:ident) => {
+        impl ::core::fmt::Display for $thing {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> Result<(), ::core::fmt::Error> {
+                ::core::fmt::Debug::fmt(self, f)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+macro_rules! hex_script {
+    ($s:expr) => (Script::from(Vec::from(hex!($s))));
+}

--- a/libs/chainscript/src/util.rs
+++ b/libs/chainscript/src/util.rs
@@ -19,88 +19,88 @@
 
 /// Implements standard indexing methods for a given wrapper type
 macro_rules! impl_index_newtype {
-	($thing:ident, $ty:ty) => {
-		impl ::core::ops::Index<usize> for $thing {
-			type Output = $ty;
+    ($thing:ident, $ty:ty) => {
+        impl ::core::ops::Index<usize> for $thing {
+            type Output = $ty;
 
-			#[inline]
-			fn index(&self, index: usize) -> &$ty {
-				&self.0[index]
-			}
-		}
+            #[inline]
+            fn index(&self, index: usize) -> &$ty {
+                &self.0[index]
+            }
+        }
 
-		impl ::core::ops::Index<::core::ops::Range<usize>> for $thing {
-			type Output = [$ty];
+        impl ::core::ops::Index<::core::ops::Range<usize>> for $thing {
+            type Output = [$ty];
 
-			#[inline]
-			fn index(&self, index: ::core::ops::Range<usize>) -> &[$ty] {
-				&self.0[index]
-			}
-		}
+            #[inline]
+            fn index(&self, index: ::core::ops::Range<usize>) -> &[$ty] {
+                &self.0[index]
+            }
+        }
 
-		impl ::core::ops::Index<::core::ops::RangeTo<usize>> for $thing {
-			type Output = [$ty];
+        impl ::core::ops::Index<::core::ops::RangeTo<usize>> for $thing {
+            type Output = [$ty];
 
-			#[inline]
-			fn index(&self, index: ::core::ops::RangeTo<usize>) -> &[$ty] {
-				&self.0[index]
-			}
-		}
+            #[inline]
+            fn index(&self, index: ::core::ops::RangeTo<usize>) -> &[$ty] {
+                &self.0[index]
+            }
+        }
 
-		impl ::core::ops::Index<::core::ops::RangeFrom<usize>> for $thing {
-			type Output = [$ty];
+        impl ::core::ops::Index<::core::ops::RangeFrom<usize>> for $thing {
+            type Output = [$ty];
 
-			#[inline]
-			fn index(&self, index: ::core::ops::RangeFrom<usize>) -> &[$ty] {
-				&self.0[index]
-			}
-		}
+            #[inline]
+            fn index(&self, index: ::core::ops::RangeFrom<usize>) -> &[$ty] {
+                &self.0[index]
+            }
+        }
 
-		impl ::core::ops::Index<::core::ops::RangeFull> for $thing {
-			type Output = [$ty];
+        impl ::core::ops::Index<::core::ops::RangeFull> for $thing {
+            type Output = [$ty];
 
-			#[inline]
-			fn index(&self, _: ::core::ops::RangeFull) -> &[$ty] {
-				&self.0[..]
-			}
-		}
-	};
+            #[inline]
+            fn index(&self, _: ::core::ops::RangeFull) -> &[$ty] {
+                &self.0[..]
+            }
+        }
+    };
 }
 
 macro_rules! display_from_debug {
-	($thing:ident) => {
-		impl ::core::fmt::Display for $thing {
-			fn fmt(&self, f: &mut ::core::fmt::Formatter) -> Result<(), ::core::fmt::Error> {
-				::core::fmt::Debug::fmt(self, f)
-			}
-		}
-	};
+    ($thing:ident) => {
+        impl ::core::fmt::Display for $thing {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> Result<(), ::core::fmt::Error> {
+                ::core::fmt::Debug::fmt(self, f)
+            }
+        }
+    };
 }
 
 #[cfg(test)]
 macro_rules! hex_script {
-	($s:expr) => {
-		Script::from(Vec::from(hex!($s)))
-	};
+    ($s:expr) => {
+        Script::from(Vec::from(hex!($s)))
+    };
 }
 
 // Export some hash functions.
 pub use sp_io::hashing::sha2_256 as sha256;
 
 pub fn sha1(data: &[u8]) -> [u8; 20] {
-	use sha1::{Digest, Sha1};
-	Sha1::digest(data).into()
+    use sha1::{Digest, Sha1};
+    Sha1::digest(data).into()
 }
 
 pub fn ripemd160(data: &[u8]) -> [u8; 20] {
-	use ripemd160::{Digest, Ripemd160};
-	Ripemd160::digest(data).into()
+    use ripemd160::{Digest, Ripemd160};
+    Ripemd160::digest(data).into()
 }
 
 pub fn hash256(data: &[u8]) -> [u8; 32] {
-	sha256(&sha256(data))
+    sha256(&sha256(data))
 }
 
 pub fn hash160(data: &[u8]) -> [u8; 20] {
-	ripemd160(&sha256(data))
+    ripemd160(&sha256(data))
 }


### PR DESCRIPTION
This moves the code from the `chainscript` repo in the main node repo. Integration of the scripting capabilities into the node will be a separate PR. For now, the extent of integration reduces to the ability to run chainscript tests together with all the other tests.

The code in `libs/chainscript` folder has already been reviewed, you only need to pay attention to changes outside of that folder, which are all in the last commit.