### PR TITLE
Basic scripting integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4119,6 +4119,7 @@ dependencies = [
 name = "pallet-utxo"
 version = "0.1.0"
 dependencies = [
+ "chainscript",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -4133,7 +4134,9 @@ dependencies = [
  "sp-core",
  "sp-keystore",
  "sp-runtime",
+ "sp-std",
  "utxo-api",
+ "variant_count",
 ]
 
 [[package]]
@@ -7930,6 +7933,16 @@ checksum = "dd320e1520f94261153e96f7534476ad869c14022aee1e59af7c778075d840ae"
 dependencies = [
  "ctor",
  "version_check",
+]
+
+[[package]]
+name = "variant_count"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae2faf80ac463422992abf4de234731279c058aaf33171ca70277c98406b124"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/libs/chainscript/src/interpreter.rs
+++ b/libs/chainscript/src/interpreter.rs
@@ -172,6 +172,17 @@ impl<'a> From<Vec<Item<'a>>> for Stack<'a> {
     }
 }
 
+/// Verify given witness script against given lock script.
+pub fn verify_witness_lock<Ctx: Context>(
+    ctx: &Ctx,
+    witness: &Script,
+    lock: &Script,
+) -> crate::Result<()> {
+    let stack = run_pushdata(ctx, &witness)?;
+    let stack = run_script(ctx, &lock, stack)?;
+    stack.verify()
+}
+
 /// Run given script limited to data push operations only.
 pub fn run_pushdata<'a, Ctx: Context>(ctx: &Ctx, script: &'a Script) -> crate::Result<Stack<'a>> {
     if script.len() > Ctx::MAX_SCRIPT_SIZE {

--- a/libs/chainscript/src/interpreter.rs
+++ b/libs/chainscript/src/interpreter.rs
@@ -253,9 +253,8 @@ pub fn run_script<'a, Ctx: Context>(
                     opcodes::AltStack::OP_TOALTSTACK => alt_stack.push(stack.pop()?),
                     opcodes::AltStack::OP_FROMALTSTACK => stack.push(alt_stack.pop()?),
                 },
-                opcodes::Class::Signature(sig_opcode) => {
+                opcodes::Class::Signature(sig_opcode) if executing => {
                     match sig_opcode {
-                        opcodes::Signature::OP_CODESEPARATOR => subscript = instr_iter.subscript(),
                         opcodes::Signature::OP_CHECKSIG | opcodes::Signature::OP_CHECKSIGVERIFY => {
                             let pubkey = stack.pop()?;
                             let sig = stack.pop()?;
@@ -302,6 +301,9 @@ pub fn run_script<'a, Ctx: Context>(
                     );
                 }
                 opcodes::Class::ControlFlow(cf) => match cf {
+                    opcodes::ControlFlow::OP_CODESEPARATOR => {
+                        subscript = instr_iter.subscript();
+                    }
                     opcodes::ControlFlow::OP_IF | opcodes::ControlFlow::OP_NOTIF => {
                         let cond = executing && {
                             let cond = match stack.pop()?.as_ref() {
@@ -584,6 +586,19 @@ mod test {
                 .push_opcode(OP_ENDIF)
                 .into_script(),
         );
+    }
+
+    #[test]
+    fn unit_checksig_not_executed() {
+        use opcodes::all::*;
+        let script = Builder::new()
+            .push_int(0)
+            .push_opcode(OP_IF)
+            .push_opcode(OP_CHECKSIGVERIFY)
+            .push_opcode(OP_ENDIF)
+            .into_script();
+        let result = run_script(&TestContext::default(), &script, vec![].into());
+        assert_eq!(result, Ok(vec![].into()));
     }
 
     #[test]

--- a/libs/chainscript/src/lib.rs
+++ b/libs/chainscript/src/lib.rs
@@ -61,5 +61,5 @@ pub mod script;
 pub use context::testcontext::TestContext;
 pub use context::Context;
 pub use error::{Error, Result};
-pub use interpreter::{run_pushdata, run_script, Stack};
+pub use interpreter::{run_pushdata, run_script, verify_witness_lock, Stack};
 pub use script::{Builder, Script};

--- a/libs/chainscript/src/opcodes.rs
+++ b/libs/chainscript/src/opcodes.rs
@@ -821,7 +821,7 @@ macro_rules! opcode_category {
 
 // Control flow opcodes
 opcode_category! {
-    ControlFlow -> OP_IF, OP_NOTIF, OP_ELSE, OP_ENDIF
+    ControlFlow -> OP_IF, OP_NOTIF, OP_ELSE, OP_ENDIF, OP_CODESEPARATOR
 }
 
 // Alt stack manipulation opcodes
@@ -832,8 +832,7 @@ opcode_category! {
 // Signature verification opcodes
 opcode_category! {
     Signature ->
-        OP_CHECKSIG, OP_CHECKSIGVERIFY, OP_CHECKMULTISIG, OP_CHECKMULTISIGVERIFY,
-        OP_CODESEPARATOR
+        OP_CHECKSIG, OP_CHECKSIGVERIFY, OP_CHECKMULTISIG, OP_CHECKMULTISIGVERIFY
 }
 
 // Pushdata opcodes

--- a/pallets/utxo/Cargo.toml
+++ b/pallets/utxo/Cargo.toml
@@ -12,13 +12,21 @@ std = [
     'frame-support/std',
     'frame-system/std',
     'frame-benchmarking/std',
-    'sp-core/std'
+    'chainscript/std',
+    'sp-core/std',
+    'sp-std/std',
 ]
 
 [dependencies]
 hex-literal = "0.2.1"
 log = "0.4.8"
 serde = '1.0.119'
+variant_count = '1.1'
+
+[dependencies.chainscript]
+default-features = false
+path = '../../libs/chainscript'
+version = '0.1.0'
 
 [dependencies.codec]
 default-features = false
@@ -54,6 +62,12 @@ version = '4.0.0-dev'
 branch = "master"
 
 [dependencies.sp-core]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+version = '4.0.0-dev'
+branch = "master"
+
+[dependencies.sp-std]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 version = '4.0.0-dev'

--- a/pallets/utxo/src/script.rs
+++ b/pallets/utxo/src/script.rs
@@ -1,0 +1,150 @@
+// Copyright (c) 2021 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): L. Kuklinek
+
+use codec::DecodeAll;
+use codec::{Decode, Encode};
+use core::convert::TryInto;
+use frame_support::sp_io::crypto;
+use sp_core::sr25519;
+use sp_std::prelude::*;
+use variant_count::VariantCount;
+
+/// An unvalidated signature type
+type RawSignatureType = u8;
+
+/// A signature together with its usage information
+struct Signature {
+    /// The raw signature data.
+    signature: Vec<u8>,
+    /// Sighash specifies which parts of the transaction are included in the hash that is verified
+    /// by the signature.
+    /// TODO: Sighash is not implemented at the moment, `SIGHASH_ALL` mode is used for everything.
+    sighash: (),
+}
+
+/// A public key. An enum to accommodate for multiple signature schemes.
+#[repr(u8)]
+#[derive(Eq, PartialEq, Clone, Copy, Encode, Decode, Debug, VariantCount)]
+enum Public {
+    /// Schnorr public key
+    Schnorr(sr25519::Public),
+}
+
+/// Mintlayer script context.
+struct MLContext<'a> {
+    tx_data: &'a [u8],
+}
+
+impl<'a> MLContext<'a> {
+    fn new(tx_data: &'a [u8]) -> Self {
+        MLContext { tx_data }
+    }
+}
+
+impl chainscript::Context for MLContext<'_> {
+    /// Maximum number of bytes pushable to the stack
+    ///
+    /// We do not limit the size of data pushed into the stack in Mintlayer since programmable pool
+    /// binaries may be fairly large. Maximum size is still subject to `MAX_SCRIPT_SIZE`.
+    const MAX_SCRIPT_ELEMENT_SIZE: usize = usize::MAX;
+
+    /// Maximum number of public keys per multisig
+    const MAX_PUBKEYS_PER_MULTISIG: usize = 20;
+
+    /// Maximum script length in bytes
+    ///
+    /// Set it to 100kB for now to allow for mid-size smart contracts to be included in the script.
+    const MAX_SCRIPT_SIZE: usize = 100 * 1024;
+
+    /// Either parsed signature + metadata or unrecognized signature type.
+    type Signature = Signature;
+
+    /// Either a parsed public key or unrecognized pubkey type.
+    type Public = Result<Public, RawSignatureType>;
+
+    /// Extract a signature and sighash.
+    fn parse_signature(&self, sig: &[u8]) -> Option<Self::Signature> {
+        let (&_sighash_byte, sig) = sig.split_last()?;
+        Some(Signature {
+            signature: sig.to_vec(),
+            sighash: (),
+        })
+    }
+
+    /// Extract a pubkey and check it is in the correct format.
+    ///
+    /// Explanation of return values is analogous to `parse_signature`.
+    ///
+    /// The function returns a Rsult wrapped in an Option type.
+    /// * `None` represents a parsing failure, the transaction is rejected.
+    /// * `Some(Err(x))` represents an unrecognized pubkey type with type ID `x`.
+    ///   The pubkey with unknown type ID always succeeds validation. This allows the type to be
+    ///   allocated later for a new signature scheme without introducing a hard fork.
+    /// * `Some(Ok(pk))` is a successfully processed key.
+    fn parse_pubkey(&self, pk: &[u8]) -> Option<Self::Public> {
+        let &key_type = pk.get(0)?;
+        if (key_type as usize) < Public::VARIANT_COUNT {
+            Public::decode_all(&mut &pk[..]).map(Ok).ok()
+        } else {
+            Some(Err(key_type))
+        }
+    }
+
+    /// Verify signature.
+    fn verify_signature(
+        &self,
+        sig: &Self::Signature,
+        pk: &Self::Public,
+        _subscript: &[u8],
+    ) -> bool {
+        let Signature {
+            signature: sig,
+            sighash: _sighash,
+        } = sig;
+        match pk {
+            Ok(Public::Schnorr(pk)) => (&sig[..]).try_into().map_or(false, |sig| {
+                crypto::sr25519_verify(&sr25519::Signature::from_raw(sig), self.tx_data, pk)
+            }),
+            // Unrecognized signature type => accept the signature.
+            Err(_pk) => true,
+        }
+    }
+}
+
+/// Verify mintlayer script.
+pub fn verify(tx_data: &[u8], witness: Vec<u8>, lock: Vec<u8>) -> chainscript::Result<()> {
+    let ctx = MLContext::new(tx_data);
+    chainscript::verify_witness_lock(&ctx, &witness.into(), &lock.into())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use chainscript::Context;
+
+    #[test]
+    fn test_parse_pubkey() {
+        let tx_data = [];
+        let ctx = MLContext::new(&tx_data);
+        let key = sr25519::Public::from_raw([42u8; 32]);
+        let mut keydata = vec![0u8];
+        keydata.extend(key.0.iter());
+        assert_eq!(ctx.parse_pubkey(&keydata), Some(Ok(Public::Schnorr(key))));
+        assert_eq!(ctx.parse_pubkey(&[42u8]), Some(Err(42u8)));
+        assert_eq!(ctx.parse_pubkey(&[0u8, 1u8]), None);
+    }
+}


### PR DESCRIPTION
Not particuralry thoroughly tested for now. The test present is more of an usage example. The way transactions are signed is about to be changed. For now, just sign the transaction with all witness fields set to empty (`get_simple_transaction` does this). Not everything is implemented but most common features are working. Some resource limits are not enforced yet, time locks are not implemented, Mintlayer-specific extensions and some other minor things missing as well.