### PR TITLE
fix name of binary and some details printed by cli on boot

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
+authors = ['RBB S.r.l <https://github.com/mintlayer>']
 build = 'build.rs'
-description = 'A fresh FRAME-based Substrate node, ready for hacking.'
+description = 'The Mintlayer core node'
 edition = '2018'
 homepage = 'https://substrate.dev'
 license = 'Unlicense'
-name = 'node-template'
-repository = 'https://github.com/substrate-developer-hub/substrate-node-template/'
-version = '3.0.0'
+name = 'mintlayer-core'
+repository = 'https://github.com/mintlayer/core'
+version = '0.1.0'
 
 [[bin]]
-name = 'node-template'
+name = 'mintlayer-core'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -51,7 +51,7 @@ fn fetch_bootnode_list() -> Result<Vec<MultiaddrWithPeerId>, Box<dyn Error>> {
 
 impl SubstrateCli for Cli {
     fn impl_name() -> String {
-        "Mint Layer Node".into()
+        "Mintlayer Node".into()
     }
 
     fn impl_version() -> String {
@@ -63,7 +63,7 @@ impl SubstrateCli for Cli {
     }
 
     fn author() -> String {
-        "Mint Layer".into()
+        "Mintlayer".into()
     }
 
     fn support_url() -> String {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -98,8 +98,8 @@ pub mod opaque {
 // To learn more about runtime versioning and what each of the following value means:
 //   https://substrate.dev/docs/en/knowledgebase/runtime/upgrades#runtime-versioning
 pub const VERSION: RuntimeVersion = RuntimeVersion {
-    spec_name: create_runtime_str!("node-template"),
-    impl_name: create_runtime_str!("node-template"),
+    spec_name: create_runtime_str!("mintlayer-core"),
+    impl_name: create_runtime_str!("mintlayer-core"),
     authoring_version: 1,
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,


### PR DESCRIPTION
Fix the name of the produced binary so it makes sense, I've gone with mintlayer-core.
I've also fixed a few bits in the cli where Mintlayer was spelt Mint Layer.

Nothing all that interesting though.