### PR TITLE
utxo: Add some tests for real-time time locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4142,6 +4142,7 @@ dependencies = [
  "pallet-utxo-tokens",
  "parity-scale-codec",
  "pp-api",
+ "proptest",
  "serde",
  "sp-consensus-aura",
  "sp-core",

--- a/pallets/utxo/Cargo.toml
+++ b/pallets/utxo/Cargo.toml
@@ -106,3 +106,6 @@ branch = "master"
 git = 'https://github.com/paritytech/substrate.git'
 version = '0.10.0-dev'
 branch = "master"
+
+[dev-dependencies.proptest]
+version = "1.0.0"

--- a/pallets/utxo/src/script.rs
+++ b/pallets/utxo/src/script.rs
@@ -162,11 +162,17 @@ pub fn verify<AccountId: Encode>(
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     use super::*;
     use chainscript::Context;
     use core::time::Duration;
     use sp_core::sr25519;
+    use proptest::prelude::*;
+
+    // Generate block time in seconds
+    pub fn gen_block_time_real() -> impl Strategy<Value = RawBlockTime> {
+        (RawBlockTime::THRESHOLD..3 * RawBlockTime::THRESHOLD).prop_map(RawBlockTime::new)
+    }
 
     #[test]
     fn test_parse_pubkey() {

--- a/pallets/utxo/src/tests.rs
+++ b/pallets/utxo/src/tests.rs
@@ -16,8 +16,8 @@
 // Author(s): C. Yap
 
 use crate::{
-    mock::*, BlockTime, Destination, RewardTotal, TokenList, Transaction, TransactionInput,
-    TransactionOutput, UtxoStore, Value,
+    mock::*, BlockTime, Destination, RawBlockTime, RewardTotal, TokenList, Transaction,
+    TransactionInput, TransactionOutput, UtxoStore, Value,
 };
 use chainscript::{opcodes::all as opc, Builder};
 use codec::Encode;
@@ -27,6 +27,8 @@ use frame_support::{
     sp_runtime::traits::{BlakeTwo256, Hash},
 };
 use pallet_utxo_tokens::TokenInstance;
+use proptest::prelude::*;
+use crate::script::test::gen_block_time_real;
 use sp_core::{sp_std::vec, sr25519::Public, testing::SR25519, H256, H512};
 
 fn tx_input_gen_no_signature() -> (TransactionOutput<H256>, TransactionInput) {
@@ -34,13 +36,13 @@ fn tx_input_gen_no_signature() -> (TransactionOutput<H256>, TransactionInput) {
     (utxo, TransactionInput::new_empty(hash))
 }
 
-fn execute_with_alice<F>(mut execute: F)
+fn execute_with_alice<F, R>(mut execute: F) -> R
 where
-    F: FnMut(Public),
+    F: FnMut(Public) -> R,
 {
     new_test_ext().execute_with(|| {
         let alice_pub_key = crypto::sr25519_public_keys(SR25519)[0];
-        execute(alice_pub_key);
+        execute(alice_pub_key)
     })
 }
 
@@ -600,4 +602,92 @@ fn test_send_to_address() {
             "Failed to decode address: invalid HRP",
         );
     })
+}
+
+proptest! {
+    #[test]
+    fn prop_gen_block_time_real_works(bt in gen_block_time_real()) {
+        // This generator should not sample block-based time.
+        prop_assert!(!bt.is_blocks());
+    }
+
+    #[test]
+    fn prop_time_lock_realtime_with_script(
+        script_lock_time in gen_block_time_real(),
+        tx_lock_time in gen_block_time_real(),
+        current_time in gen_block_time_real(),
+    ) {
+        let result = execute_with_alice(|alice| {
+            // Convert seconds to milliseconds
+            Timestamp::set_timestamp(current_time.as_u64() * 1000);
+
+            let (utxo0, input0) = tx_input_gen_no_signature();
+            let script = Builder::new()
+                .push_int(script_lock_time.as_u64() as i64)
+                .push_opcode(opc::OP_CLTV)
+                .into_script();
+            let script_hash: H256 = BlakeTwo256::hash(script.as_ref());
+            let tx1 = Transaction {
+                inputs: vec![input0],
+                outputs: vec![TransactionOutput::new_script_hash(90, script_hash)],
+                time_lock: Default::default(),
+            }
+            .sign_unchecked(&[utxo0], 0, &alice);
+            let outpoint = tx1.outpoint(0);
+            assert!(Utxo::spend(Origin::signed(H256::zero()), tx1).is_ok());
+
+            let tx2 = Transaction {
+                inputs: vec![TransactionInput::new_script(outpoint, script, Default::default())],
+                outputs: vec![TransactionOutput::new_pubkey(50, H256::from(alice))],
+                time_lock: tx_lock_time,
+            };
+            Utxo::spend(Origin::signed(H256::zero()), tx2)
+        });
+
+        // The transaction should be accepted if and only if:
+        // current time >= transaction lock time >= script lock time
+        let model = current_time.as_u64() >= tx_lock_time.as_u64()
+            && tx_lock_time.as_u64() >= script_lock_time.as_u64();
+        prop_assert_eq!(result.is_ok(), model);
+    }
+
+    #[test]
+    fn prop_time_lock_realtime_monotonic(
+        tx_lock_time in gen_block_time_real(),
+        time0 in gen_block_time_real(),
+        time1 in gen_block_time_real(),
+    ) {
+        // Make sure time0 and time1 are in order
+        let (time0, time1) = (
+            std::cmp::min_by_key(time0, time1, RawBlockTime::as_u64),
+            std::cmp::max_by_key(time0, time1, RawBlockTime::as_u64),
+        );
+
+        let (res0, res1) = execute_with_alice(|alice| {
+            let (utxo0, input0) = tx_input_gen_no_signature();
+            let tx = Transaction {
+                inputs: vec![input0],
+                outputs: vec![TransactionOutput::new_pubkey(50, H256::from(alice))],
+                time_lock: tx_lock_time,
+            }
+            .sign_unchecked(&[utxo0], 0, &alice);
+
+            Timestamp::set_timestamp(time0.as_u64() * 1000);
+            let res0 = crate::pallet::validate_transaction::<Test>(&tx);
+
+            Timestamp::set_timestamp(time1.as_u64() * 1000);
+            let res1 = crate::pallet::validate_transaction::<Test>(&tx);
+
+            (res0, res1)
+        });
+
+        // The flow of time cannot turn a valid transaction int an invalid one.
+        // This is an implication: If a transaction validates at time0, it validates at time1.
+        prop_assert!(!res0.is_ok() || res1.is_ok());
+
+        // Check the error message given if the transaction validation fails.
+        if let Err(e) = res0 {
+            prop_assert_eq!(e, "Time lock restrictions not satisfied");
+        }
+    }
 }


### PR DESCRIPTION
These tests use `proptest` for randomized property-based testing.

By default, the `prop_*` functions are run with 256 different inputs.