### PR TITLE
DO NOT MERGE.  This is for using `pallet-staking`'s logic to do staking. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,6 +1559,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-election-provider-support"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#6e15de9703bfe09b85efa33fd6e3a94d2446dd01"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "sp-arithmetic",
+ "sp-npos-elections",
+ "sp-std",
+]
+
+[[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#6e15de9703bfe09b85efa33fd6e3a94d2446dd01"
@@ -3643,13 +3656,16 @@ name = "node-template-runtime"
 version = "3.0.0"
 dependencies = [
  "frame-benchmarking",
+ "frame-election-provider-support",
  "frame-executive",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "hex-literal 0.3.3",
+ "log",
  "pallet-aura",
+ "pallet-authorship",
  "pallet-balances",
  "pallet-contracts",
  "pallet-contracts-primitives",
@@ -3657,6 +3673,9 @@ dependencies = [
  "pallet-grandpa",
  "pallet-pp",
  "pallet-randomness-collective-flip",
+ "pallet-session",
+ "pallet-staking",
+ "pallet-staking-reward-curve",
  "pallet-sudo",
  "pallet-template",
  "pallet-timestamp",
@@ -3674,6 +3693,7 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
+ "sp-staking",
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
@@ -4038,6 +4058,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-staking"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#6e15de9703bfe09b85efa33fd6e3a94d2446dd01"
+dependencies = [
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authorship",
+ "pallet-session",
+ "parity-scale-codec",
+ "serde",
+ "sp-application-crypto",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-staking-reward-curve"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#6e15de9703bfe09b85efa33fd6e3a94d2446dd01"
+dependencies = [
+ "proc-macro-crate 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#6e15de9703bfe09b85efa33fd6e3a94d2446dd01"
@@ -4136,13 +4187,10 @@ dependencies = [
  "frame-system",
  "hex-literal 0.2.1",
  "log",
- "pallet-aura",
- "pallet-timestamp",
  "pallet-utxo-tokens",
  "parity-scale-codec",
  "pp-api",
  "serde",
- "sp-consensus-aura",
  "sp-core",
  "sp-keystore",
  "sp-runtime",
@@ -6945,6 +6993,30 @@ source = "git+https://github.com/paritytech/substrate.git?branch=master#6e15de97
 dependencies = [
  "ruzstd",
  "zstd",
+]
+
+[[package]]
+name = "sp-npos-elections"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#6e15de9703bfe09b85efa33fd6e3a94d2446dd01"
+dependencies = [
+ "parity-scale-codec",
+ "serde",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-npos-elections-solution-type",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-npos-elections-solution-type"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#6e15de9703bfe09b85efa33fd6e3a94d2446dd01"
+dependencies = [
+ "proc-macro-crate 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/pallets/utxo/Cargo.toml
+++ b/pallets/utxo/Cargo.toml
@@ -89,18 +89,3 @@ branch = "master"
 version = "0.10.0-dev"
 git = 'https://github.com/paritytech/substrate.git'
 branch = "master"
-
-[dev-dependencies.pallet-aura]
-git = 'https://github.com/paritytech/substrate.git'
-version = '4.0.0-dev'
-branch = "master"
-
-[dev-dependencies.sp-consensus-aura]
-git = 'https://github.com/paritytech/substrate.git'
-version = '0.10.0-dev'
-branch = "master"
-
-[dev-dependencies.pallet-timestamp]
-git = 'https://github.com/paritytech/substrate.git'
-branch = "master"
-version = '4.0.0-dev'

--- a/pallets/utxo/README.md
+++ b/pallets/utxo/README.md
@@ -10,47 +10,70 @@ To run the test cases, just run command `cargo test`.
 1. After running the core, declare the custom datatypes. GO to **Settings** > **Developer** tab and paste in the ff. JSON and then save:
 ```json
 {
-  "Value": "u128",
-  "Destination": {
-    "_enum": {
-      "Pubkey": "Public",
-      "CreatePP": "DestinationCreatePP",
-      "CallPP": "DestinationCallPP"
-    }
-  },
-  "DestinationCreatePP": {
-    "code": "Vec<u8>",
-    "data": "Vec<u8>"
-  },
-  "DestinationCallPP": {
-    "dest_account": "AccountId",
-    "input_data": "Vec<u8>"
-  },
-  "TransactionInput": {
-    "outpoint": "Hash",
-    "lock": "Vec<u8>",
-    "witness": "Vec<u8>"
-  },
-  "TransactionOutput": {
-    "value": "Value",
-    "header": "TXOutputHeader",
-    "destination": "Destination"
-  },
-  "TransactionOutputFor": "TransactionOutput",
-  "Transaction": {
-    "inputs": "Vec<TransactionInput>",
-    "outputs": "Vec<TransactionOutput>"
-  },
-  "TransactionFor": "Transaction",
-  "Address": "MultiAddress",
-  "LookupSource": "MultiAddress",
-  "TXOutputHeader": "u16",
-  "Difficulty": "U256",
-  "DifficultyAndTimestamp": {
-    "difficulty": "Difficulty",
-    "timestamp": "Moment"
-  },
-  "Public": "H256"
+   "Value": "u128",
+   "Destination": {
+      "_enum": {
+         "Pubkey": "Public",
+         "CreatePP": "DestinationCreatePP",
+         "CallPP": "DestinationCallPP",
+         "ScriptHash": "Public",
+         "PubkeyHash": "Vec<u8>",
+         "Stake": "DestinationStake",
+         "StakeExtra": "Public",
+         "WithdrawStake": "DestinationWithdrawStake"
+      }
+   },
+   "DestinationWithdrawStake": {
+      "outpoints": "Vec<Hash>",
+      "pub_key": "Public"
+   },
+   "DestinationStake": {
+      "stash_account": "AccountId",
+      "controller_account": "AccountId",
+      "rotate_keys": "Vec<u8>"
+   },
+   "DestinationCreatePP": {
+      "code": "Vec<u8>",
+      "data": "Vec<u8>"
+   },
+   "DestinationCallPP": {
+      "dest_account": "AccountId",
+      "input_data": "Vec<u8>"
+   },
+   "TransactionInput": {
+      "outpoint": "Hash",
+      "lock": "Vec<u8>",
+      "witness": "Vec<u8>"
+   },
+   "TransactionOutput": {
+      "value": "Value",
+      "header": "TXOutputHeader",
+      "destination": "Destination"
+   },
+   "TransactionOutputFor": "TransactionOutput",
+   "Transaction": {
+      "inputs": "Vec<TransactionInput>",
+      "outputs": "Vec<TransactionOutput>"
+   },
+   "TransactionFor": "Transaction",
+   "Address": "MultiAddress",
+   "LookupSource": "MultiAddress",
+   "TXOutputHeader": "u128",
+   "Difficulty": "U256",
+   "DifficultyAndTimestamp": {
+      "difficulty": "Difficulty",
+      "timestamp": "Moment"
+   },
+   "Public": "H256",
+   "String": "Vec<u8>",
+   "TokenID": "u64",
+   "TokenInstance": {
+      "id": "u64",
+      "name": "String",
+      "ticker": "String",
+      "supply": "u128"
+   },
+   "TokenListData": "Vec<TokenInstance>"
 }
 ```
 2. To confirm that Alice already has UTXO at genesis, go to **Developer** > **Chain state** > **Storage**.  

--- a/pallets/utxo/src/authorship.rs
+++ b/pallets/utxo/src/authorship.rs
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): C. Yap
+
+use crate::{Config, BlockAuthor};
+use frame_support::{traits::FindAuthor,ConsensusEngineId};
+use frame_support::traits::ValidatorSet;
+
+/// Get the `H256` version of the BlockAuthor.
+/// The BlockAuthor is known by its index position only.
+/// To return the actual accountId, the Validators set is required.
+pub struct FindAccountFromAuthorIndex<T,Inner,Validators>(core::marker::PhantomData<(T,Inner,Validators)>);
+
+
+impl<T: Config, Inner: FindAuthor<u32>, Validators:ValidatorSet<T::AccountId>>
+FindAuthor<Validators::ValidatorId> for FindAccountFromAuthorIndex<T,Inner, Validators>
+{
+    fn find_author<'a, I>(digests: I) -> Option<Validators::ValidatorId>
+        where
+            I: 'a + IntoIterator<Item=(ConsensusEngineId, &'a [u8])> {
+        let i = Inner::find_author(digests)?;
+        if let Some(authority) = T::authorities().get(i as usize) {
+            <BlockAuthor::<T>>::put(Some(*authority));
+        }
+
+        let validators = Validators::validators();
+        validators.get(i as usize).map(|k| k.clone())
+    }
+}

--- a/pallets/utxo/src/benchmarking.rs
+++ b/pallets/utxo/src/benchmarking.rs
@@ -123,12 +123,12 @@ benchmarks! {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mock::{new_test_ext, Test};
+    use crate::mock::{alice_test_ext, Test};
     use frame_support::assert_ok;
 
     #[test]
     fn spend() {
-        new_test_ext().execute_with(|| {
+        alice_test_ext().execute_with(|| {
             assert_ok!(test_benchmark_test_spend::<Test>());
         });
     }

--- a/pallets/utxo/src/lib.rs
+++ b/pallets/utxo/src/lib.rs
@@ -1097,6 +1097,9 @@ pub mod pallet {
             spend::<T>(&signer, &tx)
         }
 
+        /// unlock the stake, if use wants to stop validating and wants to withdraw the locked utxos.
+        /// To withdraw, note that you need to check with the outside staking (a.k.a. pallet-staking)
+        /// the period of time (or era, as it is called) to when a withdrawal can be done.
         #[pallet::weight(T::WeightInfo::unlock_stake(1 as u32))]
         pub fn unlock_stake(
             origin: OriginFor<T>,
@@ -1114,7 +1117,9 @@ pub mod pallet {
     pub struct GenesisConfig<T: Config> {
         pub genesis_utxos: Vec<TransactionOutputFor<T>>,
         pub locked_utxos: Vec<TransactionOutputFor<T>>,
+        /// number of coins available for rewarding, esp. to block authors/producers.
         pub extra_mlt_coins:Value,
+        /// the amount to reward block authors/producers.
         pub initial_reward_amount:Value,
         pub _marker: PhantomData<T>,
     }
@@ -1146,7 +1151,6 @@ pub mod pallet {
                 if let Destination::Stake { stash_account:_, controller_account, rotate_keys:_ } =  &u.destination {
                     <StakingCount<T>>::insert(controller_account.clone(),1);
                 }
-                log::debug!("inserting {:?} to LockedUtxos:",u);
                 LockedUtxos::<T>::insert(BlakeTwo256::hash_of(&u), Some(u));
             });
         }

--- a/pallets/utxo/src/rewards.rs
+++ b/pallets/utxo/src/rewards.rs
@@ -1,0 +1,99 @@
+// Copyright (c) 2021 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): C. Yap
+
+use crate::{Config, Pallet, Event, BlockAuthorRewardAmount, BlockAuthor, MLTCoinsAvailable, TransactionOutput, UtxoStore, period_elapsed};
+
+use frame_support::traits::Get;
+use sp_runtime::traits::{SaturatedConversion, BlakeTwo256, Hash, Zero};
+
+/// Returns the newly reduced reward amount for a Block Author.
+/// How much a reward is reduced, is based on the config's`RewardReductionFraction`.
+pub(super) fn update_reward_amount<T:Config>(coins_available:u128) -> u128 {
+    let reduction_fraction = T::RewardReductionFraction::get();
+
+    let reward_amount = <BlockAuthorRewardAmount<T>>::take();
+    log::info!("current reward amount: {}", reward_amount);
+    let reward_amount_deducted = reduction_fraction.mul_ceil(reward_amount);
+    if let Some(reward_amount) = reward_amount.checked_sub(reward_amount_deducted) {
+
+        // as long as there is still coins available, set the reward to 1.
+        return if reward_amount.is_zero() {
+            <BlockAuthorRewardAmount<T>>::put(1);
+            1
+        }
+        else if reward_amount <= coins_available {
+            <BlockAuthorRewardAmount<T>>::put(reward_amount);
+            reward_amount
+        } else {
+            <BlockAuthorRewardAmount<T>>::put(coins_available);
+            coins_available
+        };
+    }
+    0
+}
+
+
+/// Rewards the block author with a utxo of value basaed on the `BlockAuthorRewardAmount`.
+pub(super) fn reward_block_author<T:Config>(block_number: T::BlockNumber) {
+    let coins_available = <MLTCoinsAvailable<T>>::take();
+
+    // give rewards only if there are coins available.
+    if coins_available > 0 {
+        // give rewards only if a block author is found
+        if let Some(block_author) = <BlockAuthor<T>>::take() {
+            log::debug!("reward_block_author:: : {:?}", block_author);
+
+            // check if a period has passed.
+            // if it has, update the reward amount based on the reduction rate.
+            // see RewardReductionFraction
+            let reward_amount = if period_elapsed::<T>(block_number) {
+                update_reward_amount::<T>(coins_available)
+            } else {
+                <BlockAuthorRewardAmount<T>>::get()
+            };
+
+            // just double check to avoid creating a utxo of value 0
+            if !reward_amount.is_zero() {
+                let utxo = TransactionOutput::new_pubkey(reward_amount, block_author.clone());
+
+                let hash = {
+                    let b_num = block_number.saturated_into::<u64>();
+                    BlakeTwo256::hash_of(&(&utxo, b_num, "author_reward"))
+                };
+
+                if !<UtxoStore<T>>::contains_key(hash) {
+                    <UtxoStore<T>>::insert(hash, Some(utxo.clone()));
+
+                    // deduct the coins transferred to the block author
+                    <MLTCoinsAvailable<T>>::put(coins_available - reward_amount);
+
+                    <Pallet<T>>::deposit_event(Event::<T>::BlockAuthorRewarded { value: utxo.value, destination: block_author});
+
+                    return;
+                }
+            }
+
+        } else {
+            log::warn!("no block author found for block number {:?}", block_number);
+        }
+
+        <MLTCoinsAvailable<T>>::put(coins_available);
+    } else {
+        log::warn!("no coins available for rewarding");
+    }
+
+}

--- a/pallets/utxo/src/staking.rs
+++ b/pallets/utxo/src/staking.rs
@@ -1,0 +1,151 @@
+
+use crate::{Config, StakingCount, Error,Event, Pallet, TransactionOutput, Destination, LockedUtxos, Value, UtxoStore};
+use sp_core::H256;
+use frame_support::{dispatch::{DispatchResultWithPostInfo, Vec}, ensure};
+
+/// A helper trait to handle staking NOT found in pallet-utxo.
+pub trait StakingHelper<AccountId>{
+
+    fn get_account_id(pub_key: &H256) -> AccountId;
+
+    /// start the staking.
+    /// # Arguments
+    /// * `stash_account` - A placeholder of the "supposed" validator. This is only to "satisfy"
+    /// the `pallet-staking`'s needs to be able to stake.
+    /// * `controller_account` - The ACTUAL validator. But this is NOT SO, in the `pallet-staking`.
+    /// In `pallet-staking`, its job is like an "accountant" to the stash account.
+    /// * `rotate_keys` - or also called the session keys, to get up-to-date
+    /// with validators, eras, sessions. see `pallet-session`.
+    fn stake(stash_account:&AccountId, controller_account:&AccountId, rotate_keys:&mut Vec<u8>) -> DispatchResultWithPostInfo;
+
+    /// quitting the role of a validator.
+    fn pause(controller_account:&AccountId) -> DispatchResultWithPostInfo;
+
+    /// transfer balance from the locked state to the actual free balance.
+    fn withdraw(controller_account: &AccountId) -> DispatchResultWithPostInfo;
+
+}
+
+/// performs the staking outside of the `pallet-utxo`.
+pub(crate) fn stake<T: Config>(
+    stash_account: &T::AccountId,
+    controller_account: &T::AccountId,
+    rotate_keys:&Vec<u8>)
+    -> DispatchResultWithPostInfo {
+    if <StakingCount<T>>::contains_key(controller_account) {
+        Err(Error::<T>::StakingAlreadyExists)?
+    }
+
+    let mut rotate_keys = rotate_keys.to_vec();
+    T::StakingHelper::stake(stash_account, controller_account, &mut rotate_keys)?;
+
+    Ok(().into())
+}
+
+/// unlocking the staked funds outside of the `pallet-utxo`.
+/// also means quitting/pausing from being a validator.
+pub(crate) fn unlock<T: Config>(controller_pubkey: &H256) -> DispatchResultWithPostInfo {
+    let controller_account= T::StakingHelper::get_account_id(controller_pubkey);
+    T::StakingHelper::pause(&controller_account)?;
+
+    Ok(().into())
+}
+
+
+/// Consolidates all unlocked utxos  into one, and moves it to `UtxoStore`.
+/// Make SURE that `fn unlock(...)` has been called and the era for withdrawal has passed, before
+/// performing a withdrawal.
+/// # Arguments
+/// * `output` - the output containing the `Destination::WithdrawStake`.
+/// * `hash` - is the outpoint/key to save the new utxo
+pub(crate) fn withdraw<T: Config>(output:&TransactionOutput<T::AccountId>,hash:H256) -> DispatchResultWithPostInfo {
+    if let Destination::WithdrawStake { outpoints, pub_key } =  &output.destination {
+        let controller_account = T::StakingHelper::get_account_id(pub_key);
+        T::StakingHelper::withdraw(&controller_account)?;
+
+        let mut sum:Value = 0;
+        outpoints.iter().for_each(|hash| sum += <LockedUtxos<T>>::take(hash).unwrap().value);
+
+        let new_tx = TransactionOutput {
+            value: sum,
+            header: 0,
+            destination: Destination::Pubkey(pub_key.clone())
+        };
+
+        if !<UtxoStore<T>>::contains_key(hash) {
+            log::info!("inserting to UtxoStore {:?} as key {:?}", new_tx, hash);
+            <UtxoStore<T>>::insert(hash, Some(new_tx));
+            <StakingCount<T>>::remove(controller_account);
+
+            <Pallet<T>>::deposit_event(Event::<T>::StakeWithdrawn(sum,pub_key.clone()));
+        }
+    } else {
+        log::error!("InvalidOperation; when performing a withdrawal, make sure the destination is `WithdrawStake`");
+        Err(Error::<T>::InvalidOperation)?
+    }
+
+    Ok(().into())
+}
+
+/// Checks whether a given pub_key is a validator.
+pub(crate) fn check_controller<T:Config>(controller_pubkey: &H256) -> Option<T::AccountId> {
+    let controller_account = T::StakingHelper::get_account_id(controller_pubkey);
+    if !<StakingCount<T>>::contains_key(&controller_account) {
+        log::error!("No staking record found.");
+        return None;
+    }
+    Some(controller_account.clone())
+}
+
+
+/// Checks a given hash outpoint/key is owned by the specified pub_key
+/// # Arguments
+/// * `hash` - is the outpoint/key of the locked utxo.
+/// * `ctrl_pub_key` - the controller_pub_key, said to "own" the locked utxo
+/// * `ctrl_account` - the account derivation of the controller_pub_key
+pub(crate) fn is_owned_locked_utxo<T:Config>(hash:&H256, ctrl_pub_key: &H256, ctrl_account: &T::AccountId) -> Result<(), &'static str> {
+    if let Some(utxo) = <LockedUtxos<T>>::get(hash) {
+        match utxo.destination {
+            Destination::Stake { stash_account:_, controller_account, rotate_keys: _ } => {
+                ensure!(&controller_account == ctrl_account, "hash of stake not owned");
+
+            }
+            Destination::StakeExtra(controller_pub_key) => {
+                ensure!(&controller_pub_key == ctrl_pub_key, "hash of extra stake not owned");
+            }
+            _ => {
+                log::error!("For locked utxos, only with destinations `Stake` and `StakeExtra` are allowed.");
+                Err("destination not applicable")?
+            }
+        }
+    } else {
+        Err("hash not found in lockedutxos.")?
+    }
+
+    Ok(())
+}
+
+
+/// It includes:
+/// 1. Check if the pub key is a controller.
+/// 2. Checking the number of outpoints owned by the given pub key
+/// 3. Checking each outpoints if they are indeed owned by the pub key
+/// Returns a Result with an empty Ok, or an Err in string.
+/// # Arguments
+/// * `controller_pub_key` - An H256 public key of an account
+/// * `outpoints` - List of keys of unlocked utxos said to be "owned" by the controller_pub_key
+pub(crate) fn validate_withdrawal<T:Config>(controller_pub_key: &H256, outpoints:&Vec<H256>) -> Result<(), &'static str> {
+    let controller_account = T::StakingHelper::get_account_id(controller_pub_key);
+    if <StakingCount<T>>::contains_key(controller_account.clone()) {
+        if <StakingCount<T>>::get(&controller_account) == outpoints.len() as u64 {
+            for hash in outpoints {
+                is_owned_locked_utxo::<T>(hash,controller_pub_key,&controller_account)?;
+            }
+        } else {
+            Err("unexpected number of outpoints.")?
+        }
+    } else {
+        Err("controller_pub_key not a validator")?
+    }
+    Ok(())
+}

--- a/pallets/utxo/src/staking_tests.rs
+++ b/pallets/utxo/src/staking_tests.rs
@@ -1,0 +1,306 @@
+// Copyright (c) 2021 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): C. Yap
+
+use crate::{mock::*, Destination, RewardTotal, Transaction, TransactionInput, TransactionOutput, UtxoStore, Value, LockedUtxos, Error, StakingCount, TransactionOutputFor, StartingPeriod, period_elapsed, BlockAuthorRewardAmount, MLTCoinsAvailable};
+use codec::Encode;
+use frame_support::{
+    assert_err, assert_noop, assert_ok,
+    sp_io::crypto,
+    sp_runtime::traits::{BlakeTwo256, Hash},
+};
+use sp_core::{sp_std::{ collections::btree_map::BTreeMap, vec}, sr25519::Public, testing::SR25519, H256, H512};
+use crate::rewards::update_reward_amount;
+
+#[test]
+fn simple_staking() {
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+        let (karl_pub_key, karl_genesis) = keys_and_hashes[1];
+
+        let mut tx = Transaction {
+            inputs: vec![
+                TransactionInput::new_empty(karl_genesis)
+            ],
+            outputs: vec![
+                // KARL (index 1) wants to be a validator. He will use GREG (index 2) as the stash account.
+                // minimum value to stake is 10,
+                TransactionOutput::new_stake(10, 2,1,vec![2,1]),
+                TransactionOutput::new_pubkey(90,H256::from(karl_pub_key))
+            ]
+        };
+        let karl_sig = crypto::sr25519_sign(SR25519,&karl_pub_key, &tx.encode()).unwrap();
+        tx.inputs[0].witness = karl_sig.0.to_vec();
+        let locked_utxo_hash = tx.outpoint(0);
+        let new_utxo_hash = tx.outpoint(1);
+
+        assert_ok!(Utxo::spend(Origin::signed(1), tx));
+        assert!(UtxoStore::<Test>::contains_key(new_utxo_hash));
+        assert!(LockedUtxos::<Test>::contains_key(locked_utxo_hash));
+        assert!(StakingCount::<Test>::contains_key(0));
+        assert!(StakingCount::<Test>::contains_key(1));
+    })
+}
+
+#[test]
+fn less_than_minimum_stake() {
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+        let (karl_pub_key, karl_genesis) = keys_and_hashes[1];
+        let mut tx = Transaction {
+            inputs: vec![
+                TransactionInput::new_empty(karl_genesis)
+            ],
+            outputs: vec![
+                // KARL (index 1) wants to be a validator. He will use GREG (index 2) as the stash account.
+                // minimum value to stake is 10, but KARL only staked 5.
+                TransactionOutput::new_stake(5, 2,1,vec![2,1]),
+                TransactionOutput::new_pubkey(90,H256::from(karl_pub_key))
+            ]
+        };
+        let karl_sig = crypto::sr25519_sign(SR25519,&karl_pub_key, &tx.encode()).unwrap();
+        tx.inputs[0].witness = karl_sig.0.to_vec();
+
+
+        assert_err!(Utxo::spend(Origin::signed(1), tx), "output value must be equal or more than the set minimum stake");
+
+    })
+}
+
+#[test]
+fn staker_staking_again() {
+
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+        let (alice_pub_key, alice_genesis) = keys_and_hashes[0];
+        let mut tx = Transaction {
+            inputs: vec![
+                TransactionInput::new_empty(alice_genesis)
+            ],
+            outputs: vec![
+                // ALICE (index 0) wants to stake again. He will use GREG (index 2) as the stash account.
+                TransactionOutput::new_stake(10, 2,0,vec![2,0]),
+                TransactionOutput::new_pubkey(90,H256::from(alice_pub_key))
+            ]
+        };
+        let alice_sig = crypto::sr25519_sign(SR25519,&alice_pub_key, &tx.encode()).unwrap();
+        tx.inputs[0].witness = alice_sig.0.to_vec();
+
+        assert_err!(Utxo::spend(Origin::signed(0), tx), Error::<Test>::StakingAlreadyExists);
+    })
+}
+
+#[test]
+fn stash_account_is_staking() {
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+        let (tom_pub_key, tom_genesis) = keys_and_hashes[3];
+        let mut tx = Transaction {
+            inputs: vec![
+                TransactionInput::new_empty(tom_genesis)
+            ],
+            outputs: vec![
+                // TOM (index 3) wants to stake. But he's a stash account already!
+                TransactionOutput::new_stake(10, 2,3,vec![2,3]),
+                TransactionOutput::new_pubkey(90,H256::from(tom_pub_key))
+            ]
+        };
+        let tom_sig = crypto::sr25519_sign(SR25519,&tom_pub_key, &tx.encode()).unwrap();
+        tx.inputs[0].witness = tom_sig.0.to_vec();
+
+        assert_err!(Utxo::spend(Origin::signed(3), tx), "CANNOT STAKE. CONTROLLER ACCOUNT IS ACTUALLY A STASH ACCOUNT");
+    })
+}
+
+#[test]
+fn simple_staking_extra() {
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+        let (alice_pub_key, alice_genesis) = keys_and_hashes[0];
+        let mut tx = Transaction {
+            inputs: vec![
+                TransactionInput::new_empty(alice_genesis)
+            ],
+            outputs: vec![
+                // ALICE (index 0) wants to add extra stake.
+                TransactionOutput::new_stake_extra(20, H256::from(alice_pub_key)),
+                TransactionOutput::new_pubkey(70,H256::from(alice_pub_key))
+            ]
+        };
+        let alice_sig = crypto::sr25519_sign(SR25519,&alice_pub_key, &tx.encode()).unwrap();
+        tx.inputs[0].witness = alice_sig.0.to_vec();
+        let locked_utxo_hash = tx.outpoint(0);
+        let new_utxo_hash = tx.outpoint(1);
+
+
+        assert_ok!(Utxo::spend(Origin::signed(0), tx));
+        assert!(UtxoStore::<Test>::contains_key(new_utxo_hash));
+        assert!(LockedUtxos::<Test>::contains_key(locked_utxo_hash));
+        assert_eq!(StakingCount::<Test>::get(0),2);
+    })
+}
+
+#[test]
+fn non_validator_staking_extra() {
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+        let (greg_pub_key, greg_genesis) = keys_and_hashes[2];
+        let mut tx = Transaction {
+            inputs: vec![
+                TransactionInput::new_empty(greg_genesis)
+            ],
+            outputs: vec![
+                // GREG (index 2) wants to stake extra funds. But he's not a validator...
+                TransactionOutput::new_stake_extra(20, H256::from(greg_pub_key)),
+                TransactionOutput::new_pubkey(100,H256::from(greg_pub_key))
+            ]
+        };
+        let greg_sig = crypto::sr25519_sign(SR25519,&greg_pub_key, &tx.encode()).unwrap();
+        tx.inputs[0].witness = greg_sig.0.to_vec();
+
+        assert_err!(Utxo::spend(Origin::signed(2), tx), Error::<Test>::NoStakingRecordFound);
+    })
+}
+
+#[test]
+fn pausing_and_withdrawing() {
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+
+        let mut alice_locked_utxo:Vec<H256>= LockedUtxos::<Test>::iter().map(|(key,value)| {
+            key
+        }).collect();
+        let alice_locked_utxo = alice_locked_utxo.pop().unwrap();
+
+        // ALICE (index 0) wants to stop validating.
+        let (alice_pub_key, alice_genesis) = keys_and_hashes[0];
+
+        assert_ok!(Utxo::unlock_stake(Origin::signed(0),H256::from(alice_pub_key)));
+        next_block();
+
+        let mut tx = Transaction {
+            inputs: vec![
+                TransactionInput::new_empty(alice_genesis)
+            ],
+            outputs: vec![
+                // ALICE withdraws her stake.
+                TransactionOutput::new_withdraw_stake(1,vec![alice_locked_utxo],H256::from(alice_pub_key)),
+                TransactionOutput::new_pubkey(98,H256::from(alice_pub_key))
+            ]
+        };
+        let alice_sig = crypto::sr25519_sign(SR25519,&alice_pub_key, &tx.encode()).unwrap();
+        tx.inputs[0].witness = alice_sig.0.to_vec();
+
+        // increase the block number, as if a new block has been created.
+        next_block();
+        next_block();
+        next_block();
+        next_block();
+        next_block();
+        assert_ok!(Utxo::spend(Origin::signed(0),tx));
+    })
+}
+
+#[test]
+fn non_validator_pausing(){
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+        let (karl_pub_key, _) = keys_and_hashes[1];
+        assert_err!(
+            Utxo::unlock_stake(Origin::signed(1),H256::from(karl_pub_key)),
+            Error::<Test>::NoStakingRecordFound
+        );
+    })
+}
+
+#[test]
+fn non_validator_withdrawing() {
+
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+        let (karl_pub_key, karl_genesis) = keys_and_hashes[1];
+
+        let mut alice_locked_utxo:Vec<H256>= LockedUtxos::<Test>::iter().map(|(key,value)| {
+            key
+        }).collect();
+        let alice_locked_utxo = alice_locked_utxo.pop().unwrap();
+
+        let mut tx = Transaction {
+            inputs: vec![
+                TransactionInput::new_empty(karl_genesis)
+            ],
+            outputs: vec![
+                // ALICE withdraws her stake.
+                TransactionOutput::new_withdraw_stake(1,vec![alice_locked_utxo],H256::from(karl_pub_key)),
+                TransactionOutput::new_pubkey(98,H256::from(karl_pub_key))
+            ]
+        };
+        let karl_sig = crypto::sr25519_sign(SR25519,&karl_pub_key, &tx.encode()).unwrap();
+        tx.inputs[0].witness = karl_sig.0.to_vec();
+
+        assert_err!(Utxo::spend(Origin::signed(1),tx), "controller_pub_key not found in the list of authorities");
+    })
+}
+
+#[test]
+fn withdrawing_before_expected_period() {
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+
+        let mut alice_locked_utxo:Vec<H256>= LockedUtxos::<Test>::iter().map(|(key,value)| {
+            key
+        }).collect();
+        let alice_locked_utxo = alice_locked_utxo.pop().unwrap();
+
+        // ALICE (index 0) wants to stop validating.
+        let (alice_pub_key, alice_genesis) = keys_and_hashes[0];
+
+        assert_ok!(Utxo::unlock_stake(Origin::signed(0),H256::from(alice_pub_key)));
+
+        let mut tx = Transaction {
+            inputs: vec![
+                TransactionInput::new_empty(alice_genesis)
+            ],
+            outputs: vec![
+                // ALICE withdraws her stake.
+                TransactionOutput::new_withdraw_stake(1,vec![alice_locked_utxo],H256::from(alice_pub_key)),
+                TransactionOutput::new_pubkey(98,H256::from(alice_pub_key))
+            ]
+        };
+        let alice_sig = crypto::sr25519_sign(SR25519,&alice_pub_key, &tx.encode()).unwrap();
+        tx.inputs[0].witness = alice_sig.0.to_vec();
+
+        // ALICE is not waiting for the withdrawal period.
+        assert_err!(Utxo::spend(Origin::signed(0),tx), Error::<Test>::InvalidOperation);
+    })
+}
+
+#[test]
+fn reward_reduced() {
+    let (mut test_ext, _, _ ) =  alice_test_ext_and_keys();
+    test_ext.execute_with(|| {
+        assert_eq!(StartingPeriod::<Test>::get(),0);
+        assert_eq!(BlockAuthorRewardAmount::<Test>::get(),100);
+        assert_eq!(MLTCoinsAvailable::<Test>::get(),1_000);
+        // RewardReduction Period is 5; so at block 6, reward should be reduced.
+        let time_now = 6;
+        period_elapsed::<Test>(time_now);
+        assert_eq!(StartingPeriod::<Test>::get(),time_now);
+
+        let reward_amount =  update_reward_amount::<Test>(1_000);
+        assert_eq!(BlockAuthorRewardAmount::<Test>::get(), reward_amount);
+    })
+}

--- a/pallets/utxo/src/tests.rs
+++ b/pallets/utxo/src/tests.rs
@@ -352,7 +352,7 @@ fn test_script() {
 fn test_tokens() {
     use crate::TokensHigherID;
 
-    let (mut test_ext, alice_pub_key, karl_pub_key) = new_test_ext_and_keys();
+    let (mut test_ext, alice_pub_key, karl_pub_key) = alice_test_ext_and_keys();
     test_ext.execute_with(|| {
         // Let's create a new test token
         let token_id = <TokensHigherID<Test>>::get()
@@ -422,7 +422,7 @@ fn attack_double_spend_by_tweaking_input() {
         };
         let alice_sig = crypto::sr25519_sign(SR25519, &alice_pub_key, &tx0.encode()).unwrap();
         tx0.inputs[0].witness = alice_sig.0.to_vec();
-        assert_ok!(Utxo::spend(Origin::signed(0), tx0.clone()));
+        assert_ok!(Utxo::spend(Origin::signed(H256::zero()), tx0.clone()));
 
         // Create a transaction that spends the same input 10 times by slightly modifying the
         // redeem script.
@@ -437,7 +437,7 @@ fn attack_double_spend_by_tweaking_input() {
             outputs: vec![TransactionOutput::new_pubkey(500, H256::from(alice_pub_key))],
         };
         assert_err!(
-            Utxo::spend(Origin::signed(0), tx1),
+            Utxo::spend(Origin::signed(H256::zero()), tx1),
             "each input should be used only once"
         );
     });
@@ -485,7 +485,7 @@ fn test_pubkey_hash() {
 
 #[test]
 fn test_send_to_address() {
-    let (mut test_ext, alice_pub_key, _karl_pub_key) = new_test_ext_and_keys();
+    let (mut test_ext, alice_pub_key, _karl_pub_key) = alice_test_ext_and_keys();
     test_ext.execute_with(|| {
         // `addr` is bech32-encoded hash160(karl_pub_key)
         let addr = "bc1q7pyaw92rh34mj6flsh7acccd7ayn4wf787ws4m";

--- a/pallets/utxo/src/weights.rs
+++ b/pallets/utxo/src/weights.rs
@@ -56,4 +56,13 @@ impl<T: frame_system::Config> crate::WeightInfo for WeightInfo<T> {
             .saturating_add(T::DbWeight::get().reads(3 as Weight))
             .saturating_add(T::DbWeight::get().writes(3 as Weight))
     }
+
+    //TODO this needs a benchmark
+    fn unlock_stake(s: u32) -> Weight {
+        (548_270_000 as Weight)
+            //TODO: literally just copying from substrate's
+            .saturating_add((1_146_000 as Weight).saturating_mul(s as Weight))
+            .saturating_add(T::DbWeight::get().reads(3 as Weight))
+            .saturating_add(T::DbWeight::get().writes(3 as Weight))
+    }
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -16,6 +16,7 @@ version = '5.0.0-dev'
 branch = "master"
 
 [dependencies]
+log = "0.4.14"
 pallet-utxo-tokens = { path = "../pallets/utxo/tokens" }
 
 [dependencies.codec]
@@ -30,6 +31,12 @@ git = 'https://github.com/paritytech/substrate.git'
 optional = true
 branch = "master"
 version = '4.0.0-dev'
+
+[dependencies.frame-election-provider-support]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+version = '4.0.0-dev'
+branch = "master"
 
 [dependencies.frame-executive]
 default-features = false
@@ -72,6 +79,12 @@ git = 'https://github.com/paritytech/substrate.git'
 version = '4.0.0-dev'
 branch = "master"
 
+[dependencies.pallet-authorship]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+version = '4.0.0-dev'
+branch = "master"
+
 [dependencies.pallet-balances]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
@@ -85,6 +98,24 @@ version = '4.0.0-dev'
 branch = "master"
 
 [dependencies.pallet-randomness-collective-flip]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+version = '4.0.0-dev'
+branch = "master"
+
+[dependencies.pallet-session]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+version = '4.0.0-dev'
+branch = "master"
+
+[dependencies.pallet-staking]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+version = '4.0.0-dev'
+branch = "master"
+
+[dependencies.pallet-staking-reward-curve]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 version = '4.0.0-dev'
@@ -144,6 +175,13 @@ git = 'https://github.com/paritytech/substrate.git'
 version = '4.0.0-dev'
 branch = "master"
 
+## This might be needed during voting.
+#[dependencies.sp-npos-elections]
+#default-features = false
+#git = 'https://github.com/paritytech/substrate.git'
+#version = '4.0.0-dev'
+#branch = "master"
+
 [dependencies.sp-offchain]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
@@ -157,6 +195,12 @@ branch = "master"
 version = '4.0.0-dev'
 
 [dependencies.sp-session]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+version = '4.0.0-dev'
+branch = "master"
+
+[dependencies.sp-staking]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 version = '4.0.0-dev'
@@ -237,9 +281,12 @@ std = [
     'frame-system-rpc-runtime-api/std',
     'frame-system/std',
     'pallet-aura/std',
+    'pallet-authorship/std',
     'pallet-balances/std',
     'pallet-grandpa/std',
     'pallet-randomness-collective-flip/std',
+    'pallet-session/std',
+    'pallet-staking/std',
     'pallet-sudo/std',
     'pallet-template/std',
     'pallet-timestamp/std',
@@ -254,9 +301,11 @@ std = [
     'sp-consensus-aura/std',
     'sp-core/std',
     'sp-inherents/std',
+#    'sp-npos-elections/std',
     'sp-offchain/std',
     'sp-runtime/std',
     'sp-session/std',
+    'sp-staking/std',
     'sp-std/std',
     'sp-transaction-pool/std',
     'sp-version/std',

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2,22 +2,27 @@
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
 
+mod staking;
+
 // Make the WASM binary available.
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
+use frame_election_provider_support::onchain;
 use pallet_grandpa::fg_primitives;
 use pallet_grandpa::{AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
+use pallet_session::historical as pallet_session_historical;
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata, H256};
 use sp_runtime::traits::{
-    AccountIdLookup, BlakeTwo256, Block as BlockT, IdentifyAccount, NumberFor, Verify,
+    AccountIdLookup, BlakeTwo256, Block as BlockT, IdentifyAccount, NumberFor, OpaqueKeys, Verify
 };
 use sp_runtime::{
     create_runtime_str, generic, impl_opaque_keys,
     transaction_validity::{TransactionSource, TransactionValidity},
     ApplyExtrinsicResult, MultiSignature,
+    // curve::PiecewiseLinear,
 };
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
@@ -27,7 +32,7 @@ use sp_version::RuntimeVersion;
 // A few exports that help ease life for downstream crates.
 pub use frame_support::{
     construct_runtime, parameter_types,
-    traits::{Everything, IsSubType, KeyOwnerProofSystem, Nothing, Randomness},
+    traits::{Everything, IsSubType, KeyOwnerProofSystem, Nothing, Randomness, U128CurrencyToVote},
     weights::{
         constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
         IdentityFee, Weight,
@@ -37,16 +42,18 @@ pub use frame_support::{
 pub use pallet_balances::Call as BalancesCall;
 use pallet_contracts::weights::WeightInfo;
 pub use pallet_timestamp::Call as TimestampCall;
+pub use pallet_staking::StakerStatus;
 use pallet_transaction_payment::CurrencyAdapter;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
-pub use sp_runtime::{Perbill, Permill};
+pub use sp_runtime::{Perbill, Permill, Percent};
 
 /// Import the template pallet.
 pub use pallet_template;
 
 pub use pallet_pp;
 pub use pallet_utxo;
+pub use staking::*;
 use sp_runtime::transaction_validity::{InvalidTransaction, TransactionValidityError};
 
 /// An index to a block.
@@ -230,7 +237,7 @@ impl pallet_grandpa::Config for Runtime {
     type Event = Event;
     type Call = Call;
 
-    type KeyOwnerProofSystem = ();
+    type KeyOwnerProofSystem = Historical;
 
     type KeyOwnerProof =
         <Self::KeyOwnerProofSystem as KeyOwnerProofSystem<(KeyTypeId, GrandpaId)>>::Proof;
@@ -297,12 +304,21 @@ impl pallet_template::Config for Runtime {
     type Event = Event;
 }
 
+parameter_types!{
+    pub const MinimumStake: u128 = 40_000 * 1_000 * 100_000_000;
+    pub const RewardReductionPeriod: BlockNumber = MINUTES * 5;
+	pub const RewardReductionFraction: Percent = Percent::from_percent(25);
+}
+
 impl pallet_utxo::Config for Runtime {
     type Event = Event;
     type Call = Call;
     type WeightInfo = pallet_utxo::weights::WeightInfo<Runtime>;
     type ProgrammablePool = pallet_pp::Pallet<Runtime>;
     type AssetId = u64;
+
+    type RewardReductionFraction = RewardReductionFraction;
+    type RewardReductionPeriod = RewardReductionPeriod;
 
     fn authorities() -> Vec<H256> {
         Aura::authorities()
@@ -313,6 +329,9 @@ impl pallet_utxo::Config for Runtime {
             })
             .collect()
     }
+
+    type StakingHelper = StakeOps<Runtime>;
+    type MinimumStake = MinimumStake;
 }
 
 impl pallet_pp::Config for Runtime {
@@ -370,6 +389,108 @@ impl pallet_contracts::Config for Runtime {
     type ContractDeposit = ();
 }
 
+parameter_types! {
+    pub const DisabledValidatorsThreshold: Perbill = Perbill::from_percent(17);
+    pub const Period: u32 = 2;
+    pub const Offset: u32 = 0;
+}
+
+impl pallet_session_historical::Config for Runtime {
+    type FullIdentification = pallet_staking::Exposure<AccountId, Balance>;
+    type FullIdentificationOf = pallet_staking::ExposureOf<Runtime>;
+}
+
+impl pallet_session::Config for Runtime {
+    type Event = Event;
+    type ValidatorId = AccountId;
+    type ValidatorIdOf = pallet_staking::StashOf<Self>;
+    type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
+    type NextSessionRotation = ();
+    type SessionManager = pallet_session_historical::NoteHistoricalRoot<Self,Staking>;
+    type SessionHandler = <opaque::SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
+    type Keys = opaque::SessionKeys;
+    type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
+    type WeightInfo = pallet_session::weights::SubstrateWeight<Runtime>;
+}
+
+impl onchain::Config for Runtime {
+    type AccountId = AccountId;
+    type BlockNumber = BlockNumber;
+    type Accuracy = Perbill;
+    type DataProvider = Staking;
+}
+
+// pallet_staking_reward_curve::build! {
+//     const REWARD_CURVE: PiecewiseLinear<'static> = curve!(
+//         min_inflation: 0_025_000,
+// 		max_inflation: 0_100_000,
+// 		ideal_stake: 0_500_000,
+// 		falloff: 0_050_000,
+// 		max_piece_count: 40,
+// 		test_precision: 0_005_000,
+//     );
+// }
+
+parameter_types! {
+    pub const SessionsPerEra: sp_staking::SessionIndex = 2;
+    pub const BondingDuration: pallet_staking::EraIndex = 2;
+    pub const SlashDeferDuration: pallet_staking::EraIndex = 1; // 1/4 the bonding duration
+    // pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
+    pub const MaxNominatorRewardedPerValidator: u32 = 5;
+    pub OffchainRepeat: BlockNumber = 5;
+}
+
+impl pallet_staking::Config for Runtime {
+    type Currency = Balances;
+    type UnixTime = Timestamp;
+    type CurrencyToVote = U128CurrencyToVote;
+    type ElectionProvider = onchain::OnChainSequentialPhragmen<Self>;
+    type GenesisElectionProvider = Self::ElectionProvider;
+    const MAX_NOMINATIONS: u32 = 5;
+    type RewardRemainder = (); // Treasury, or something similar
+    type Event = Event;
+    type Slash = (); // Treasury, or something similar
+    type Reward = ();
+    type SessionsPerEra = SessionsPerEra;
+    type BondingDuration = BondingDuration;
+    type SlashDeferDuration = SlashDeferDuration;
+    type SlashCancelOrigin = frame_system::EnsureRoot<Self::AccountId>;
+    type SessionInterface = Self;
+    type EraPayout = (); // pallet_staking::ConvertCurve<RewardCurve>;
+    type NextNewSession = Session;
+    type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
+    type WeightInfo = pallet_staking::weights::SubstrateWeight<Runtime>;
+}
+
+parameter_types! {
+    pub const UncleGenerations: BlockNumber = 4;
+}
+
+impl pallet_authorship::Config for Runtime {
+    type FindAuthor = pallet_utxo::FindAccountFromAuthorIndex<Self, Aura, Session>;
+    type UncleGenerations = UncleGenerations;
+    type FilterUncle = ();
+    type EventHandler = (); //pallet_staking::Pallet<Runtime>;
+}
+
+impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime where
+    Call: From<C>,
+{
+    type Extrinsic = UncheckedExtrinsic;
+    type OverarchingCall = Call;
+}
+
+// sp_npos_elections::generate_solution_type!(
+// 	#[compact]
+// 	pub struct NposSolution16::<
+// 		VoterIndex = u32,
+// 		TargetIndex = u16,
+// 		Accuracy = sp_runtime::PerU16,
+// 	>(16)
+// );
+
+pub const MAX_NOMINATIONS: u32 = 5; //<NposSolution16 as sp_npos_elections::NposSolution>::LIMIT as u32;
+
 // Create the runtime by composing the FRAME pallets that were previously configured.
 construct_runtime!(
     pub enum Runtime where
@@ -390,6 +511,10 @@ construct_runtime!(
         Utxo: pallet_utxo::{Pallet, Call, Config<T>, Storage, Event<T>},
         Pp: pallet_pp::{Pallet, Call, Config<T>, Storage, Event<T>},
         Contracts: pallet_contracts::{Pallet, Call, Storage, Event<T>},
+        Authorship: pallet_authorship::{Pallet, Call, Storage, Inherent},
+        Session: pallet_session::{Pallet, Call, Config<T>, Storage, Event},
+        Staking: pallet_staking::{Pallet, Call, Config<T>, Storage, Event<T>},
+        Historical: pallet_session_historical::{Pallet},
     }
 );
 
@@ -474,11 +599,13 @@ impl_runtime_apis! {
             tx: <Block as BlockT>::Extrinsic,
             block_hash: <Block as BlockT>::Hash,
         ) -> TransactionValidity {
+            log::debug!("transaction to validate: {:?}",tx);
             if let Some(pallet_utxo::Call::spend(ref tx)) =
             IsSubType::<pallet_utxo::Call::<Runtime>>::is_sub_type(&tx.function) {
                 match pallet_utxo::validate_transaction::<Runtime>(&tx) {
                     Ok(valid_tx) => { return Ok(valid_tx); }
-                    Err(_) => {
+                    Err(e) => {
+                        log::error!("pallet_utxo validation error: {:?}", e);
                         return Err(TransactionValidityError::Invalid(InvalidTransaction::Custom(1)));
                     }
                 }
@@ -537,12 +664,13 @@ impl_runtime_apis! {
 
         fn generate_key_ownership_proof(
             _set_id: fg_primitives::SetId,
-            _authority_id: GrandpaId,
+            authority_id: GrandpaId,
         ) -> Option<fg_primitives::OpaqueKeyOwnershipProof> {
-            // NOTE: this is the only implementation possible since we've
-            // defined our key owner proof type as a bottom type (i.e. a type
-            // with no values).
-            None
+            use codec::Encode;
+
+            Historical::prove((fg_primitives::KEY_TYPE, authority_id))
+            .map(|p| p.encode())
+            .map(fg_primitives::OpaqueKeyOwnershipProof::new)
         }
     }
 

--- a/runtime/src/staking.rs
+++ b/runtime/src/staking.rs
@@ -1,0 +1,86 @@
+use crate::Perbill;
+
+use codec::{Decode, EncodeLike};
+use frame_support::{traits::Currency, dispatch::{DispatchResultWithPostInfo, Vec}};
+use frame_system::{Config as SysConfig, RawOrigin};
+use pallet_staking::Pallet as StakingPallet;
+use pallet_utxo::staking::StakingHelper;
+use sp_core::{H256, sp_std::vec, sr25519::Public};
+use sp_runtime::traits::StaticLookup;
+use sp_runtime::AccountId32;
+
+type StakeAccountId<T> =  <T as SysConfig>::AccountId;
+type LookupSourceOf<T> = <<T as SysConfig>::Lookup as StaticLookup>::Source;
+
+pub struct StakeOps<T>(sp_core::sp_std::marker::PhantomData<T>);
+impl <T: pallet_staking::Config + pallet_utxo::Config + pallet_session::Config> StakingHelper<T::AccountId> for StakeOps<T>
+    where StakeAccountId<T>: From<Public> + EncodeLike<AccountId32>
+{
+    fn get_account_id(pub_key: &H256) -> StakeAccountId<T> {
+      Public::from_h256(pub_key.clone()).into()
+    }
+
+    fn stake(stash_account: &StakeAccountId<T>, controller_account: &StakeAccountId<T>, rotate_keys: &mut Vec<u8>) -> DispatchResultWithPostInfo {
+        let controller_lookup: LookupSourceOf<T> = T::Lookup::unlookup(controller_account.clone());
+        let amount = T::Currency::minimum_balance();
+        let reward_destination = pallet_staking::RewardDestination::Staked;
+
+        // bond the funds
+        StakingPallet::<T>::bond(
+            RawOrigin::Signed(stash_account.clone()).into(),
+            controller_lookup,
+            amount,
+            reward_destination
+        )?;
+
+        let rotate_keys = sp_core::Bytes::from(rotate_keys.to_vec());
+        // session keys
+        let sesh_key = <T as pallet_session::Config>::Keys::decode(&mut &rotate_keys[..]).expect("SessionKeys decoded successfully");
+        pallet_session::Pallet::<T>::set_keys(
+            RawOrigin::Signed(controller_account.clone()).into(),
+            sesh_key,
+            vec![]
+        )?;
+
+        let validator_prefs = pallet_staking::ValidatorPrefs {
+            commission: Perbill::from_percent(0),
+            ..Default::default()
+        };
+
+        // validate
+        StakingPallet::<T>::validate(
+            RawOrigin::Signed(controller_account.clone()).into(),
+            validator_prefs
+        )?;
+
+        Ok(().into())
+    }
+
+    fn pause(controller_account: &StakeAccountId<T>) -> DispatchResultWithPostInfo {
+        // stop validating / block producing
+        StakingPallet::<T>::chill(RawOrigin::Signed(controller_account.clone()).into())?;
+
+        // get the total balance to free up
+        if let Some(stake_ledger) = <StakingPallet<T>>::ledger(controller_account.clone()) {
+
+            // let balance:BalanceOf<T> = stake_ledger.total;
+            // unbond
+            StakingPallet::<T>::unbond(
+                RawOrigin::Signed(controller_account.clone()).into(),
+                stake_ledger.total
+            )?;
+        } else {
+            log::error!("check sync with pallet-staking.");
+            Err(pallet_utxo::Error::<T>::NoStakingRecordFound)?
+        }
+
+        Ok(().into())
+    }
+
+
+    fn withdraw(controller_account: &StakeAccountId<T>) -> DispatchResultWithPostInfo {
+        StakingPallet::<T>::withdraw_unbonded(RawOrigin::Signed(controller_account.clone()).into(),0)?;
+
+        Ok(().into())
+    }
+}


### PR DESCRIPTION
pallet-utxo
- `lib.rs`
  - added more config:
    - constants:
      - **`RewardReductionFraction`** - the percentage drop of a reward value. (e.g. 10%, 15%, etc.)
      - **`RewardReductionPeriod`** - the next block number to execute a drop of reward value.
      - **`MinimumStake`** - minimum value to start staking/validating
   - **`StakingHelper`** - a trait for performing staking OUTSIDE of pallet-utxo
 - added `Destinations`:
  - **`Stake`** - first time of the node to do staking. Requires the dummy `stash_account`, the `controller_account`, and the `rotate_keys` (for `pallet-session`). This is to satisfy the `pallet-staking`.
  - **`StakeExtra`** - if the validator wants to stake extra utxos (also `bond_extra` of `pallet-staking`). Can be done ONLY for existing validators.
  - **`WithdrawStake`** - stop validating and withdraw the staked utxos (also called as "locked utxos"). This can be done ONLY if the `unlock_stake` is executed.
 - added more storage:
   - **`StartingPeriod`** - stores the 1st block number of every new period
   - **`MLTCoinsAvailable`** - the extra mlt coins used to reward block authors, etc.
   - **`BlockAuthorRewardAmount`** - the reward value
   - **`BlockAuthor`** - the current block author
   - **`LockedUtxos`** - the "staked" utxos of the validators. Cannot be withdrawn.
   - **`StakingCount`** - tracks the number of utxos a controller has locked.
 - more events:
   - **`BlockAuthorRewarded`** - shows how much a validator is rewarded for producing a block
   - **`StakeUnlocked`** - shows a validator quiting the role.
   - **`StakeWithdrawn`** - shows a node withdrawing its staked/locked utxos; in other words, moving the utxo back to `UtxoStore`.
 - added Errors:
   - **`NoStakingRecordFound`**,
   - **`StakingAlreadyExists`** - a stash account CANNOT become a controller. And vice-versa
   - **`InvalidOperation`**
 - added more fields in `GenesisConfig`:
   - **`locked_utxos`** - the initial utxos locked (the initial authorities/validators)
   - **`extra_mlt_coins`** - the coins used for rewarding, etc.
   - **`initial_reward_amount`** - the initial block author reward amount  

- `authorship.rs` - to help look for the block author 

- `rewards.rs` - handles rewarding block authors 

- `staking.rs` - handles the staking. Also contains the trait definition of `StakeHelper`. For implementation, go to `runtime/src/staking.rs`.
  - **`fn get_account_id()`** - get account id conversion of public key.
  - **`fn stake()`**- handles the staking outside of `pallet-utxo.`
  - **`fn pause()`** - stops the validator from validating. It's not effective immediately; there's a waiting period time. (based on the `pallet-staking`)
  - **`fn withdraw()`** - withdraw funds back to free balance. 

- `staking_test.rs` - test cases for testing.  

runtime
- `lib.rs`
  - added the ff. pallets:
    - **`pallet-staking`** - the pallet used for its logic on staking. This follows the NPoS Consensus, BUT the configuration is only making use of its "validator" role.
    - **`pallet-session`** - this is a required pallet of `pallet-staking`
    -**`pallet-authorship`** - to identify the block author  

- `staking.rs` - implementation of StakeHelper.
  - **`fn get_account_id()`** - converts h256 to sr25519 Public and into the AccountId.
  - **`fn stake()`**- consists of `pallet-staking`'s `bond()`, `pallet-session`'s `set_key()` and `pallet-staking`'s `validate()`
  - **`fn pause()`** - performs `pallet-staking`'s `chill()` and `unbond()`. This does not mean that the funds can be withdrawn immediately; it should wait for the era to end. See the `SessionsPerEra` configuration of `pallet_staking::Config`, and the `Period` defined in `ShouldEndSession` of `pallet_session::Config`.
  - **`fn withdraw()`** - calls the `withdraw_unbonded()` of `pallet-staking` 


TODO:
 - add the `bond_extra` of `pallet-staking` (inside `runtime/staking.rs` when staking extra funds/utxos.
 - add more tests about the reward.
 - move those numerals like `40_000 * 100_000_000 * 1_000` AND `1_000 * 100_000_000 * 400_000_000` somewhere else.
 - ask Ben the minimum amount to spend for "withdrawing".
 - change reward reduction period to "yearly". 
  - change  `extra_mlt_coins` value to `200_000_000`. (inside `chain_spec.rs`)
  - benchmark the `fn unlock_stake()` call for  actual weight computation.