### PR TITLE
Transaction signatures

### DIFF
--- a/doc/tx-sign.md
+++ b/doc/tx-sign.md
@@ -1,0 +1,100 @@
+# Signing Transactions
+
+This document defines the serialization format used to obtain message used to sign transactions or
+verify transaction signatures in Mintlayer's UTXO model.
+
+## Definitions and notation
+
+Constants `SIGHASH_*` have the same values as in Bitcoin
+
+`hash(x)`: a 256-bit BLAKE2 hash of the SCALE serialization of `x`
+
+`seq[i]` gives `i`-th element of a sequence
+
+`x.field` access a struct field
+
+`seq.*field`: given a vector `seq`, this is equivalent to Python pseudo-code `[ x.field for x in seq ]`
+
+## Pubkey Format
+
+The first byte determines signature scheme used for this public key.
+The key itself immediately follows.
+
+* If signature type is:
+  * Schnorr:
+    * [1B] constant `0x00`
+    * [32B] Schnorr pubkey
+
+## Signature Format
+
+Different signature schemes have different signature sizes.
+
+* [`N` Bytes] signature
+  * The length `N` is determined by corresponding pubkey type
+* If `sighash` is:
+  * 0x00 (default):
+    * [0B] nothing
+  * otherwise:
+    * [1B] sighash
+
+## Message Format
+
+Given:
+
+* `tx`: transaction
+* `index`: the index of input curretnly under consideration
+* `sighash`: signature mode (1 byte)
+* `input_utxos`: a sequence of UTXOs being spent by transaction inputs
+  * `index` < `input_utxos.len()` = `tx.inputs.len()`
+* `codesep_pos`: 4-byte position of the last `OP_CODESEPARATOR`
+  * position is in number of decoded instructions (executed or not)
+  * or `0xffffffff` if no `OP_CODESEPARATOR` has been seen so far
+    or we are outside of a script context (e.g. plain pay to pubkey, no script involved)
+
+The message is a concatenation of:
+
+* [1B] sighash
+* If `sighash & SIGHASH_ANYONECANPAY` is:
+  * 0:
+    * [1B] constant `0x00`
+    * [32B] outpoints hash `hash(tx.inputs.*outpoint)`
+    * [32B] hash of UTXOs being spent `hash(input_utxos)`
+    * [8B] `index`
+  * non-0:
+    * [1B] constant `0x01`
+    * [32B] current outpoint `tx.inputs[index].outpoint`
+    * [32B] hash of UTXO being spent `hash(input_utxos[index])`
+* If `sighash & 0x03` is:
+  * `SIGHASH_ALL`:
+    * [1B] constant `0x01`
+    * [32B] hash of all outputs `hash(tx.outputs)`
+  * `SIGHASH_NONE`:
+    * [1B] constant `0x02`
+  * `SIGHASH_SINGLE`
+    * [1B] constant `0x03`
+    * If `index` < `tx.outputs.len()`:
+      * true:
+        * [32B] hash of output matching current input index `hash(tx.outputs[index])`
+      * false:
+        * [32B] constant hash `0x0000...00000`
+* [4B] `codesep_pos`
+
+## Notes
+
+The `tx.inputs.*witness` fields are not signed since they cointain the signatures.
+
+The `tx.inputs.*lock` fields do not show up directly. They are, however, committed to indirectly
+because the `lock` field is fully determined by contents of the output being spent by the input
+by requiring it to conform to a particular hash (e.g. like in P2SH or requiring it to be empty).
+
+Many of the hashes included in the resultant message will be the same for many signatures
+and can be cached or pre-calculated.
+
+The message is at most 111 bytes long.
+
+## References
+
+* [SCALE encoding](https://substrate.dev/docs/en/knowledgebase/advanced/codec),
+  [github](https://github.com/paritytech/parity-scale-codec)
+* Taproot signatures
+* SegWit signatures

--- a/libs/chainscript/src/context.rs
+++ b/libs/chainscript/src/context.rs
@@ -54,7 +54,13 @@ pub trait Context {
     fn parse_pubkey(&self, pk: &[u8]) -> Option<Self::Public>;
 
     /// Verify signature.
-    fn verify_signature(&self, sig: &Self::Signature, pk: &Self::Public, subscript: &[u8]) -> bool;
+    fn verify_signature(
+        &self,
+        sig: &Self::Signature,
+        pk: &Self::Public,
+        subscript: &[u8],
+        codesep_idx: u32,
+    ) -> bool;
 
     /// Check absolute time lock.
     fn check_lock_time(&self, _lock_time: i64) -> bool {
@@ -124,6 +130,7 @@ pub mod testcontext {
             sig: &Self::Signature,
             pk: &Self::Public,
             subscript: &[u8],
+            _codesep_idx: u32,
         ) -> bool {
             let msg = sha256(&[&self.transaction[..], subscript].concat());
             sig.iter().zip(pk.iter()).zip(msg.iter()).all(|((&s, &p), &m)| (s ^ p ^ m) == 0)

--- a/libs/chainscript/src/context.rs
+++ b/libs/chainscript/src/context.rs
@@ -17,6 +17,23 @@
 
 //! Context provide interface between script engine and blockchain
 
+/// Result of parsing data with possible future extensions.
+#[derive(PartialEq, Eq, Debug)]
+pub enum ParseResult<T> {
+    /// Decoding successful
+    Ok(T),
+    /// Decoding failed
+    Err,
+    /// Reserved for future extensions
+    Reserved,
+}
+
+impl<T> From<Option<T>> for ParseResult<T> {
+    fn from(o: Option<T>) -> Self {
+        o.map_or(ParseResult::Err, ParseResult::Ok)
+    }
+}
+
 /// Context for the script interpreter.
 ///
 /// This trait defines how the interpreter interfaces with the blockchain. It allows the client
@@ -31,6 +48,7 @@
 ///   multiple smaller ones for greater flexibility in the future.
 /// * The interface is not fully finalized. It is likely to change as new requirements come in. E.g.
 ///   it may be currently too limited to support signature batching.
+/// * The constants may be turned into methods to allow chain forks.
 pub trait Context {
     /// Maximum number of bytes pushable to the stack
     const MAX_SCRIPT_ELEMENT_SIZE: usize = 520;
@@ -41,23 +59,24 @@ pub trait Context {
     /// Maximum script length in bytes
     const MAX_SCRIPT_SIZE: usize;
 
-    /// Signature, parsed and verified for correct format.
-    type Signature;
-
     /// Public key type.
     type Public;
 
-    /// Extract a signature and check it is in the correct format.
-    fn parse_signature(&self, sig: &[u8]) -> Option<Self::Signature>;
+    /// Data needed to verify a signature. This probably contains signature, public key, sighash
+    /// if used and other data used for verification.
+    type SignatureData;
 
     /// Extract a pubkey and check it is in the correct format.
-    fn parse_pubkey(&self, pk: &[u8]) -> Option<Self::Public>;
+    fn parse_pubkey(&self, pk: &[u8]) -> ParseResult<Self::Public>;
+
+    /// Extract a signature and check it is in the correct format. Pubkey is provided since it may
+    /// determine signature format and is likely to be included in the result.
+    fn parse_signature(&self, pk: Self::Public, sig: &[u8]) -> Option<Self::SignatureData>;
 
     /// Verify signature.
     fn verify_signature(
         &self,
-        sig: &Self::Signature,
-        pk: &Self::Public,
+        sig: &Self::SignatureData,
         subscript: &[u8],
         codesep_idx: u32,
     ) -> bool;
@@ -114,26 +133,21 @@ pub mod testcontext {
         const MAX_SCRIPT_SIZE: usize = 10000;
 
         // Signatures, keys and transaction IDs are just 4-byte binary data each.
-        type Signature = [u8; 4];
+        type SignatureData = [u8; 4];
         type Public = [u8; 4];
 
-        fn parse_signature(&self, sig: &[u8]) -> Option<Self::Signature> {
-            Self::Signature::try_from(sig).ok()
+        fn parse_signature(&self, pk: Self::Public, sig: &[u8]) -> Option<Self::SignatureData> {
+            let res: Vec<_> = sig.iter().zip(pk.iter()).map(|(&s, &p)| s ^ p).collect();
+            Self::SignatureData::try_from(&res[..]).ok()
         }
 
-        fn parse_pubkey(&self, pk: &[u8]) -> Option<Self::Public> {
-            Self::Public::try_from(pk).ok()
+        fn parse_pubkey(&self, pk: &[u8]) -> ParseResult<Self::Public> {
+            Self::Public::try_from(pk).ok().into()
         }
 
-        fn verify_signature(
-            &self,
-            sig: &Self::Signature,
-            pk: &Self::Public,
-            subscript: &[u8],
-            _codesep_idx: u32,
-        ) -> bool {
+        fn verify_signature(&self, sig: &Self::SignatureData, subscript: &[u8], _ix: u32) -> bool {
             let msg = sha256(&[&self.transaction[..], subscript].concat());
-            sig.iter().zip(pk.iter()).zip(msg.iter()).all(|((&s, &p), &m)| (s ^ p ^ m) == 0)
+            sig.iter().zip(msg.iter()).all(|(&s, &m)| (s ^ m) == 0)
         }
     }
 }

--- a/libs/chainscript/src/interpreter.rs
+++ b/libs/chainscript/src/interpreter.rs
@@ -224,6 +224,8 @@ pub fn run_script<'a, Ctx: Context>(
 
     let mut instr_iter = script.instructions_iter(ctx.enforce_minimal_push());
     let mut subscript: &[u8] = instr_iter.subscript();
+    let mut cur_instr_num = 0u32;
+    let mut codesep_idx = u32::MAX;
     let mut exec_stack = ExecStack::default();
     let mut alt_stack = Stack::<'a>::default();
 
@@ -264,6 +266,7 @@ pub fn run_script<'a, Ctx: Context>(
                                 core::iter::once(sig.as_ref()),
                                 core::iter::once(pubkey.as_ref()),
                                 subscript,
+                                codesep_idx,
                             )?;
                             stack.push_bool(result);
                         }
@@ -285,13 +288,11 @@ pub fn run_script<'a, Ctx: Context>(
                             let sigs = stack.top_slice(sig_range)?.iter().map(AsRef::as_ref);
 
                             // Verify
-                            let result = check_multisig(ctx, sigs, keys, subscript)?;
+                            let result = check_multisig(ctx, sigs, keys, subscript, codesep_idx)?;
 
                             // Clean up stack, ensure! dummy 0.
                             stack.drop(nsig + nkey + 1)?;
-                            if !stack.pop()?.is_empty() {
-                                return Err(Error::NullDummy);
-                            }
+                            ensure!(stack.pop()?.is_empty(), Error::NullDummy);
                             stack.push_bool(result);
                         }
                     }
@@ -303,6 +304,7 @@ pub fn run_script<'a, Ctx: Context>(
                 opcodes::Class::ControlFlow(cf) => match cf {
                     opcodes::ControlFlow::OP_CODESEPARATOR => {
                         subscript = instr_iter.subscript();
+                        codesep_idx = cur_instr_num;
                     }
                     opcodes::ControlFlow::OP_IF | opcodes::ControlFlow::OP_NOTIF => {
                         let cond = executing && {
@@ -330,6 +332,8 @@ pub fn run_script<'a, Ctx: Context>(
                 _ => (),
             },
         }
+
+        cur_instr_num = cur_instr_num.saturating_add(1);
     }
 
     // Check OP_IF/OP_NOTIF has been closed properly wiht OP_ENDIF.
@@ -347,6 +351,7 @@ fn check_multisig<'a, Ctx: Context>(
     mut sigs: impl Iterator<Item = &'a [u8]> + ExactSizeIterator,
     mut pubkeys: impl Iterator<Item = &'a [u8]> + ExactSizeIterator,
     subscript: &[u8],
+    codesep_idx: u32,
 ) -> crate::Result<bool> {
     // Check each signature has its corresponding pubkey.
     while let Some(sig) = sigs.next() {
@@ -360,7 +365,7 @@ fn check_multisig<'a, Ctx: Context>(
                 return Ok(false);
             }
             let pubkey = ctx.parse_pubkey(pubkeys.next().unwrap()).ok_or(Error::PubkeyFormat)?;
-            if ctx.verify_signature(&sig, &pubkey, subscript) {
+            if ctx.verify_signature(&sig, &pubkey, subscript, codesep_idx) {
                 break;
             }
         }
@@ -622,6 +627,7 @@ mod test {
                 sigs.iter().map(AsRef::as_ref),
                 keys.iter().map(AsRef::as_ref),
                 &[],
+                0,
             );
             assert_eq!(result, expected);
         };

--- a/libs/chainscript/src/lib.rs
+++ b/libs/chainscript/src/lib.rs
@@ -51,7 +51,7 @@
 #[macro_use]
 mod util;
 
-mod context;
+pub mod context;
 mod error;
 mod interpreter;
 pub mod opcodes;

--- a/libs/chainscript/src/lib.rs
+++ b/libs/chainscript/src/lib.rs
@@ -56,6 +56,7 @@ mod error;
 mod interpreter;
 pub mod opcodes;
 pub mod script;
+pub mod sighash;
 
 #[cfg(feature = "testcontext")]
 pub use context::testcontext::TestContext;

--- a/libs/chainscript/src/script.rs
+++ b/libs/chainscript/src/script.rs
@@ -584,7 +584,8 @@ impl Builder {
         self
     }
 
-    /// Adds instructions to push some arbitrary data onto the stack in minimal encoding
+    /// Adds instructions to push some arbitrary data onto the stack in minimal encoding when
+    /// interpreted as a byte array (numbers have a different minimal encoding).
     pub fn push_slice_minimal(self, data: &[u8]) -> Builder {
         match data {
             [129] => self.push_int(-1),

--- a/libs/chainscript/src/sighash.rs
+++ b/libs/chainscript/src/sighash.rs
@@ -1,0 +1,82 @@
+// Copyright (c) 2021 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): L. Kuklinek
+
+use codec::Encode;
+
+/// Specifies which parts of the transaction a signature commits to.
+///
+/// The values of the flags are the same as in Bitcoin.
+#[derive(Eq, PartialEq, Clone, Copy, Encode)]
+pub struct SigHash(u8);
+
+impl SigHash {
+    const DEFAULT: u8 = 0x00;
+    const ALL: u8 = 0x01;
+    const NONE: u8 = 0x02;
+    const SINGLE: u8 = 0x03;
+    const ANYONECANPAY: u8 = 0x80;
+
+    const MASK_OUT: u8 = 0x7f;
+    const MASK_IN: u8 = 0x80;
+
+    pub fn from_u8(sighash_byte: u8) -> Option<SigHash> {
+        let ok = matches!(
+            sighash_byte & Self::MASK_OUT,
+            Self::ALL | Self::NONE | Self::SINGLE
+        );
+        ok.then(|| Self(sighash_byte))
+    }
+
+    pub fn input_mode(&self) -> InputMode {
+        match self.0 & Self::MASK_IN {
+            Self::ANYONECANPAY => InputMode::AnyoneCanPay,
+            _ => InputMode::CommitWhoPays,
+        }
+    }
+
+    pub fn output_mode(&self) -> OutputMode {
+        match self.0 & Self::MASK_OUT {
+            Self::NONE => OutputMode::None,
+            Self::SINGLE => OutputMode::Single,
+            _ => OutputMode::All,
+        }
+    }
+}
+
+impl Default for SigHash {
+    fn default() -> Self {
+        Self(Self::DEFAULT)
+    }
+}
+
+/// How inputs should be hashed
+pub enum InputMode {
+    /// Commit to all inputs
+    CommitWhoPays,
+    /// Commit to the current input only
+    AnyoneCanPay,
+}
+
+/// How outputs should be hashed
+pub enum OutputMode {
+    /// Commit to all outputs
+    All,
+    /// Don't commit to any outputs
+    None,
+    /// Commit to the output corresponding to the current input
+    Single,
+}

--- a/pallets/utxo/README.md
+++ b/pallets/utxo/README.md
@@ -13,9 +13,10 @@ To run the test cases, just run command `cargo test`.
   "Value": "u128",
   "Destination": {
     "_enum": {
-      "Pubkey": "Public",
+      "Pubkey": "Pubkey",
       "CreatePP": "DestinationCreatePP",
-      "CallPP": "DestinationCallPP"
+      "CallPP": "DestinationCallPP",
+      "ScriptHash": "H256"
     }
   },
   "DestinationCreatePP": {
@@ -50,6 +51,11 @@ To run the test cases, just run command `cargo test`.
     "difficulty": "Difficulty",
     "timestamp": "Moment"
   },
+  "Pubkey": {
+    "_enum": {
+      "Schnorr": "Public"
+    }
+  },
   "Public": "H256"
 }
 ```
@@ -71,6 +77,14 @@ Choose `utxo` for _submit the following extrinsic_ dropdown. Input the ff. param
     * witness (signature): `0x7860d0e15cb0dbc98c713857b334aa0fbe1c11cb7daeca09ec4b87928c9dbb34e78aea9cb5818b601c2088751477c0d3b90cd28fffc50c51a39791b8f5d3da83`
     * value: `50`
     * destination: Pubkey: `0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48`
+3. Let's spend 50 of Alice's utxo to Bob. Go to **Developer** > **Extrinsics**.
+   Choose `utxo` for _submit the following extrinsic_ dropdown.
+   Input the following parameters (and then submit transaction):
+    * outpoint: `0xfa1d0b34f8950f771881cd7a1601cc8817376ed5b18c6d528cc1ccac863482cc`
+    * lock: `0x` (empty byte string)
+    * witness (signature): `0x3c2f4d9264285ce26317e3aaec119db3efe46cbc7e6304d6015fced79d0d342dd9308e9fa07cbc00731513bcfc410c062c2b46083e6d1dae4ba29a95250c2f83`
+    * value: `50`
+    * destination: Pubkey: Schnorr: `0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48`
 4. Wait for the upper right corner to change from 
 ```
 utxo.spend

--- a/pallets/utxo/src/lib.rs
+++ b/pallets/utxo/src/lib.rs
@@ -31,33 +31,29 @@ mod benchmarking;
 
 mod header;
 mod script;
+mod sign;
 pub mod weights;
 
 #[frame_support::pallet]
 pub mod pallet {
-    use core::convert::TryInto;
     use core::marker::PhantomData;
     use hex_literal::hex;
     #[cfg(feature = "std")]
     use serde::{Deserialize, Serialize};
 
+    use crate::sign;
     use crate::{validate_header, SignatureMethod, TXOutputHeader, TXOutputHeaderImpls, TokenType};
     use chainscript::Script;
     use codec::{Decode, Encode};
     use frame_support::{
         dispatch::{DispatchResultWithPostInfo, Vec},
         pallet_prelude::*,
-        sp_io::crypto,
         sp_runtime::traits::{BlakeTwo256, Dispatchable, Hash, SaturatedConversion},
         traits::IsSubType,
     };
     use frame_system::pallet_prelude::*;
     use pp_api::ProgrammablePoolApi;
-    use sp_core::{
-        sp_std::collections::btree_map::BTreeMap,
-        sr25519::{Public as SR25Pub, Signature as SR25Sig},
-        H256, H512,
-    };
+    use sp_core::{sp_std::collections::btree_map::BTreeMap, H256, H512};
 
     pub type Value = u128;
 
@@ -150,10 +146,10 @@ pub mod pallet {
 
     /// Destination specifies where a payment goes. Can be a pubkey hash, script, etc.
     #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-    #[derive(Clone, Encode, Decode, Eq, PartialEq, PartialOrd, Ord, RuntimeDebug, Hash)]
+    #[derive(Clone, Encode, Decode, Eq, PartialEq, PartialOrd, Ord, RuntimeDebug)]
     pub enum Destination<AccountId> {
         /// Plain pay-to-pubkey
-        Pubkey(H256),
+        Pubkey(sign::Public),
         /// Pay to fund a new programmable pool. Takes code and data.
         CreatePP(Vec<u8>, Vec<u8>),
         /// Pay to an existing contract. Takes a destination account and input data.
@@ -181,7 +177,7 @@ pub mod pallet {
 
     /// Output of a transaction
     #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-    #[derive(Clone, Encode, Decode, Eq, PartialEq, PartialOrd, Ord, RuntimeDebug, Hash)]
+    #[derive(Clone, Encode, Decode, Eq, PartialEq, PartialOrd, Ord, RuntimeDebug)]
     pub struct TransactionOutput<AccountId> {
         pub(crate) value: Value,
         pub(crate) header: TXOutputHeader,
@@ -193,11 +189,12 @@ pub mod pallet {
         /// token type for both the value and fee is MLT,
         /// and the signature method is BLS.
         /// functions are available in TXOutputHeaderImpls to update the header.
-        pub fn new_pubkey(value: Value, pub_key: H256) -> Self {
+        pub fn new_pubkey(value: Value, pubkey: H256) -> Self {
+            let pubkey = sp_core::sr25519::Public::from_h256(pubkey);
             Self {
                 value,
                 header: 0,
-                destination: Destination::Pubkey(pub_key),
+                destination: Destination::Pubkey(pubkey.into()),
             }
         }
 
@@ -252,23 +249,10 @@ pub mod pallet {
     }
 
     #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-    #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, Hash, Default)]
+    #[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, Default)]
     pub struct Transaction<AccountId> {
         pub(crate) inputs: Vec<TransactionInput>,
         pub(crate) outputs: Vec<TransactionOutput<AccountId>>,
-    }
-
-    impl<AccountId> Transaction<AccountId> {
-        /// Iterator over transaction outputs together with output indices
-        pub fn enumerate_outputs(
-            &self,
-        ) -> Result<
-            impl Iterator<Item = (u64, &TransactionOutput<AccountId>)> + ExactSizeIterator,
-            &'static str,
-        > {
-            ensure!((self.outputs.len() as u32) < u32::MAX, "too many outputs");
-            Ok(self.outputs.iter().enumerate().map(|(ix, out)| (ix as u64, out)))
-        }
     }
 
     impl<AccountId: Encode> Transaction<AccountId> {
@@ -376,9 +360,11 @@ pub mod pallet {
         tx: &TransactionFor<T>,
     ) -> Result<ValidTransaction, &'static str> {
         //ensure rather than assert to avoid panic
-        //both inputs and outputs should contain at least 1 utxo
+        //both inputs and outputs should contain at least 1 and at most u32::MAX - 1 entries
         ensure!(!tx.inputs.is_empty(), "no inputs");
         ensure!(!tx.outputs.is_empty(), "no outputs");
+        ensure!(tx.inputs.len() < (u32::MAX as usize), "too many inputs");
+        ensure!(tx.outputs.len() < (u32::MAX as usize), "too many outputs");
 
         //ensure each input is used only a single time
         //maps each input into btree
@@ -409,10 +395,6 @@ pub mod pallet {
             );
         }
 
-        let mut total_input: Value = 0;
-        let mut total_output: Value = 0;
-        let simple_tx = get_simple_transaction(tx);
-
         // In order to avoid race condition in network we maintain a list of required utxos for a tx
         // Example of race condition:
         // Assume both alice and bob have 10 coins each and bob owes charlie 20 coins
@@ -421,56 +403,37 @@ pub mod pallet {
         // then the tx from bob to charlie is invalid. By maintaining a list of required utxos we can ensure the tx can happen as and
         // when the utxo is available. We use max longevity at the moment. That should be fixed.
 
-        let mut missing_utxos = Vec::new();
+        // Resolve the transaction inputs by looking up UTXOs being spent by them.
+        //
+        // This will cointain one of the following:
+        // * Ok(utxos): a vector of UTXOs each input spends.
+        // * Err(missing): a vector of outputs missing from the store
+        let input_utxos = {
+            let mut missing = Vec::new();
+            let mut resolved: Vec<TransactionOutputFor<T>> = Vec::new();
+
+            for input in &tx.inputs {
+                if let Some(input_utxo) = <UtxoStore<T>>::get(&input.outpoint) {
+                    let lock_commitment = input_utxo.destination.lock_commitment();
+                    ensure!(
+                        input.lock_hash() == *lock_commitment,
+                        "Lock hash does not match"
+                    );
+                    resolved.push(input_utxo);
+                } else {
+                    missing.push(input.outpoint.clone().as_fixed_bytes().to_vec());
+                }
+            }
+
+            missing.is_empty().then(|| resolved).ok_or(missing)
+        };
+
         let mut new_utxos = Vec::new();
+        let mut total_output: Value = 0;
         let mut reward = 0;
 
-        // Check that inputs are valid
-        for input in tx.inputs.iter() {
-            if let Some(input_utxo) = <UtxoStore<T>>::get(&input.outpoint) {
-                let lock_commitment = input_utxo.destination.lock_commitment();
-                ensure!(
-                    input.lock_hash() == *lock_commitment,
-                    "Lock hash does not match"
-                );
-
-                match input_utxo.destination {
-                    Destination::Pubkey(pubkey) => {
-                        let sig = (&input.witness[..])
-                            .try_into()
-                            .map_err(|_| "signature length incorrect")?;
-                        ensure!(
-                            crypto::sr25519_verify(
-                                &SR25Sig::from_raw(sig),
-                                &simple_tx,
-                                &SR25Pub::from_h256(pubkey)
-                            ),
-                            "signature must be valid"
-                        );
-                    }
-                    Destination::CreatePP(_, _) => {
-                        log::info!("TODO validate spending of OP_CREATE");
-                    }
-                    Destination::CallPP(_, _) => {
-                        log::info!("TODO validate spending of OP_CALL");
-                    }
-                    Destination::ScriptHash(_hash) => {
-                        use crate::script::verify;
-                        ensure!(
-                            verify(&simple_tx, input.witness.clone(), input.lock.clone()).is_ok(),
-                            "script verification failed"
-                        );
-                    }
-                }
-                total_input =
-                    total_input.checked_add(input_utxo.value).ok_or("input value overflow")?;
-            } else {
-                missing_utxos.push(input.outpoint.clone().as_fixed_bytes().to_vec());
-            }
-        }
-
         // Check that outputs are valid
-        for (output_index, output) in tx.enumerate_outputs()? {
+        for (output_index, output) in tx.outputs.iter().enumerate() {
             // Check the header is valid
             let res = output.validate_header();
             if let Err(e) = res {
@@ -481,7 +444,7 @@ pub mod pallet {
             match output.destination {
                 Destination::Pubkey(_) | Destination::ScriptHash(_) => {
                     ensure!(output.value > 0, "output value must be nonzero");
-                    let hash = tx.outpoint(output_index);
+                    let hash = tx.outpoint(output_index as u64);
                     ensure!(!<UtxoStore<T>>::contains_key(hash), "output already exists");
                     new_utxos.push(hash.as_fixed_bytes().to_vec());
                 }
@@ -497,8 +460,43 @@ pub mod pallet {
             total_output = total_output.checked_add(output.value).ok_or("output value overflow")?;
         }
 
-        // if no race condition, check the math
-        if missing_utxos.is_empty() {
+        // if all spent UTXOs are available, check the math and signatures
+        if let Ok(input_utxos) = &input_utxos {
+            let mut total_input: Value = 0u128;
+
+            for (index, (input, input_utxo)) in tx.inputs.iter().zip(input_utxos).enumerate() {
+                match input_utxo.destination {
+                    Destination::Pubkey(pubkey) => {
+                        let msg = sign::TransactionSigMsg::construct(
+                            sign::SigHash::default(),
+                            &tx,
+                            &input_utxos,
+                            index as u64,
+                            u32::MAX,
+                        );
+                        let ok = pubkey
+                            .parse_sig(&input.witness[..])
+                            .ok_or("bad signature format")?
+                            .verify(&msg);
+                        ensure!(ok, "signature must be valid");
+                    }
+                    Destination::CreatePP(_, _) => {
+                        log::info!("TODO validate spending of OP_CREATE");
+                    }
+                    Destination::CallPP(_, _) => {
+                        log::info!("TODO validate spending of OP_CALL");
+                    }
+                    Destination::ScriptHash(_hash) => {
+                        let witness = input.witness.clone();
+                        let lock = input.lock.clone();
+                        crate::script::verify(&tx, &input_utxos, index as u64, witness, lock)
+                            .map_err(|_| "script verification failed")?;
+                    }
+                }
+                total_input =
+                    total_input.checked_add(input_utxo.value).ok_or("input value overflow")?;
+            }
+
             ensure!(
                 total_input >= total_output,
                 "output value must not exceed input value"
@@ -508,7 +506,7 @@ pub mod pallet {
 
         Ok(ValidTransaction {
             priority: reward as u64,
-            requires: missing_utxos,
+            requires: input_utxos.map_or_else(|x| x, |_| Vec::new()),
             provides: new_utxos,
             longevity: TransactionLongevity::MAX,
             propagate: true,
@@ -534,10 +532,10 @@ pub mod pallet {
             <UtxoStore<T>>::remove(input.outpoint);
         }
 
-        for (index, output) in tx.enumerate_outputs()? {
+        for (index, output) in tx.outputs.iter().enumerate() {
             match &output.destination {
                 Destination::Pubkey(_) | Destination::ScriptHash(_) => {
-                    let hash = tx.outpoint(index);
+                    let hash = tx.outpoint(index as u64);
                     log::debug!("inserting to UtxoStore {:?} as key {:?}", output, hash);
                     <UtxoStore<T>>::insert(hash, Some(output));
                 }

--- a/pallets/utxo/src/mock.rs
+++ b/pallets/utxo/src/mock.rs
@@ -43,11 +43,12 @@ pub type Block = frame_system::mocking::MockBlock<Test>;
 pub const ALICE_PHRASE: &str =
     "news slush supreme milk chapter athlete soap sausage put clutch what kitten";
 
-pub fn genesis_utxo() -> [u8; 32] {
+pub fn genesis_utxo() -> (TransactionOutput<u64>, H256) {
     let keystore = KeyStore::new();
     let alice_pub_key = create_pub_key(&keystore, ALICE_PHRASE);
     let output = TransactionOutput::<u64>::new_pubkey(100, H256::from(alice_pub_key));
-    BlakeTwo256::hash_of(&output).into()
+    let hash = BlakeTwo256::hash_of(&output);
+    (output, hash)
 }
 
 // Dummy programmable pool for testing

--- a/pallets/utxo/src/sign.rs
+++ b/pallets/utxo/src/sign.rs
@@ -1,0 +1,240 @@
+// Copyright (c) 2021 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): L. Kuklinek
+
+//! Verify transaction signatures
+//!
+//! This module provides two bits of functionality:
+//! 1. Tools to construct byte string to be signed when signing a transaction.
+//!    See [TransactionOutputSigMsg::construct].
+//! 2. Tools to verify signatures using multiple signature schemes.
+//!    See [Public] and [SignatureData].
+
+use crate::{Transaction, TransactionOutput};
+
+use chainscript::context::ParseResult;
+pub use chainscript::sighash::SigHash;
+use chainscript::sighash::{InputMode, OutputMode};
+use codec::{Decode, DecodeAll, Encode};
+use frame_support::sp_io::crypto;
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
+use sp_core::{sr25519, H256};
+use sp_runtime::traits::{BlakeTwo256, Hash};
+use sp_std::prelude::*;
+use variant_count::VariantCount;
+
+/// Transaction data comitted to in a signature.
+#[derive(Eq, PartialEq, Clone, Encode)]
+pub struct TransactionSigMsg {
+    /// Sighash
+    sighash: SigHash,
+    /// Information about inputs
+    inputs: TransactionInputSigMsg,
+    /// Information about outputs
+    outputs: TransactionOutputSigMsg,
+    /// OP_CODESEPARATOR position (or 0xffffffff if none seen so far)
+    codesep_idx: u32,
+}
+
+/// Transaction input data comitted to in a signature.
+#[derive(Eq, PartialEq, Clone, Encode)]
+enum TransactionInputSigMsg {
+    /// Commit to all inputs
+    CommitWhoPays {
+        outpoints: H256,
+        spending: H256,
+        index: u64,
+    },
+    /// Commit to this input only
+    AnyoneCanPay { outpoint: H256, spending: H256 },
+}
+
+/// Transaction output data comitted to in a signature.
+#[derive(Eq, PartialEq, Clone, Encode)]
+enum TransactionOutputSigMsg {
+    /// Commit to all transaction outputs
+    #[codec(index = 0x01)]
+    All { outputs: H256 },
+
+    /// Don't commit to any outputs (i.e. outputs can be changed freely)
+    #[codec(index = 0x02)]
+    None,
+
+    /// Commit to just one output that corresponds to the current input
+    #[codec(index = 0x03)]
+    Single { output: H256 },
+}
+
+impl TransactionSigMsg {
+    /// Create a `TransactionSigMsg` from a transaction, spent outputs, current index
+    /// and other context information according to given sighash.
+    ///
+    /// The `sighash` parameter specifies which parts of the transaction `tx` are signed. A list of
+    /// UTXOs corresponding to transaction inputs being spent is also required and has to be passed
+    /// in the `spending` parameter. No validation is done to ensure the UTXOs really match the
+    /// inputs, it is resposnsibility of the caller to verify it. The input being sign is passed in
+    /// the `index` argument and the index of the last `OP_CODESEPARATOR` is in `codesep_idx`.
+    ///
+    /// TODO This could be improved by pre-calculating hash values instead of hashing transaction
+    /// parts every time. Currently, all the hashes are recalculated from the scratch.
+    pub fn construct<AcctId: Encode>(
+        sighash: SigHash,
+        tx: &Transaction<AcctId>,
+        spending: &[TransactionOutput<AcctId>],
+        index: u64,
+        codesep_idx: u32,
+    ) -> Self {
+        let idx = index as usize;
+        assert!(spending.len() == tx.inputs.len());
+        assert!(idx < tx.inputs.len());
+
+        Self {
+            // Commit to the sighash mode
+            sighash,
+
+            // Inputs have three fields: outpoint, lock and witness. Witness is not committed to,
+            // outpoints are included and locks are commited to by including the output being spent
+            // into the message. The lock field is always fully determined by the output it spends.
+            inputs: match sighash.input_mode() {
+                InputMode::CommitWhoPays => TransactionInputSigMsg::CommitWhoPays {
+                    outpoints: BlakeTwo256::hash_of(
+                        &tx.inputs.iter().map(|i| &i.outpoint).collect::<Vec<&H256>>(),
+                    ),
+                    spending: BlakeTwo256::hash_of(&spending),
+                    index,
+                },
+                InputMode::AnyoneCanPay => TransactionInputSigMsg::AnyoneCanPay {
+                    outpoint: tx.inputs[idx].outpoint,
+                    spending: BlakeTwo256::hash_of(&spending[idx]),
+                },
+            },
+
+            // Outputs are comitted to as a whole, not individual fields.
+            outputs: match sighash.output_mode() {
+                OutputMode::All => TransactionOutputSigMsg::All {
+                    outputs: BlakeTwo256::hash_of(&tx.outputs),
+                },
+                OutputMode::None => TransactionOutputSigMsg::None,
+                OutputMode::Single => TransactionOutputSigMsg::Single {
+                    output: tx.outputs.get(idx).map_or(H256::zero(), BlakeTwo256::hash_of),
+                },
+            },
+
+            // Code separator position
+            codesep_idx,
+        }
+    }
+}
+
+/// Signature schemes. Identified by the public key type.
+pub trait Scheme: Sized {
+    /// Signature type corresponding to the pubkey type for this scheme.
+    type Signature: Decode;
+
+    /// Verify signature against raw data.
+    fn verify_raw(&self, sig: &Self::Signature, msg: &[u8]) -> bool;
+
+    /// Parse signature & sighash and bundle it with a pubkey.
+    fn parse_sig(self, sig: &[u8]) -> Option<SignatureDataFor<Self>> {
+        let mut input = sig;
+        let signature = Decode::decode(&mut input).ok()?;
+        let sighash = match input {
+            &[x] => SigHash::from_u8(x)?,
+            &[] => SigHash::default(),
+            _ => return None,
+        };
+        Some(SignatureDataFor {
+            pubkey: self,
+            signature,
+            sighash,
+        })
+    }
+}
+
+// Schnorr signature scheme.
+impl Scheme for sr25519::Public {
+    type Signature = sr25519::Signature;
+
+    fn verify_raw(&self, sig: &Self::Signature, msg: &[u8]) -> bool {
+        crypto::sr25519_verify(sig, msg, self)
+    }
+}
+
+/// A public key. An enum to accommodate for multiple signature schemes.
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Encode, Decode, Debug, VariantCount)]
+pub enum Public {
+    /// Schnorr public key
+    Schnorr(sr25519::Public),
+}
+
+impl Public {
+    /// Parse a public key from given key byte array.
+    pub fn parse(pk: &[u8]) -> ParseResult<Self> {
+        let key_type = match pk.get(0) {
+            Some(&kt) => kt,
+            None => return ParseResult::Err,
+        };
+        if (key_type as usize) < Self::VARIANT_COUNT {
+            Self::decode_all(&mut &pk).ok().into()
+        } else {
+            ParseResult::Reserved
+        }
+    }
+
+    /// Parse signature data according to the current pubkey type.
+    pub fn parse_sig(self, sig: &[u8]) -> Option<SignatureData> {
+        match self {
+            Public::Schnorr(pk) => pk.parse_sig(sig).map(SignatureData::Schnorr),
+        }
+    }
+}
+
+impl From<sr25519::Public> for Public {
+    fn from(pk: sr25519::Public) -> Self {
+        Self::Schnorr(pk)
+    }
+}
+
+/// A signature together with its usage information for particular signature scheme.
+pub struct SignatureDataFor<P: Scheme> {
+    pubkey: P,
+    signature: P::Signature,
+    sighash: SigHash,
+}
+
+/// Signature data for multiple possible key types
+pub enum SignatureData {
+    Schnorr(SignatureDataFor<sr25519::Public>),
+}
+
+impl SignatureData {
+    /// Verify signature against a message.
+    pub fn verify<T: Encode>(&self, msg: &T) -> bool {
+        let data = T::encode(msg);
+        match self {
+            SignatureData::Schnorr(s) => s.pubkey.verify_raw(&s.signature, &data),
+        }
+    }
+
+    /// Get sighash
+    pub fn sighash(&self) -> SigHash {
+        match self {
+            SignatureData::Schnorr(s) => s.sighash,
+        }
+    }
+}

--- a/pallets/utxo/src/tests.rs
+++ b/pallets/utxo/src/tests.rs
@@ -28,8 +28,25 @@ use frame_support::{
 };
 use sp_core::{sp_std::vec, sr25519::Public, testing::SR25519, H256, H512};
 
-fn tx_input_gen_no_signature() -> TransactionInput {
-    TransactionInput::new_empty(H256::from(genesis_utxo()))
+impl Transaction<u64> {
+    // A convenience method to sign a transaction
+    fn sign(mut self, utxos: &[TransactionOutput<u64>], index: usize, pk: &Public) -> Self {
+        let msg = crate::sign::TransactionSigMsg::construct(
+            Default::default(),
+            &self,
+            &utxos,
+            index as u64,
+            u32::MAX,
+        );
+        self.inputs[index].witness =
+            crypto::sr25519_sign(SR25519, pk, &msg.encode()).unwrap().0.to_vec();
+        self
+    }
+}
+
+fn tx_input_gen_no_signature() -> (TransactionOutput<u64>, TransactionInput) {
+    let (utxo, hash) = genesis_utxo();
+    (utxo, TransactionInput::new_empty(hash))
 }
 
 fn execute_with_alice<F>(mut execute: F)
@@ -44,7 +61,7 @@ where
 
 #[test]
 fn pubkey_commitment_hash() {
-    let dest = Destination::<u64>::Pubkey(H256::zero());
+    let dest = Destination::<u64>::Pubkey(Public([0; 32]).into());
     assert_eq!(dest.lock_commitment(), &BlakeTwo256::hash(&[]));
 }
 
@@ -62,12 +79,12 @@ fn test_script_preimage() {
         let script_hash: H256 = BlakeTwo256::hash(script.as_ref());
         let witness_script = Builder::new().push_slice(password).into_script();
 
-        let mut tx1 = Transaction {
-            inputs: vec![tx_input_gen_no_signature()],
+        let (utxo0, input0) = tx_input_gen_no_signature();
+        let tx1 = Transaction {
+            inputs: vec![input0],
             outputs: vec![TransactionOutput::new_script_hash(50, script_hash)],
-        };
-        let alice_sig = crypto::sr25519_sign(SR25519, &alice_pub_key, &tx1.encode()).unwrap();
-        tx1.inputs[0].witness = alice_sig.0.to_vec();
+        }
+        .sign(&[utxo0], 0, &alice_pub_key);
 
         let tx2 = Transaction {
             inputs: vec![TransactionInput::new_script(tx1.outpoint(0), script, witness_script)],
@@ -83,15 +100,15 @@ fn test_script_preimage() {
 fn test_unchecked_2nd_output() {
     execute_with_alice(|alice_pub_key| {
         // Create and sign a transaction
-        let mut tx1 = Transaction {
-            inputs: vec![tx_input_gen_no_signature()],
+        let (utxo0, input0) = tx_input_gen_no_signature();
+        let tx1 = Transaction {
+            inputs: vec![input0],
             outputs: vec![
                 TransactionOutput::new_create_pp(0, vec![], vec![]),
                 TransactionOutput::new_pubkey(50, H256::from(alice_pub_key)),
             ],
-        };
-        let alice_sig1 = crypto::sr25519_sign(SR25519, &alice_pub_key, &tx1.encode()).unwrap();
-        tx1.inputs[0].witness = alice_sig1.0.to_vec();
+        }
+        .sign(&[utxo0], 0, &alice_pub_key);
 
         // Calculate output 1 hash.
         let utxo1_hash = tx1.outpoint(1);
@@ -106,16 +123,16 @@ fn test_unchecked_2nd_output() {
 fn test_simple_tx() {
     execute_with_alice(|alice_pub_key| {
         // Alice wants to send herself a new utxo of value 50.
-        let mut tx = Transaction {
-            inputs: vec![tx_input_gen_no_signature()],
+        let (utxo0, input0) = tx_input_gen_no_signature();
+        let tx = Transaction {
+            inputs: vec![input0],
             outputs: vec![TransactionOutput::new_pubkey(50, H256::from(alice_pub_key))],
-        };
+        }
+        .sign(&[utxo0], 0, &alice_pub_key);
 
-        let alice_sig = crypto::sr25519_sign(SR25519, &alice_pub_key, &tx.encode()).unwrap();
-        tx.inputs[0].witness = alice_sig.0.to_vec();
         let new_utxo_hash = tx.outpoint(0);
 
-        let init_utxo = genesis_utxo();
+        let (_, init_utxo) = genesis_utxo();
         assert!(UtxoStore::<Test>::contains_key(H256::from(init_utxo)));
         assert_ok!(Utxo::spend(Origin::signed(0), tx));
         assert!(!UtxoStore::<Test>::contains_key(H256::from(init_utxo)));
@@ -165,19 +182,15 @@ fn attack_with_empty_transactions() {
 #[test]
 fn attack_by_double_counting_input() {
     execute_with_alice(|alice_pub_key| {
-        let mut tx = Transaction {
-            inputs: vec![
-                tx_input_gen_no_signature(),
-                // a double spend of the same UTXO!
-                tx_input_gen_no_signature(),
-            ],
+        let (utxo0, input0) = tx_input_gen_no_signature();
+        let utxos = [utxo0.clone(), utxo0];
+        let tx = Transaction {
+            // a double spend of the same UTXO!
+            inputs: vec![input0.clone(), input0],
             outputs: vec![TransactionOutput::new_pubkey(100, H256::from(alice_pub_key))],
-        };
-
-        let alice_sig = crypto::sr25519_sign(SR25519, &alice_pub_key, &tx.encode()).unwrap();
-
-        tx.inputs[0].witness = alice_sig.0.to_vec();
-        tx.inputs[1].witness = alice_sig.0.to_vec();
+        }
+        .sign(&utxos[..], 0, &alice_pub_key)
+        .sign(&utxos[..], 1, &alice_pub_key);
 
         assert_err!(
             Utxo::spend(Origin::signed(0), tx),
@@ -189,12 +202,10 @@ fn attack_by_double_counting_input() {
 #[test]
 fn attack_with_invalid_signature() {
     execute_with_alice(|alice_pub_key| {
+        let (_utxo0, input0) = genesis_utxo();
         let tx = Transaction {
-            inputs: vec![TransactionInput::new_with_signature(
-                H256::from(genesis_utxo()),
-                // Just a random signature!
-                H512::random(),
-            )],
+            // Just a random signature!
+            inputs: vec![TransactionInput::new_with_signature(input0, H512::random())],
             outputs: vec![TransactionOutput::new_pubkey(100, H256::from(alice_pub_key))],
         };
 
@@ -208,14 +219,13 @@ fn attack_with_invalid_signature() {
 #[test]
 fn attack_by_permanently_sinking_outputs() {
     execute_with_alice(|alice_pub_key| {
-        let mut tx = Transaction {
-            inputs: vec![tx_input_gen_no_signature()],
+        let (utxo0, input0) = tx_input_gen_no_signature();
+        let tx = Transaction {
+            inputs: vec![input0],
             //A 0 value output burns this output forever!
             outputs: vec![TransactionOutput::new_pubkey(0, H256::from(alice_pub_key))],
-        };
-
-        let alice_sig = crypto::sr25519_sign(SR25519, &alice_pub_key, &tx.encode()).unwrap();
-        tx.inputs[0].witness = alice_sig.0.to_vec();
+        }
+        .sign(&[utxo0], 0, &alice_pub_key);
 
         assert_noop!(
             Utxo::spend(Origin::signed(0), tx),
@@ -227,17 +237,16 @@ fn attack_by_permanently_sinking_outputs() {
 #[test]
 fn attack_by_overflowing_value() {
     execute_with_alice(|alice_pub_key| {
-        let mut tx = Transaction {
-            inputs: vec![tx_input_gen_no_signature()],
+        let (utxo0, input0) = tx_input_gen_no_signature();
+        let tx = Transaction {
+            inputs: vec![input0],
             outputs: vec![
                 TransactionOutput::new_pubkey(Value::MAX, H256::from(alice_pub_key)),
                 // Attempts to do overflow total output value
                 TransactionOutput::new_pubkey(10, H256::from(alice_pub_key)),
             ],
-        };
-
-        let alice_sig = crypto::sr25519_sign(SR25519, &alice_pub_key, &tx.encode()).unwrap();
-        tx.inputs[0].witness = alice_sig.0.to_vec();
+        }
+        .sign(&[utxo0], 0, &alice_pub_key);
 
         assert_err!(Utxo::spend(Origin::signed(0), tx), "output value overflow");
     });
@@ -246,17 +255,16 @@ fn attack_by_overflowing_value() {
 #[test]
 fn attack_by_overspending() {
     execute_with_alice(|alice_pub_key| {
-        let mut tx = Transaction {
-            inputs: vec![tx_input_gen_no_signature()],
+        let (utxo0, input0) = tx_input_gen_no_signature();
+        let tx = Transaction {
+            inputs: vec![input0],
             outputs: vec![
                 TransactionOutput::new_pubkey(100, H256::from(alice_pub_key)),
                 // Creates 2 new utxo out of thin air
                 TransactionOutput::new_pubkey(2, H256::from(alice_pub_key)),
             ],
-        };
-
-        let alice_sig = crypto::sr25519_sign(SR25519, &alice_pub_key, &tx.encode()).unwrap();
-        tx.inputs[0].witness = alice_sig.0.to_vec();
+        }
+        .sign(&[utxo0], 0, &alice_pub_key);
 
         assert_noop!(
             Utxo::spend(Origin::signed(0), tx),
@@ -272,28 +280,26 @@ fn tx_from_alice_to_karl() {
     let (mut test_ext, alice_pub_key, karl_pub_key) = new_test_ext_and_keys();
     test_ext.execute_with(|| {
         // alice sends 10 tokens to karl and the rest back to herself
-        let mut tx = Transaction {
-            inputs: vec![tx_input_gen_no_signature()],
+        let (utxo0, input0) = tx_input_gen_no_signature();
+        let tx = Transaction {
+            inputs: vec![input0],
             outputs: vec![
                 TransactionOutput::new_pubkey(10, H256::from(karl_pub_key)),
                 TransactionOutput::new_pubkey(90, H256::from(alice_pub_key)),
             ],
-        };
-
-        let alice_sig = crypto::sr25519_sign(SR25519, &alice_pub_key, &tx.encode()).unwrap();
-        tx.inputs[0].witness = alice_sig.0.to_vec();
+        }
+        .sign(&[utxo0], 0, &alice_pub_key);
 
         assert_ok!(Utxo::spend(Origin::signed(0), tx.clone()));
         let new_utxo_hash = tx.outpoint(1);
+        let new_utxo = tx.outputs[1].clone();
 
         // then send rest of the tokens to karl (proving that the first tx was successful)
-        let mut tx = Transaction {
+        let tx = Transaction {
             inputs: vec![TransactionInput::new_empty(new_utxo_hash)],
             outputs: vec![TransactionOutput::new_pubkey(90, H256::from(karl_pub_key))],
-        };
-
-        let alice_sig = crypto::sr25519_sign(SR25519, &alice_pub_key, &tx.encode()).unwrap();
-        tx.inputs[0].witness = alice_sig.0.to_vec();
+        }
+        .sign(&[new_utxo], 0, &alice_pub_key);
 
         assert_ok!(Utxo::spend(Origin::signed(0), tx));
     });
@@ -303,13 +309,13 @@ fn tx_from_alice_to_karl() {
 #[test]
 fn test_reward() {
     execute_with_alice(|alice_pub_key| {
-        let mut tx = Transaction {
-            inputs: vec![tx_input_gen_no_signature()],
+        let (utxo0, input0) = tx_input_gen_no_signature();
+        let tx = Transaction {
+            inputs: vec![input0],
             outputs: vec![TransactionOutput::new_pubkey(90, H256::from(alice_pub_key))],
-        };
+        }
+        .sign(&[utxo0], 0, &alice_pub_key);
 
-        let alice_sig = crypto::sr25519_sign(SR25519, &alice_pub_key, &tx.encode()).unwrap();
-        tx.inputs[0].witness = alice_sig.0.to_vec();
         assert_ok!(Utxo::spend(Origin::signed(0), tx.clone()));
 
         // if the previous spend succeeded, there should be one utxo
@@ -325,16 +331,14 @@ fn test_reward() {
 #[test]
 fn test_script() {
     execute_with_alice(|alice_pub_key| {
-        let mut tx = Transaction {
-            inputs: vec![tx_input_gen_no_signature()],
+        let (utxo0, input0) = tx_input_gen_no_signature();
+        let tx = Transaction {
+            inputs: vec![input0],
             outputs: vec![TransactionOutput::new_pubkey(90, H256::from(alice_pub_key))],
-        };
+        }
+        .sign(&[utxo0], 0, &alice_pub_key);
 
-        tx.outputs[0].destination = Destination::Pubkey(H256::zero());
-
-        let alice_sig = crypto::sr25519_sign(SR25519, &alice_pub_key, &tx.encode()).unwrap();
-        tx.inputs[0].witness = alice_sig.0.to_vec();
-        assert_ok!(Utxo::spend(Origin::signed(0), tx.clone()));
+        assert_ok!(Utxo::spend(Origin::signed(0), tx));
     })
 }
 
@@ -342,14 +346,14 @@ fn test_script() {
 fn attack_double_spend_by_tweaking_input() {
     execute_with_alice(|alice_pub_key| {
         // Prepare and send a transaction with a 50-token output
+        let (utxo0, input0) = tx_input_gen_no_signature();
         let drop_script = Builder::new().push_opcode(opc::OP_DROP).into_script();
         let drop_script_hash = BlakeTwo256::hash(drop_script.as_ref());
-        let mut tx0 = Transaction {
-            inputs: vec![tx_input_gen_no_signature()],
+        let tx0 = Transaction {
+            inputs: vec![input0],
             outputs: vec![TransactionOutput::new_script_hash(50, drop_script_hash)],
-        };
-        let alice_sig = crypto::sr25519_sign(SR25519, &alice_pub_key, &tx0.encode()).unwrap();
-        tx0.inputs[0].witness = alice_sig.0.to_vec();
+        }
+        .sign(&[utxo0], 0, &alice_pub_key);
         assert_ok!(Utxo::spend(Origin::signed(0), tx0.clone()));
 
         // Create a transaction that spends the same input 10 times by slightly modifying the


### PR DESCRIPTION
Update the transaction signature mechanism. It is a kind of hybrid between Segwit and Taproot way of doing signatures. Since generating signatures is no longer so straightforward, there will be matching utxo-tester PR soon which should help with experimenting and as a second reference implementation.