### PR TITLE
Fix a double spend issue

### DIFF
--- a/libs/chainscript/Cargo.toml
+++ b/libs/chainscript/Cargo.toml
@@ -21,12 +21,12 @@ displaydoc = { default-features = false, version = "0.2" }
 codec = { default-features = false, features = ['derive'], package = 'parity-scale-codec', version = '2.0.0' }
 sp-core = { default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
 sp-io = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
+sp-runtime = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
 sp-std = { default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
 frame-support = { default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
 
 [dev-dependencies]
 # serde = '1.0.119'
-sp-runtime = {default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', branch = 'master'}
 hex-literal = "0.3.1"
 proptest = "1.0.0"
 

--- a/pallets/utxo/src/lib.rs
+++ b/pallets/utxo/src/lib.rs
@@ -388,7 +388,8 @@ pub mod pallet {
         //https://github.com/substrate-developer-hub/utxo-workshop/blob/workshop/runtime/src/utxo.rs
         //input_map.len() > transaction.inputs.len() //THIS IS WRONG
         {
-            let input_map: BTreeMap<_, ()> = tx.inputs.iter().map(|input| (input, ())).collect();
+            let input_map: BTreeMap<_, ()> =
+                tx.inputs.iter().map(|input| (input.outpoint, ())).collect();
             //we want map size and input size to be equal to ensure each is used only once
             ensure!(
                 input_map.len() == tx.inputs.len(),


### PR DESCRIPTION
Double spend fix + standalone compilation fix for `chainscript`. See commit messages for a bit more info about either.