### PR TITLE
Bootnodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "chunked_transfer"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
+
+[[package]]
 name = "cid"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3579,6 +3585,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "jsonrpc-core",
+ "log",
  "node-template-runtime",
  "pallet-contracts",
  "pallet-contracts-rpc",
@@ -3604,6 +3611,7 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-transaction-pool-api",
+ "serde_json",
  "sp-api",
  "sp-authorship",
  "sp-block-builder",
@@ -3618,6 +3626,7 @@ dependencies = [
  "structopt",
  "substrate-build-script-utils",
  "substrate-frame-rpc-system",
+ "ureq",
 ]
 
 [[package]]
@@ -7862,6 +7871,22 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3131cd6cb18488da91da1d10ed31e966f453c06b65bf010d35638456976a3fd7"
+dependencies = [
+ "base64 0.13.0",
+ "chunked_transfer",
+ "log",
+ "once_cell",
+ "rustls",
+ "url 2.2.2",
+ "webpki",
+ "webpki-roots",
+]
 
 [[package]]
 name = "url"

--- a/assets/bootnodes.json
+++ b/assets/bootnodes.json
@@ -1,0 +1,5 @@
+{
+	"nodes": [
+		"/ip4/13.58.14.136/tcp/30333/p2p/12D3KooWEWRUqkmpZeweDgQYLeYpPT9UrfrNMFME7cdq5DY3xCeT"
+	]
+}

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,6 +24,13 @@ structopt = '0.3.8'
 node-template-runtime = {version = '3.0.0', path = '../runtime'}
 pallet-utxo-rpc = { path = "../pallets/utxo/rpc" }
 pallet-utxo-rpc-runtime-api = { path = "../pallets/utxo/rpc/runtime-api" }
+log = "0.4.8"
+ureq = "2.2.0"
+
+[dependencies.serde_json]
+version = '1.0.45'
+default-features = false
+features = ['alloc']
 
 [dependencies.frame-benchmarking]
 git = 'https://github.com/paritytech/substrate.git'

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -2,13 +2,13 @@ use node_template_runtime::{
     pallet_utxo, AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, PpConfig,
     Signature, SudoConfig, SystemConfig, UtxoConfig, WASM_BINARY,
 };
+use sc_network::config::MultiaddrWithPeerId;
 use sc_service::ChainType;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
+use sp_core::H256;
 use sp_core::{sr25519, Pair, Public};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
 use sp_runtime::traits::{IdentifyAccount, Verify};
-
-use sp_core::H256;
 
 // The URL for the telemetry server.
 // const STAGING_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
@@ -38,8 +38,24 @@ pub fn authority_keys_from_seed(s: &str) -> (AuraId, GrandpaId) {
     (get_from_seed::<AuraId>(s), get_from_seed::<GrandpaId>(s))
 }
 
+/// Return a list of bootnodes
+fn get_bootnodes() -> Vec<MultiaddrWithPeerId> {
+    vec![
+        "/ip4/13.59.157.140/tcp/30333/p2p/12D3KooWEEBFM1JumGXaaeimNV1UMjhoBjKMnHCeEJ4Dr5i4hLnG"
+            .parse()
+            .expect("Unable to parse bootnode address!"),
+        "/ip4/18.222.194.251/tcp/30333/p2p/12D3KooWB11zFddP43zTSiGXvYxUuELTRigVscf9RgUpKFXeqxzF"
+            .parse()
+            .expect("Unable to parse bootnode address!"),
+        "/ip4/3.138.108.99/tcp/30333/p2p/12D3KooWHW8LoXQhGL5aGNtvRFUUoG7UYV2qRQtwj5m57kWDwpHS"
+            .parse()
+            .expect("Unable to parse bootnode address!"),
+    ]
+}
+
 pub fn development_config() -> Result<ChainSpec, String> {
     let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
+    let bootnodes = get_bootnodes();
 
     Ok(ChainSpec::from_genesis(
         // Name
@@ -69,7 +85,7 @@ pub fn development_config() -> Result<ChainSpec, String> {
             )
         },
         // Bootnodes
-        vec![],
+        bootnodes,
         // Telemetry
         None,
         // Protocol ID
@@ -83,6 +99,7 @@ pub fn development_config() -> Result<ChainSpec, String> {
 
 pub fn local_testnet_config() -> Result<ChainSpec, String> {
     let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
+    let bootnodes = get_bootnodes();
 
     Ok(ChainSpec::from_genesis(
         // Name
@@ -120,7 +137,7 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
             )
         },
         // Bootnodes
-        vec![],
+        bootnodes,
         // Telemetry
         None,
         // Protocol ID


### PR DESCRIPTION
If `--dev` is used when the node is started, the bootnode list is not fetched to prevent unnecessary interference with testing. Node also doesn't establish a permanent connection with the hard-coded nodes listed in the chainspec because they're running a different chainspec than dev. Thus, this change should not interfere with anybody's development work.

If you want to test this, you can find a list of bootnodes from `https://raw.githubusercontent.com/altonen/core/master/assets/bootnodes.json`