### PR TITLE
Rewards and Staking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4182,6 +4182,7 @@ dependencies = [
  "pallet-utxo-tokens",
  "parity-scale-codec",
  "pp-api",
+ "proptest",
  "serde",
  "sp-core",
  "sp-keystore",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,6 +1559,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-election-provider-support"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#6e15de9703bfe09b85efa33fd6e3a94d2446dd01"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "sp-arithmetic",
+ "sp-npos-elections",
+ "sp-std",
+]
+
+[[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#6e15de9703bfe09b85efa33fd6e3a94d2446dd01"
@@ -3407,6 +3420,7 @@ dependencies = [
  "sc-telemetry",
  "sc-transaction-pool",
  "sc-transaction-pool-api",
+ "serde",
  "serde_json",
  "sp-api",
  "sp-authorship",
@@ -3643,13 +3657,16 @@ name = "node-template-runtime"
 version = "3.0.0"
 dependencies = [
  "frame-benchmarking",
+ "frame-election-provider-support",
  "frame-executive",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "hex-literal 0.3.3",
+ "log",
  "pallet-aura",
+ "pallet-authorship",
  "pallet-balances",
  "pallet-contracts",
  "pallet-contracts-primitives",
@@ -3657,6 +3674,8 @@ dependencies = [
  "pallet-grandpa",
  "pallet-pp",
  "pallet-randomness-collective-flip",
+ "pallet-session",
+ "pallet-staking",
  "pallet-sudo",
  "pallet-template",
  "pallet-timestamp",
@@ -3674,6 +3693,7 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
+ "sp-staking",
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
@@ -4039,6 +4059,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-staking"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#6e15de9703bfe09b85efa33fd6e3a94d2446dd01"
+dependencies = [
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authorship",
+ "pallet-session",
+ "parity-scale-codec",
+ "serde",
+ "sp-application-crypto",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#6e15de9703bfe09b85efa33fd6e3a94d2446dd01"
@@ -4137,14 +4177,13 @@ dependencies = [
  "frame-system",
  "hex-literal 0.2.1",
  "log",
- "pallet-aura",
+ "pallet-authorship",
  "pallet-timestamp",
  "pallet-utxo-tokens",
  "parity-scale-codec",
  "pp-api",
  "proptest",
  "serde",
- "sp-consensus-aura",
  "sp-core",
  "sp-keystore",
  "sp-runtime",
@@ -6948,6 +6987,30 @@ source = "git+https://github.com/paritytech/substrate.git?branch=master#6e15de97
 dependencies = [
  "ruzstd",
  "zstd",
+]
+
+[[package]]
+name = "sp-npos-elections"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#6e15de9703bfe09b85efa33fd6e3a94d2446dd01"
+dependencies = [
+ "parity-scale-codec",
+ "serde",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-npos-elections-solution-type",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-npos-elections-solution-type"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#6e15de9703bfe09b85efa33fd6e3a94d2446dd01"
+dependencies = [
+ "proc-macro-crate 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4182,7 +4182,6 @@ dependencies = [
  "pallet-utxo-tokens",
  "parity-scale-codec",
  "pp-api",
- "proptest",
  "serde",
  "sp-core",
  "sp-keystore",

--- a/assets/functional_test_keys.json
+++ b/assets/functional_test_keys.json
@@ -1,0 +1,34 @@
+{
+	"users": [
+		{
+			"name": "Alice",
+			"sr25519_public_controller": "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
+			"sr25519_public_stash": "0xbe5ddb1579b72e84524fc29e78609e3caf42e85aa118ebfe0b0ad404b5bdd25f",
+			"ed25519_public": "0x88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee"
+		},
+		{
+			"name": "Bob",
+			"sr25519_public_controller": "0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48",
+			"sr25519_public_stash": "0xfe65717dad0447d715f660a0a58411de509b42e6efb8375f562f58a554d5860e",
+			"ed25519_public": "0xd17c2d7823ebf260fd138f2d7e27d114c0145d968b5ff5006125f2414fadae69"
+		},
+		{
+			"name": "Charlie",
+			"sr25519_public_controller": "0x90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22",
+			"sr25519_public_stash": "0x1e07379407fecc4b89eb7dbd287c2c781cfb1907a96947a3eb18e4f8e7198625",
+			"ed25519_public": "0x439660b36c6c03afafca027b910b4fecf99801834c62a5e6006f27d978de234f"
+		},
+		{
+			"name": "Dave",
+			"sr25519_public_controller": "0x306721211d5404bd9da88e0204360a1a9ab8b87c66c1bc2fcdd37f3c2222cc20",
+			"sr25519_public_stash": "0xe860f1b1c7227f7c22602f53f15af80747814dffd839719731ee3bba6edc126c",
+			"ed25519_public": "0x5e639b43e0052c47447dac87d6fd2b6ec50bdd4d0f614e4299c665249bbd09d9"
+		},
+		{
+			"name": "Erin",
+			"sr25519_public_controller": "0xe659a7a1628cdd93febc04a4e0646ea20e9f5f0ce097d9a05290d4a9e054df4e",
+			"sr25519_public_stash": "0x8ac59e11963af19174d0b94d5d78041c233f55d2e19324665bafdfb62925af2d",
+			"ed25519_public": "0x1dfe3e22cc0d45c70779c1095f7489a8ef3cf52d62fbd8c2fa38c9f1723502b5"
+		}
+	]
+}

--- a/assets/test_keys.json
+++ b/assets/test_keys.json
@@ -1,0 +1,34 @@
+{
+	"users": [
+		{
+			"name": "Alice",
+			"sr25519_public_controller": "0xba04ce6f11a1a73d5a8286446baa63671bf02eb9d2d896b5093b1b00ec9a6039",
+			"sr25519_public_stash": "0xe8aee020dff3bf215aad934ea22d38cb64079581480dcf50573758cac29a8147",
+			"ed25519_public": "0x7d17c5b414545a11d63237ccabadbda97a0fd6d1946405b105f8361338ed14ce"
+		},
+		{
+			"name": "Bob",
+			"sr25519_public_controller": "0x64a76e4603735144eaf30b7343565a4e5adf752f26e3096c58daa47723179855",
+			"sr25519_public_stash": "0x7e2cb3ed66cbd412203f41d29577f6a69ca3cba05ff026022c646d8118ee1708",
+			"ed25519_public": "0x3d5e4f7b55d3e2487358961cd55297639bc459b1c0b632b3097ee8d9633847bc"
+		},
+		{
+			"name": "Charlie",
+			"sr25519_public_controller": "0x8cb53fc2aa9b8bcc976537dd2b05a09a40f2929cfcef11014e608cc667dba60a",
+			"sr25519_public_stash": "0x042a16e8cd2702d1808d8fe1adedbb8e0ca6f33a56c5681d9bc9f48b478a6651",
+			"ed25519_public": "0x5f821a3eb5e4079582b7b936a32640f1546b6bc8ff10c7b602919959b0f54820"
+		},
+		{
+			"name": "Dave",
+			"sr25519_public_controller": "0xf81245c610127ca6cf4a6ea41580a7a0ed7553a115728a97f29a9a25534ba202",
+			"sr25519_public_stash": "0x56b2ce9c488bb1cdb1fb713e971aa68654783c9d6ccaca7572f4239fb300833e",
+			"ed25519_public": "0x9d60dcd1d5d5418473dc9b20721063d86e12385871899add7a7078093993f922"
+		},
+		{
+			"name": "Erin",
+			"sr25519_public_controller": "0x9eff4160f35aefab5574169eea8a9ce46078d808ce0e51fc9dbc774083758545",
+			"sr25519_public_stash": "0xb6c13894c3f920624bac58da3dadbeec678350dcc6548de9b0ca36cc4b819722",
+			"ed25519_public": "0x93b4f09a45fafdbe3acff66a9500f86d3792735b37ba1aa3907cd909634c92fe"
+		}
+	]
+}

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -33,6 +33,11 @@ version = '1.0.45'
 default-features = false
 features = ['alloc']
 
+[dependencies.serde]
+version = '1.0.130'
+default-features = false
+features = ['derive']
+
 [dependencies.frame-benchmarking]
 git = 'https://github.com/paritytech/substrate.git'
 version = '4.0.0-dev'

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -57,12 +57,11 @@ pub fn release_config(endowed_accounts: Vec<MltKeysInfo>) -> Result<ChainSpec, S
     let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
     let bootnodes = get_bootnodes();
 
-    // only Alice has sudo powers
-    let sudo = endowed_accounts.first().cloned().ok_or("endowed accounts is empty")?;
-
-    // alice won't be a validator.
-    let mut validator_accounts = endowed_accounts.clone();
-    validator_accounts.remove(0);
+    let mut validators = endowed_accounts.clone();
+    // remove alice from the validators list.
+    validators.remove(0);
+    // setting bob as the sudo user.
+    let sudo = validators.first().cloned().ok_or("endowed accounts is empty")?;
 
     Ok(ChainSpec::from_genesis(
         // Name
@@ -74,7 +73,7 @@ pub fn release_config(endowed_accounts: Vec<MltKeysInfo>) -> Result<ChainSpec, S
             testnet_genesis(
                 wasm_binary,
                 // Initial PoA authorities;
-                validator_accounts.clone(),
+                validators.clone(),
                 // Sudo account
                 sudo.controller_account_id(),
                 // Pre-funded accounts;

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,12 +1,12 @@
 use node_template_runtime::{
-    pallet_utxo, AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, PpConfig,
-    Signature, SudoConfig, SystemConfig, UtxoConfig, WASM_BINARY,
+    pallet_utxo, AccountId, BalancesConfig, GenesisConfig, PpConfig, SessionConfig, Signature,
+    StakerStatus, StakingConfig, SudoConfig, SystemConfig, UtxoConfig, MINIMUM_STAKE,
+    NUM_OF_VALIDATOR_SLOTS, WASM_BINARY,
 };
 use sc_network::config::MultiaddrWithPeerId;
 use sc_service::ChainType;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_core::H256;
-use sp_core::{sr25519, Pair, Public};
+use sp_core::{sr25519, H256};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
@@ -16,26 +16,26 @@ use sp_runtime::traits::{IdentifyAccount, Verify};
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec = sc_service::GenericChainSpec<GenesisConfig>;
 
-/// Generate a crypto pair from seed.
-pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
-    TPublic::Pair::from_string(&format!("//{}", seed), None)
-        .expect("static values are valid; qed")
-        .public()
+pub type AccountPublic = <Signature as Verify>::Signer;
+
+/// Holds information about keys needed for the accounts
+#[derive(Default, Debug, Clone)]
+pub struct MltKeysInfo {
+    pub name: String,
+    pub sr25519_public_controller: sr25519::Public,
+    pub sr25519_public_stash: sr25519::Public,
+    pub ed25519_public: sp_core::ed25519::Public,
+    pub mlt_tokens: pallet_utxo::Value,
 }
 
-type AccountPublic = <Signature as Verify>::Signer;
+impl MltKeysInfo {
+    fn controller_account_id(&self) -> AccountId {
+        AccountPublic::from(self.sr25519_public_controller).into_account()
+    }
 
-/// Generate an account ID from seed.
-pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
-where
-    AccountPublic: From<<TPublic::Pair as Pair>::Public>,
-{
-    AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
-}
-
-/// Generate an Aura authority key.
-pub fn authority_keys_from_seed(s: &str) -> (AuraId, GrandpaId) {
-    (get_from_seed::<AuraId>(s), get_from_seed::<GrandpaId>(s))
+    fn stash_account_id(&self) -> AccountId {
+        AccountPublic::from(self.sr25519_public_stash).into_account()
+    }
 }
 
 /// Return a list of bootnodes
@@ -53,9 +53,55 @@ fn get_bootnodes() -> Vec<MultiaddrWithPeerId> {
     ]
 }
 
-pub fn development_config() -> Result<ChainSpec, String> {
+pub fn release_config(endowed_accounts: Vec<MltKeysInfo>) -> Result<ChainSpec, String> {
     let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
     let bootnodes = get_bootnodes();
+
+    // only Alice has sudo powers
+    let sudo = endowed_accounts.first().cloned().ok_or("endowed accounts is empty")?;
+
+    // alice won't be a validator.
+    let mut validator_accounts = endowed_accounts.clone();
+    validator_accounts.remove(0);
+
+    Ok(ChainSpec::from_genesis(
+        // Name
+        "Release",
+        // ID
+        "rel",
+        ChainType::Development, //TODO: should it be custom? I'm not sure about this part.
+        move || {
+            testnet_genesis(
+                wasm_binary,
+                // Initial PoA authorities;
+                validator_accounts.clone(),
+                // Sudo account
+                sudo.controller_account_id(),
+                // Pre-funded accounts;
+                endowed_accounts.clone(),
+                // Pre-fund all accounts in the pallet-balance
+                endowed_accounts.clone(),
+            )
+        },
+        // Bootnodes
+        bootnodes,
+        // Telemetry
+        None,
+        // Protocol ID
+        None,
+        // Properties
+        None,
+        // Extensions
+        None,
+    ))
+}
+
+pub fn development_config(endowed_accounts: Vec<MltKeysInfo>) -> Result<ChainSpec, String> {
+    let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
+    let bootnodes = get_bootnodes();
+
+    // only Alice has sudo powers
+    let sudo = endowed_accounts.first().cloned().ok_or("endowed accounts is empty")?;
 
     Ok(ChainSpec::from_genesis(
         // Name
@@ -66,22 +112,15 @@ pub fn development_config() -> Result<ChainSpec, String> {
         move || {
             testnet_genesis(
                 wasm_binary,
-                // Initial PoA authorities
-                vec![authority_keys_from_seed("Alice")],
+                // Initial PoA authorities; 2
+                endowed_accounts.iter().cloned().take(2).collect(),
                 // Sudo account
-                get_account_id_from_seed::<sr25519::Public>("Alice"),
-                // Pre-funded accounts
-                vec![
-                    get_account_id_from_seed::<sr25519::Public>("Alice"),
-                    get_account_id_from_seed::<sr25519::Public>("Bob"),
-                    get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-                ],
-                vec![
-                    get_from_seed::<sr25519::Public>("Alice"),
-                    get_from_seed::<sr25519::Public>("Bob"),
-                ],
-                true,
+                sudo.controller_account_id(),
+                // Pre-funded accounts; only the first 2 are funded. This is important for
+                // the functional tests.
+                endowed_accounts.iter().cloned().take(2).collect(),
+                // Pre-fund all accounts in the pallet-balance
+                endowed_accounts.clone(),
             )
         },
         // Bootnodes
@@ -97,9 +136,12 @@ pub fn development_config() -> Result<ChainSpec, String> {
     ))
 }
 
-pub fn local_testnet_config() -> Result<ChainSpec, String> {
+pub fn local_testnet_config(endowed_accounts: Vec<MltKeysInfo>) -> Result<ChainSpec, String> {
     let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
     let bootnodes = get_bootnodes();
+
+    // only Alice
+    let sudo = endowed_accounts.first().cloned().ok_or("endowed accounts is empty")?;
 
     Ok(ChainSpec::from_genesis(
         // Name
@@ -111,29 +153,13 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
             testnet_genesis(
                 wasm_binary,
                 // Initial PoA authorities
-                vec![authority_keys_from_seed("Alice"), authority_keys_from_seed("Bob")],
-                // Sudo account
-                get_account_id_from_seed::<sr25519::Public>("Alice"),
-                // Pre-funded accounts
-                vec![
-                    get_account_id_from_seed::<sr25519::Public>("Alice"),
-                    get_account_id_from_seed::<sr25519::Public>("Bob"),
-                    get_account_id_from_seed::<sr25519::Public>("Charlie"),
-                    get_account_id_from_seed::<sr25519::Public>("Dave"),
-                    get_account_id_from_seed::<sr25519::Public>("Eve"),
-                    get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-                    get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
-                    get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
-                ],
-                vec![
-                    get_from_seed::<sr25519::Public>("Alice"),
-                    get_from_seed::<sr25519::Public>("Bob"),
-                ],
-                true,
+                endowed_accounts.iter().cloned().take(2).collect(),
+                // Sudo account; the first one, being Alice
+                sudo.controller_account_id(),
+                // Pre-funded utxos for the ff. accounts
+                endowed_accounts.clone(),
+                // Pre-funded all the accounts in the pallet-balance
+                endowed_accounts.clone(),
             )
         },
         // Bootnodes
@@ -152,23 +178,85 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
 /// Configure initial storage state for FRAME modules.
 fn testnet_genesis(
     wasm_binary: &[u8],
-    initial_authorities: Vec<(AuraId, GrandpaId)>,
+    initial_authorities: Vec<MltKeysInfo>,
     root_key: AccountId,
-    endowed_accounts: Vec<AccountId>,
-    endowed_utxos: Vec<sr25519::Public>,
-    _enable_println: bool,
+    endowed_utxos: Vec<MltKeysInfo>,
+    endowed_accounts: Vec<MltKeysInfo>,
 ) -> GenesisConfig {
-    // only Alice contains 400 million coins.
-    let genesis = endowed_utxos
-        .first()
-        .map(|x| {
-            // may need to create a const variable to represent 1_000 and 100_000_000
-            pallet_utxo::TransactionOutput::new_pubkey(
-                1_000 * 100_000_000 * 400_000_000 as pallet_utxo::Value,
-                H256::from_slice(x.as_slice()),
-            )
-        })
-        .unwrap();
+    //TODO: clean up this code
+    // Endowment for the pallet-balances.
+    // Bigger endowment means security from all fees or costs generated by doing multiple actions;
+    // actions which are not charged when dealing with the utxo system.
+    // An example is the first time staking; that involves 3 steps; but in the utxo system, it's only 1.
+    const ENDOWMENT: u128 = 1 << 90;
+
+    let (locked_utxos, stakers, session_keys) = initial_authorities.iter().fold(
+        (
+            vec![], // the utxos locked
+            vec![], // the stakers: (<stash_account_id>, <controller_account_id>, <stash_amount>, <role>)
+            vec![], // session keys: (<account_id>, <validator_id a.k.a. account_id>, <runtime_defined_keys>). See Pallet-Session
+        ),
+        |(mut locked_utxos, mut stakers, mut session_keys), auth_keys| {
+            // initial authorities meaning they're also validators.
+            // locking some values as a stake from validators
+            locked_utxos.push(
+                pallet_utxo::TransactionOutput::<AccountId>::new_lock_for_staking(
+                    // this is the minimum stake amount
+                    MINIMUM_STAKE,
+                    auth_keys.stash_account_id(),
+                    auth_keys.controller_account_id(),
+                    vec![],
+                ),
+            );
+
+            // to initialize the pallet-staking
+            stakers.push((
+                auth_keys.stash_account_id(),
+                auth_keys.controller_account_id(),
+                // minimum balance set in the runtime. check `lib.rs` of runtime module.
+                MINIMUM_STAKE,
+                // the role is `validator`. See pallet-staking
+                StakerStatus::Validator,
+            ));
+
+            // Where aura and grandpa are initialized.
+            session_keys.push((
+                auth_keys.stash_account_id(),
+                auth_keys.stash_account_id(),
+                node_template_runtime::opaque::SessionKeys {
+                    aura: AuraId::from(auth_keys.sr25519_public_controller),
+                    grandpa: GrandpaId::from(auth_keys.ed25519_public),
+                },
+            ));
+
+            (locked_utxos, stakers, session_keys)
+        },
+    );
+
+    let genesis_utxos: Vec<pallet_utxo::TransactionOutput<AccountId>> =
+        endowed_utxos.into_iter().fold(vec![], |mut genesis_utxos, info| {
+            // share tokens between the controller and the stash accounts
+            let shared_tokens = info.mlt_tokens / 2;
+
+            // add tokens for the controller account
+            genesis_utxos.push(pallet_utxo::TransactionOutput::<AccountId>::new_pubkey(
+                shared_tokens,
+                H256::from(info.sr25519_public_controller),
+            ));
+
+            // add token for the stash_account
+            genesis_utxos.push(pallet_utxo::TransactionOutput::<AccountId>::new_pubkey(
+                shared_tokens,
+                H256::from(info.sr25519_public_stash),
+            ));
+            genesis_utxos
+        });
+
+    let balances = endowed_accounts.iter().fold(vec![], |mut acc, info| {
+        acc.push((info.controller_account_id(), ENDOWMENT));
+        acc.push((info.stash_account_id(), ENDOWMENT));
+        acc
+    });
 
     GenesisConfig {
         system: SystemConfig {
@@ -177,25 +265,36 @@ fn testnet_genesis(
             changes_trie_config: Default::default(),
         },
         balances: BalancesConfig {
-            // Configure endowed accounts with initial balance of 1 << 60.
-            balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 60)).collect(),
+            // Configure endowed accounts
+            balances,
         },
-        aura: AuraConfig {
-            authorities: initial_authorities.iter().map(|x| (x.0.clone())).collect(),
-        },
-        grandpa: GrandpaConfig {
-            authorities: initial_authorities.iter().map(|x| (x.1.clone(), 1)).collect(),
-        },
+        // This has been initialized from the session config
+        aura: Default::default(),
+        // This has been initialized from the session config
+        grandpa: Default::default(),
         sudo: SudoConfig {
             // Assign network admin rights.
             key: root_key,
         },
         utxo: UtxoConfig {
-            genesis_utxos: vec![genesis],
-            _marker: Default::default(),
+            genesis_utxos,
+            // The # of validators set should also be the same here.
+            // This should be the same as what's set as the initial authorities
+            locked_utxos,
+            // initial_reward_amount: 100 * MLT_UNIT
         },
         pp: PpConfig {
             _marker: Default::default(),
+        },
+        session: SessionConfig { keys: session_keys },
+        staking: StakingConfig {
+            validator_count: NUM_OF_VALIDATOR_SLOTS,
+            // The # of validators set should be the same number of locked_utxos specified in UtxoConfig.
+            minimum_validator_count: 1,
+            invulnerables: initial_authorities.iter().map(|x| x.controller_account_id()).collect(),
+            slash_reward_fraction: sp_runtime::Perbill::from_percent(0), // nothing, since we're not using this at all.
+            stakers,
+            ..Default::default()
         },
     }
 }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -6,6 +6,9 @@ pub struct Cli {
     #[structopt(subcommand)]
     pub subcommand: Option<Subcommand>,
 
+    #[structopt(long, conflicts_with_all = &["chain"])]
+    pub release: bool,
+
     #[structopt(flatten)]
     pub run: RunCmd,
 }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -6,7 +6,7 @@ pub struct Cli {
     #[structopt(subcommand)]
     pub subcommand: Option<Subcommand>,
 
-    #[structopt(long, conflicts_with_all = &["chain"])]
+    #[structopt(long, conflicts_with_all = &["chain", "dev"])]
     pub release: bool,
 
     #[structopt(flatten)]

--- a/pallets/utxo/Cargo.toml
+++ b/pallets/utxo/Cargo.toml
@@ -68,6 +68,12 @@ git = 'https://github.com/paritytech/substrate.git'
 version = '4.0.0-dev'
 branch = "master"
 
+[dependencies.pallet-authorship]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+version = '4.0.0-dev'
+branch = "master"
+
 [dependencies.pallet-timestamp]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
@@ -96,16 +102,3 @@ branch = "master"
 version = "0.10.0-dev"
 git = 'https://github.com/paritytech/substrate.git'
 branch = "master"
-
-[dev-dependencies.pallet-aura]
-git = 'https://github.com/paritytech/substrate.git'
-version = '4.0.0-dev'
-branch = "master"
-
-[dev-dependencies.sp-consensus-aura]
-git = 'https://github.com/paritytech/substrate.git'
-version = '0.10.0-dev'
-branch = "master"
-
-[dev-dependencies.proptest]
-version = "1.0.0"

--- a/pallets/utxo/Cargo.toml
+++ b/pallets/utxo/Cargo.toml
@@ -102,3 +102,6 @@ branch = "master"
 version = "0.10.0-dev"
 git = 'https://github.com/paritytech/substrate.git'
 branch = "master"
+
+[dev-dependencies.proptest]
+version = "1.0.0"

--- a/pallets/utxo/README.md
+++ b/pallets/utxo/README.md
@@ -16,9 +16,20 @@ To run the test cases, just run command `cargo test`.
       "Pubkey": "Pubkey",
       "CreatePP": "DestinationCreatePP",
       "CallPP": "DestinationCallPP",
-      "ScriptHash": "H256"
-    }
-  },
+      "ScriptHash": "H256",
+      "LockForStaking": "DestinationStake",
+       "LockExtraForStaking": "DestinationStakeExtra"
+      }
+   },
+   "DestinationStake": {
+      "stash_account": "AccountId",
+      "controller_account": "AccountId",
+      "session_key": "Vec<u8>"
+   },
+   "DestinationStakeExtra": {
+      "stash_account": "AccountId",
+      "controller_account": "AccountId"
+   },
   "DestinationCreatePP": {
     "code": "Vec<u8>",
     "data": "Vec<u8>"

--- a/pallets/utxo/src/benchmarking.rs
+++ b/pallets/utxo/src/benchmarking.rs
@@ -123,12 +123,12 @@ benchmarks! {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mock::{new_test_ext, Test};
+    use crate::mock::{alice_test_ext, Test};
     use frame_support::assert_ok;
 
     #[test]
     fn spend() {
-        new_test_ext().execute_with(|| {
+        alice_test_ext().execute_with(|| {
             assert_ok!(test_benchmark_test_spend::<Test>());
         });
     }

--- a/pallets/utxo/src/mock.rs
+++ b/pallets/utxo/src/mock.rs
@@ -141,7 +141,7 @@ impl<T: pallet_utxo::Config> StakingHelper<AccountId> for MockStaking<T> {
         })
     }
 
-    fn can_decode_session_key(session_key: &Vec<u8>) -> bool {
+    fn can_decode_session_key(_session_key: &Vec<u8>) -> bool {
         true
     }
 
@@ -276,6 +276,7 @@ frame_support::construct_runtime!(
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
         System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+        Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
         Utxo: pallet_utxo::{Pallet, Call, Config<T>, Storage, Event<T>},
     }
 );

--- a/pallets/utxo/src/mock.rs
+++ b/pallets/utxo/src/mock.rs
@@ -15,9 +15,11 @@
 //
 // Author(s): C. Yap
 use crate as pallet_utxo;
+use pallet_utxo::staking::StakingHelper;
 use pallet_utxo::TransactionOutput;
 use pp_api::ProgrammablePoolApi;
 
+use frame_support::dispatch::DispatchResultWithPostInfo;
 use frame_support::{dispatch::Vec, weights::Weight};
 use frame_support::{
     parameter_types,
@@ -25,12 +27,13 @@ use frame_support::{
     sp_runtime::{
         testing::Header,
         traits::{BlakeTwo256, Hash, IdentityLookup},
+        Percent,
     },
     traits::GenesisBuild,
 };
-use sp_consensus_aura::sr25519::AuthorityId as AuraId;
+use frame_system::Config as SysConfig;
 use sp_core::{
-    sp_std::{marker::PhantomData, vec},
+    sp_std::{cell::RefCell, collections::btree_map::BTreeMap, marker::PhantomData, vec},
     sr25519::Public,
     testing::SR25519,
     H256,
@@ -39,6 +42,23 @@ use sp_keystore::{testing::KeyStore, KeystoreExt, SyncCryptoStore};
 
 pub type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 pub type Block = frame_system::mocking::MockBlock<Test>;
+/// An index to a block.
+pub type BlockNumber = u64;
+pub type AccountId = H256;
+
+pub struct MockStaking<T: pallet_utxo::Config> {
+    pub withdrawal_span: T::BlockNumber,
+    pub current_block: T::BlockNumber,
+    pub lock_map: BTreeMap<T::AccountId, Option<T::BlockNumber>>,
+    pub ctrl_map: BTreeMap<T::AccountId, T::AccountId>,
+    pub lock_ctrl_map: BTreeMap<T::AccountId, T::AccountId>,
+    pub marker: PhantomData<T>,
+}
+
+thread_local! {
+    pub static AUTHORITIES: RefCell<Vec<Public>> = RefCell::new(vec![]);
+    pub static MOCK_STAKING: RefCell<MockStaking<Test>> = RefCell::new(MockStaking::new());
+}
 
 pub const ALICE_PHRASE: &str =
     "news slush supreme milk chapter athlete soap sausage put clutch what kitten";
@@ -47,15 +67,15 @@ pub fn genesis_utxo() -> (TransactionOutput<H256>, H256) {
     let keystore = KeyStore::new();
     let alice_pub_key = create_pub_key(&keystore, ALICE_PHRASE);
     let output = TransactionOutput::<H256>::new_pubkey(100, H256::from(alice_pub_key));
-    let hash = BlakeTwo256::hash_of(&output);
+    let hash = BlakeTwo256::hash_of(&(&output, 0u64, "genesis"));
     (output, hash)
 }
 
 // Dummy programmable pool for testing
 pub struct MockPool<T>(PhantomData<T>);
 
-impl<T: frame_system::Config> ProgrammablePoolApi for MockPool<T> {
-    type AccountId = H256;
+impl<T: SysConfig> ProgrammablePoolApi for MockPool<T> {
+    type AccountId = AccountId;
 
     fn create(
         _origin: &Self::AccountId,
@@ -81,6 +101,173 @@ impl<T: frame_system::Config> ProgrammablePoolApi for MockPool<T> {
     }
 }
 
+impl MockStaking<Test> {
+    fn new() -> Self {
+        Self {
+            withdrawal_span: 5,
+            current_block: 0,
+            lock_map: BTreeMap::new(),
+            ctrl_map: BTreeMap::new(),
+            lock_ctrl_map: BTreeMap::new(),
+            marker: Default::default(),
+        }
+    }
+}
+
+pub fn next_block() {
+    MOCK_STAKING.with(|stake_info| {
+        let mut stake_info = stake_info.borrow_mut();
+        stake_info.current_block += 1;
+    })
+}
+
+impl<T: pallet_utxo::Config> StakingHelper<AccountId> for MockStaking<T> {
+    fn get_controller_account(stash_account: &AccountId) -> Result<AccountId, &'static str> {
+        MOCK_STAKING.with(|stake_info| {
+            let stake_info = stake_info.borrow();
+
+            stake_info
+                .lock_ctrl_map
+                .get(stash_account)
+                .map(|x| *x)
+                .ok_or("StashAccountNotFound")
+        })
+    }
+
+    fn is_controller_account_exist(controller_account: &AccountId) -> bool {
+        MOCK_STAKING.with(|stake_info| {
+            let stake_info = stake_info.borrow();
+            stake_info.ctrl_map.contains_key(controller_account)
+        })
+    }
+
+    fn can_decode_session_key(session_key: &Vec<u8>) -> bool {
+        true
+    }
+
+    fn are_funds_locked(controller_account: &AccountId) -> bool {
+        MOCK_STAKING.with(|stake_info| {
+            let stake_info = stake_info.borrow();
+
+            if let Some(stash) = stake_info.ctrl_map.get(controller_account) {
+                if let Some(Some(_)) = stake_info.lock_map.get(stash) {
+                } else {
+                    return true;
+                }
+            }
+            false
+        })
+    }
+
+    fn check_accounts_matched(controller_account: &AccountId, stash_account: &AccountId) -> bool {
+        MOCK_STAKING.with(|stake_info| {
+            let stake_info = stake_info.borrow();
+
+            if let Some(stash_acc) = stake_info.ctrl_map.get(controller_account) {
+                if stash_account == stash_acc {
+                    return true;
+                }
+            }
+            false
+        })
+    }
+
+    fn lock_for_staking(
+        stash_account: &AccountId,
+        controller_account: &AccountId,
+        _rotate_keys: &Vec<u8>,
+        _value: u128,
+    ) -> DispatchResultWithPostInfo {
+        MOCK_STAKING.with(|stake_info| {
+            let mut stake_info = stake_info.borrow_mut();
+
+            if stake_info.lock_map.contains_key(stash_account) {
+                Err("CANNOT STAKE. STASH ACCOUNT IS ALREADY REGISTERED.")?
+            }
+
+            if stake_info.ctrl_map.contains_key(stash_account) {
+                Err("CANNOT STAKE. STASH ACCOUNT IS ACTUALLY A CONTROLLER ACCOUNT")?
+            }
+
+            if stake_info.lock_ctrl_map.contains_key(controller_account) {
+                Err(pallet_utxo::Error::<T>::StashAccountAlreadyRegistered)?
+            }
+
+            stake_info.lock_map.insert(stash_account.clone(), None);
+            stake_info
+                .lock_ctrl_map
+                .insert(stash_account.clone(), controller_account.clone());
+            stake_info.ctrl_map.insert(controller_account.clone(), stash_account.clone());
+
+            Ok(().into())
+        })
+    }
+
+    fn lock_extra_for_staking(
+        stash_account: &AccountId,
+        _value: u128,
+    ) -> DispatchResultWithPostInfo {
+        MOCK_STAKING.with(|stake_info| {
+            let stake_info = stake_info.borrow();
+
+            if !stake_info.lock_map.contains_key(stash_account) {
+                Err(pallet_utxo::Error::<T>::StashAccountNotFound)?
+            }
+
+            if stake_info.ctrl_map.contains_key(stash_account) {
+                Err("CANNOT STAKE. STASH ACCOUNT IS ACTUALLY A CONTROLLER ACCOUNT")?
+            }
+
+            Ok(().into())
+        })
+    }
+
+    fn unlock_request_for_withdrawal(stash_account: &AccountId) -> DispatchResultWithPostInfo {
+        MOCK_STAKING.with(|stake_info| {
+            let mut stake_info = stake_info.borrow_mut();
+
+            if stake_info.ctrl_map.contains_key(stash_account) {
+                Err("CANNOT PAUSE. STASH ACCOUNT IS ACTUALLY A CONTROLLER ACCOUNT")?
+            }
+
+            if !stake_info.lock_map.contains_key(stash_account) {
+                Err(pallet_utxo::Error::<T>::StashAccountNotFound)?
+            }
+
+            if let Some(_) = stake_info.lock_map.get(stash_account).unwrap() {
+                // if it has a value already, meaning a pause function was already performed.
+                Err("CANNOT PAUSE AGAIN.")?
+            }
+
+            let withdrawal_block = stake_info.current_block + stake_info.withdrawal_span;
+            stake_info.lock_map.insert(stash_account.clone(), Some(withdrawal_block));
+
+            Ok(().into())
+        })
+    }
+
+    fn withdraw(stash_account: &AccountId) -> DispatchResultWithPostInfo {
+        MOCK_STAKING.with(|stake_info| {
+            let mut stake_info = stake_info.borrow_mut();
+
+            match stake_info.lock_map.get(stash_account) {
+                Some(Some(withdrawal_block)) => {
+                    if *withdrawal_block <= stake_info.current_block {
+                        let ctrl_account = stake_info.lock_ctrl_map.remove(stash_account).unwrap();
+                        stake_info.ctrl_map.remove(&ctrl_account);
+                        stake_info.lock_map.remove(&stash_account);
+
+                        Ok(().into())
+                    } else {
+                        Err("not yet time to withdraw".into())
+                    }
+                }
+                Some(_) | None => Err("not yet unlocked".into()),
+            }
+        })
+    }
+}
+
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(
     pub enum Test where
@@ -89,9 +276,7 @@ frame_support::construct_runtime!(
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
         System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
-        Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
         Utxo: pallet_utxo::{Pallet, Call, Config<T>, Storage, Event<T>},
-        Aura: pallet_aura::{Pallet, Config<T>, Storage},
     }
 );
 
@@ -105,17 +290,17 @@ parameter_types! {
     pub const MaximumBlockLength: u32 = 2 * 1024;
 }
 
-impl frame_system::Config for Test {
+impl SysConfig for Test {
     type BaseCallFilter = frame_support::traits::Everything;
     type BlockWeights = ();
     type BlockLength = ();
     type Origin = Origin;
     type Call = Call;
     type Index = u64;
-    type BlockNumber = u64;
+    type BlockNumber = BlockNumber;
     type Hash = H256;
     type Hashing = BlakeTwo256;
-    type AccountId = H256;
+    type AccountId = AccountId;
     type Lookup = IdentityLookup<Self::AccountId>;
     type Header = Header;
     type Event = Event;
@@ -131,22 +316,21 @@ impl frame_system::Config for Test {
     type OnSetCode = ();
 }
 
-// required by pallet_aura
 impl pallet_timestamp::Config for Test {
     type Moment = u64;
-    type OnTimestampSet = Aura;
+    type OnTimestampSet = ();
     type MinimumPeriod = MinimumPeriod;
     type WeightInfo = ();
 }
 
 parameter_types! {
     pub const MaxAuthorities: u32 = 1000;
-}
-
-impl pallet_aura::Config for Test {
-    type AuthorityId = AuraId;
-    type DisabledValidators = ();
-    type MaxAuthorities = MaxAuthorities;
+    pub const MinimumStake: u128 = 10;
+    pub const InitialReward: u128 = 100;
+    pub const DefaultMinimumReward: u128 = 1;
+    pub const StakeWithdrawalFee: u128 = 1;
+    pub const RewardReductionPeriod: BlockNumber = 5;
+    pub const RewardReductionFraction: Percent = Percent::from_percent(25);
 }
 
 impl pallet_utxo::Config for Test {
@@ -155,23 +339,28 @@ impl pallet_utxo::Config for Test {
     type WeightInfo = crate::weights::WeightInfo<Test>;
     type ProgrammablePool = MockPool<Test>;
     type AssetId = u64;
+    type RewardReductionFraction = RewardReductionFraction;
+    type RewardReductionPeriod = RewardReductionPeriod;
 
     fn authorities() -> Vec<H256> {
-        Aura::authorities()
-            .iter()
-            .map(|x| {
-                let r: &Public = x.as_ref();
-                r.0.into()
-            })
-            .collect()
+        AUTHORITIES.with(|auths| {
+            let auths = auths.borrow();
+            auths.iter().map(|x| H256::from(x.0)).collect()
+        })
     }
+
+    type StakingHelper = MockStaking<Test>;
+    type MinimumStake = MinimumStake;
+    type StakeWithdrawalFee = StakeWithdrawalFee;
+    type InitialReward = InitialReward;
+    type DefaultMinimumReward = DefaultMinimumReward;
 }
 
 fn create_pub_key(keystore: &KeyStore, phrase: &str) -> Public {
     SyncCryptoStore::sr25519_generate_new(keystore, SR25519, Some(phrase)).unwrap()
 }
 
-pub fn new_test_ext() -> TestExternalities {
+pub fn alice_test_ext() -> TestExternalities {
     let keystore = KeyStore::new(); // a key storage to store new key pairs during testing
     let alice_pub_key = create_pub_key(&keystore, ALICE_PHRASE);
 
@@ -179,7 +368,7 @@ pub fn new_test_ext() -> TestExternalities {
 
     pallet_utxo::GenesisConfig::<Test> {
         genesis_utxos: vec![TransactionOutput::new_pubkey(100, H256::from(alice_pub_key))],
-        _marker: Default::default(),
+        locked_utxos: vec![],
     }
     .assimilate_storage(&mut t)
     .unwrap();
@@ -189,7 +378,7 @@ pub fn new_test_ext() -> TestExternalities {
     ext
 }
 
-pub fn new_test_ext_and_keys() -> (TestExternalities, Public, Public) {
+pub fn alice_test_ext_and_keys() -> (TestExternalities, Public, Public) {
     // other random account generated with subkey
     const KARL_PHRASE: &str =
         "monitor exhibit resource stumble subject nut valid furnace obscure misery satoshi assume";
@@ -201,7 +390,7 @@ pub fn new_test_ext_and_keys() -> (TestExternalities, Public, Public) {
     let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
     pallet_utxo::GenesisConfig::<Test> {
         genesis_utxos: vec![TransactionOutput::new_pubkey(100, H256::from(alice_pub_key))],
-        _marker: Default::default(),
+        locked_utxos: vec![],
     }
     .assimilate_storage(&mut t)
     .unwrap();
@@ -209,4 +398,85 @@ pub fn new_test_ext_and_keys() -> (TestExternalities, Public, Public) {
     let mut ext = TestExternalities::from(t);
     ext.register_extension(KeystoreExt(std::sync::Arc::new(keystore)));
     (ext, alice_pub_key, karl_pub_key)
+}
+
+pub fn multiple_keys_test_ext() -> (TestExternalities, Vec<(Public, H256)>) {
+    const KARL_PHRASE: &str =
+        "monitor exhibit resource stumble subject nut valid furnace obscure misery satoshi assume";
+
+    const GREG_PHRASE: &str =
+        "infant salmon buzz patrol maple subject turtle cute legend song vital leisure";
+
+    const TOM_PHRASE: &str = "clip organ olive upper oak void inject side suit toilet stick narrow";
+
+    let keystore = KeyStore::new();
+
+    let alice_pub_key = create_pub_key(&keystore, ALICE_PHRASE);
+    let karl_pub_key = create_pub_key(&keystore, KARL_PHRASE);
+    let greg_pub_key = create_pub_key(&keystore, GREG_PHRASE);
+    let tom_pub_key = create_pub_key(&keystore, TOM_PHRASE);
+
+    let alice_hash = H256::from(alice_pub_key);
+    let karl_hash = H256::from(karl_pub_key);
+    let greg_hash = H256::from(greg_pub_key);
+    let tom_hash = H256::from(tom_pub_key);
+
+    let alice_genesis = TransactionOutput::new_pubkey(100, alice_hash.clone());
+    let karl_genesis = TransactionOutput::new_pubkey(110, karl_hash.clone());
+    let greg_genesis = TransactionOutput::new_pubkey(120, greg_hash.clone());
+    let tom_genesis = TransactionOutput::new_pubkey(130, tom_hash.clone());
+
+    let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+
+    pallet_utxo::GenesisConfig::<Test> {
+        genesis_utxos: vec![
+            alice_genesis.clone(),
+            karl_genesis.clone(),
+            greg_genesis.clone(),
+            tom_genesis.clone(),
+        ],
+        locked_utxos: vec![
+            //  alice is the stash and tom is a controller account.
+            TransactionOutput::new_lock_for_staking(10, alice_hash, tom_hash, vec![3, 1]),
+        ],
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+
+    let mut ext = TestExternalities::from(t);
+    ext.register_extension(KeystoreExt(std::sync::Arc::new(keystore)));
+
+    MOCK_STAKING.with(|stake_info| {
+        let mut stake_info = stake_info.borrow_mut();
+        stake_info.lock_map.insert(alice_hash, None);
+        stake_info.lock_ctrl_map.insert(alice_hash, tom_hash);
+        stake_info.ctrl_map.insert(tom_hash, alice_hash);
+    });
+
+    AUTHORITIES.with(|auths| {
+        let mut auths = auths.borrow_mut();
+        auths.push(alice_pub_key);
+    });
+
+    (
+        ext,
+        vec![
+            (
+                alice_pub_key,
+                BlakeTwo256::hash_of(&(&alice_genesis, 0u64, "genesis")),
+            ),
+            (
+                karl_pub_key,
+                BlakeTwo256::hash_of(&(&karl_genesis, 1u64, "genesis")),
+            ),
+            (
+                greg_pub_key,
+                BlakeTwo256::hash_of(&(&greg_genesis, 2u64, "genesis")),
+            ),
+            (
+                tom_pub_key,
+                BlakeTwo256::hash_of(&(&tom_genesis, 3u64, "genesis")),
+            ),
+        ],
+    )
 }

--- a/pallets/utxo/src/rewards.rs
+++ b/pallets/utxo/src/rewards.rs
@@ -1,0 +1,218 @@
+// Copyright (c) 2021 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): C. Yap
+
+use crate::{
+    convert_to_h256, BlockAuthor, Config, Event, Pallet, RewardTotal, TransactionOutput, UtxoStore,
+    Value,
+};
+
+use frame_support::traits::Get;
+use sp_core::H256;
+use sp_runtime::traits::{BlakeTwo256, CheckedDiv, Hash, SaturatedConversion, Zero};
+use sp_runtime::Percent;
+use sp_std::convert::TryInto;
+
+/// handle event when a block author is found.
+impl<T> pallet_authorship::EventHandler<T::AccountId, T::BlockNumber> for Pallet<T>
+where
+    T: Config + pallet_authorship::Config,
+{
+    fn note_author(author: T::AccountId) {
+        match convert_to_h256::<T>(&author) {
+            Ok(author_h256) => {
+                // store the block author. Reward during the `fn finalize()` phase.
+                <BlockAuthor<T>>::put(author_h256);
+            }
+            Err(e) => {
+                log::warn!("failed to find author: {:?}", e);
+            }
+        }
+    }
+
+    fn note_uncle(_author: T::AccountId, _age: T::BlockNumber) {
+        log::info!("TODO: no support for this. Or is there...?");
+    }
+}
+
+/// checks at what period the given block number belongs to.
+/// If it exceeds to the maximum value of u8 datatype,
+/// reduction_fraction is already way over 100%.
+fn increase_reduction_fraction<T: Config>(block_number: T::BlockNumber) -> Option<u8> {
+    let reduction_period: T::BlockNumber = T::RewardReductionPeriod::get();
+
+    // When reduction_period is not set, there's no such thing as "block period".
+    // There's no need to compute for the "current" block period.
+    // Reward will not decrease at all.
+    if reduction_period.is_zero() {
+        return Some(0);
+    }
+
+    // get at what period the current block number is at.
+    match block_number
+        .checked_div(&reduction_period)
+        .expect("successfully retrieved current block period.")
+        .try_into()
+    {
+        Ok(result) => Some(result),
+        Err(_) => {
+            // block_period exceeds the maximum threshold.
+            None
+        }
+    }
+}
+
+/// Returns the newly reduced reward amount for a Block Author.
+/// How much a reward is reduced, will be based on the config's`RewardReductionFraction`.
+fn get_block_author_reward<T: Config>(block_number: T::BlockNumber) -> Value {
+    let reduction_fraction = T::RewardReductionFraction::get().deconstruct();
+    let last_block_rewarded_period = (100u8 / reduction_fraction) - 1;
+
+    match increase_reduction_fraction::<T>(block_number) {
+        None => {
+            // cannot increase the current reduction fraction anymore; it has exceeded 100%.
+        }
+        Some(current_block_period) => {
+            // if current block period has not reached to a point where reduction is at 100%
+            if current_block_period <= last_block_rewarded_period {
+                // compute for the updated reduction % , given the current block period.
+                let updated_reduction_fraction =
+                    Percent::from_percent(reduction_fraction * current_block_period);
+
+                let reward_amount = T::InitialReward::get();
+                return reward_amount - updated_reduction_fraction.mul_ceil(reward_amount);
+            }
+        }
+    }
+
+    T::DefaultMinimumReward::get()
+}
+
+fn insert_to_utxo_store<T: Config>(
+    block_number: T::BlockNumber,
+    block_author: H256,
+    reward: Value,
+) {
+    let utxo = TransactionOutput::new_pubkey(reward, block_author.clone());
+
+    //TODO: https://github.com/mintlayer/core/pull/83#discussion_r742773343
+    let hash = {
+        let b_num = block_number.saturated_into::<u64>();
+        BlakeTwo256::hash_of(&(&utxo, b_num, "author_reward"))
+    };
+
+    if !<UtxoStore<T>>::contains_key(hash) {
+        <UtxoStore<T>>::insert(hash, utxo.clone());
+
+        <Pallet<T>>::deposit_event(Event::<T>::BlockAuthorRewarded(utxo));
+    }
+}
+
+/// Rewards the block author with a utxo of value based on the `BlockAuthorRewardAmount`
+/// and the transaction fees.
+pub(crate) fn reward_block_author<T: Config>(block_number: T::BlockNumber) {
+    // As written on the definition of Take:
+    // Take a value from storage, removing it afterwards.
+    // This is taking a value of the RewardTotal storage, freeing it up.
+    let transaction_fees = <RewardTotal<T>>::take();
+
+    if let Some(reward_amount) =
+        get_block_author_reward::<T>(block_number).checked_add(transaction_fees)
+    {
+        // As written on the definition of Take:
+        // Take a value from storage, removing it afterwards.
+        // This is taking a value of the BlockAuthor storage, freeing it up.
+        let block_author = <BlockAuthor<T>>::take().expect("Block author found.");
+        insert_to_utxo_store::<T>(block_number, block_author, reward_amount)
+    } else {
+        //TODO: what's the actual behaviour (or if this happens at all)
+        log::warn!("problem adding the block author reward and the fees.");
+
+        <RewardTotal<T>>::put(transaction_fees);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::mock::*;
+
+    #[test]
+    fn increase_reduction_fraction_test() {
+        alice_test_ext().execute_with(|| {
+            // with ReductionPeriod = 5:
+            // at Block 3, period is at 0, since 3 < 5
+            assert_eq!(increase_reduction_fraction::<Test>(3), Some(0));
+
+            // at Block 3, period is at 0, since 4 < 5
+            assert_eq!(increase_reduction_fraction::<Test>(4), Some(0));
+
+            // at Block 5, period is at 1, since 5/ReductionPeriod = 1.
+            assert_eq!(increase_reduction_fraction::<Test>(5), Some(1));
+
+            // at Block 3, period is at 2
+            assert_eq!(increase_reduction_fraction::<Test>(10), Some(2));
+
+            // at Block 20, period is at 4
+            assert_eq!(increase_reduction_fraction::<Test>(20), Some(4));
+
+            // at Block 53, period is at 10, since 53/ReductionPeriod = 10 (nevermind the remainder)
+            assert_eq!(increase_reduction_fraction::<Test>(53), Some(10));
+
+            // at Block 42000, multiplication factor of the reduction fraction is way off. (nevermind the remainder)
+            assert_eq!(increase_reduction_fraction::<Test>(4200), None);
+        });
+    }
+
+    #[test]
+    fn get_block_author_reward_test() {
+        alice_test_ext().execute_with(|| {
+            // at Block 1, period is at 0, meaning no deduction of the reward.
+            assert_eq!(get_block_author_reward::<Test>(1), 100);
+
+            // at Block 2, period is still at 0, meaning no deduction of the reward.
+            assert_eq!(get_block_author_reward::<Test>(2), 100);
+
+            // at Block 5, a new period has started,
+            // meaning reward is deducted by RewardReductionFraction: 25% of 100
+            assert_eq!(get_block_author_reward::<Test>(5), 75);
+
+            // at Block 9, period is still at 1,
+            // meaning reward is deducted by RewardReductionFraction: 25% of 100
+            assert_eq!(get_block_author_reward::<Test>(9), 75);
+
+            // at Block 10, a new period has started,
+            // meaning reward is deducted by RewardReductionFraction: 25% twice.
+            assert_eq!(get_block_author_reward::<Test>(10), 50);
+
+            // at Block 12, period is still at 2,
+            // meaning reward is deducted by RewardReductionFraction: 25% twice.
+            assert_eq!(get_block_author_reward::<Test>(12), 50);
+
+            // at Block 20, a new period has started.
+            // With period set to 5, this makes Block 20 at period 4.
+            // meaning reward is deducted by RewardReductionFraction: 25% 4 times.. or by 100%.
+            // in testnet, when reduced reward approaches 0, the reward will become 1.
+            assert_eq!(get_block_author_reward::<Test>(20), 1);
+
+            // exceeds the reduction fraction of 100%, so reward is constantly at 1 based on testnet.
+            assert_eq!(get_block_author_reward::<Test>(68), 1);
+
+            // exceeds the reduction fraction of 100%, so reward is constantly at 1 based on testnet.
+            assert_eq!(get_block_author_reward::<Test>(5000), 1);
+        });
+    }
+}

--- a/pallets/utxo/src/staking.rs
+++ b/pallets/utxo/src/staking.rs
@@ -1,0 +1,407 @@
+// Copyright (c) 2021 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): C. Yap
+
+use crate::{
+    convert_to_h256, Config, Destination, Error, Event, LockedUtxos, Pallet, RewardTotal,
+    StakingCount, TransactionOutput, UtxoStore, Value,
+};
+use frame_support::{
+    dispatch::{DispatchResultWithPostInfo, Vec},
+    ensure, fail,
+    traits::Get,
+};
+use sp_core::H256;
+use sp_runtime::traits::{BlakeTwo256, Hash};
+use sp_runtime::transaction_validity::{TransactionLongevity, ValidTransaction};
+use sp_std::vec;
+
+use crate::staking::utils::remove_locked_utxos;
+pub use validation::*;
+
+/// A helper trait to handle staking NOT found in pallet-utxo.
+pub trait StakingHelper<AccountId> {
+    fn get_controller_account(stash_account: &AccountId) -> Result<AccountId, &'static str>;
+
+    fn is_controller_account_exist(controller_account: &AccountId) -> bool;
+
+    fn can_decode_session_key(session_key: &Vec<u8>) -> bool;
+
+    fn are_funds_locked(controller_account: &AccountId) -> bool;
+
+    fn check_accounts_matched(controller_account: &AccountId, stash_account: &AccountId) -> bool;
+
+    /// start the staking.
+    /// # Arguments
+    /// * `stash_account` - A placeholder of the "supposed" validator. This is only to "satisfy"
+    /// the `pallet-staking`'s needs to be able to stake.
+    /// * `controller_account` - The ACTUAL validator. But this is NOT SO, in the `pallet-staking`.
+    /// In `pallet-staking`, its job is like an "accountant" to the stash account.
+    /// * `session_key` - to get up-to-date with validators, eras, sessions. see `pallet-session`.
+    /// * `value` - the amount to stake/bond/stash
+    fn lock_for_staking(
+        stash_account: &AccountId,
+        controller_account: &AccountId,
+        session_key: &Vec<u8>,
+        value: Value,
+    ) -> DispatchResultWithPostInfo;
+
+    /// stake more funds for the validator
+    fn lock_extra_for_staking(
+        stash_account: &AccountId,
+        value: Value,
+    ) -> DispatchResultWithPostInfo;
+
+    fn unlock_request_for_withdrawal(stash_account: &AccountId) -> DispatchResultWithPostInfo;
+
+    /// transfer balance from the locked state to the actual free balance.
+    fn withdraw(stash_account: &AccountId) -> DispatchResultWithPostInfo;
+}
+
+/// Calls the outside staking logic to lock some funds
+/// Adds the transaction output to the `LockedUtxos` storage and `StakingCount` storage.
+pub(crate) fn lock_for_staking<T: Config>(
+    hash_key: H256,
+    output: &TransactionOutput<T::AccountId>,
+) -> DispatchResultWithPostInfo {
+    if let Destination::LockForStaking {
+        stash_account,
+        controller_account,
+        session_key,
+    } = &output.destination
+    {
+        T::StakingHelper::lock_for_staking(
+            stash_account,
+            controller_account,
+            session_key,
+            output.value,
+        )?;
+        return utils::add_to_locked_utxos::<T>(hash_key, output, stash_account);
+    }
+    fail!(Error::<T>::InvalidOperation)
+}
+
+/// For existing stakers who wants to add more utxos to lock.
+/// Also calls the outside staking logic to lock these extra funds.
+pub(crate) fn lock_extra_for_staking<T: Config>(
+    hash_key: H256,
+    output: &TransactionOutput<T::AccountId>,
+) -> DispatchResultWithPostInfo {
+    if let Destination::LockExtraForStaking {
+        stash_account,
+        controller_account: _,
+    } = &output.destination
+    {
+        T::StakingHelper::lock_extra_for_staking(stash_account, output.value)?;
+        return utils::add_to_locked_utxos::<T>(hash_key, output, stash_account);
+    }
+    fail!(Error::<T>::InvalidOperation)
+}
+
+/// unlocking the staked funds outside of the `pallet-utxo`.
+/// also means you don't want to be a validator anymore.
+pub(crate) fn unlock_request_for_withdrawal<T: Config>(
+    stash_account: T::AccountId,
+) -> DispatchResultWithPostInfo {
+    validate_unlock_request_for_withdrawal::<T>(&stash_account)?;
+
+    let res = T::StakingHelper::unlock_request_for_withdrawal(&stash_account)?;
+    <Pallet<T>>::deposit_event(Event::<T>::StakeUnlocked(stash_account));
+    Ok(res)
+}
+
+/// Consolidates all unlocked utxos  into one, and moves it to `UtxoStore`.
+/// Make SURE that `fn unlock(...)` has been called and the era for withdrawal has passed, before
+/// performing a withdrawal.
+pub(crate) fn withdraw<T: Config>(stash_account: T::AccountId) -> DispatchResultWithPostInfo {
+    validate_withdrawal::<T>(&stash_account)?;
+
+    let res = T::StakingHelper::withdraw(&stash_account)?;
+
+    let stash_pubkey = convert_to_h256::<T>(&stash_account)?;
+
+    // remove from the `StakingCount` storage
+    let (_, mut total) =
+        <StakingCount<T>>::take(stash_account.clone()).ok_or(Error::<T>::StashAccountNotFound)?;
+
+    let fee = T::StakeWithdrawalFee::get();
+    total = total
+        .checked_sub(fee)
+        .ok_or("Total amount of Locked UTXOs is less than minimum?")?;
+
+    let outpoints = remove_locked_utxos::<T>(&stash_account);
+    log::debug!(
+        "removed a total of {} in the LockedUtxo storage.",
+        outpoints.len()
+    );
+
+    let hash = BlakeTwo256::hash_of(&outpoints);
+    // move locked utxo back to UtxoStore
+    let utxo = TransactionOutput::new_pubkey(total, stash_pubkey);
+    <UtxoStore<T>>::insert(hash, utxo);
+
+    // insert the fee into the reward total
+    let reward_total = <RewardTotal<T>>::take();
+    <RewardTotal<T>>::put(reward_total + fee);
+
+    <Pallet<T>>::deposit_event(Event::<T>::StakeWithdrawn(total, stash_account));
+    Ok(res)
+}
+
+pub mod validation {
+    use super::*;
+    use crate::staking::utils::get_all_locked_utxo_outpoints;
+    use crate::{OutputHeaderHelper, TokenType, TransactionOutputFor};
+
+    /// to validate `LockForStaking` and `LockExtraForStaking`
+    pub fn validate_staking_ops<T: Config>(
+        tx: &TransactionOutputFor<T>,
+        hash_key: H256,
+    ) -> DispatchResultWithPostInfo {
+        ensure!(
+            !<LockedUtxos<T>>::contains_key(hash_key),
+            "output already exists in the LockedUtxos storage"
+        );
+
+        ensure!(
+            matches!(
+                tx.header.as_tx_output_header().token_type(),
+                Some(TokenType::MLT)
+            ),
+            "only MLT tokens are supported for staking"
+        );
+
+        // call individual validation functions
+        match &tx.destination {
+            Destination::LockForStaking {
+                stash_account,
+                controller_account,
+                session_key,
+            } => {
+                ensure!(
+                    tx.value >= T::MinimumStake::get(),
+                    "output value must be equal or more than the minimum stake"
+                );
+                validate_lock_for_staking_requirements::<T>(
+                    stash_account,
+                    controller_account,
+                    session_key,
+                )
+            }
+            Destination::LockExtraForStaking {
+                stash_account,
+                controller_account,
+            } => {
+                ensure!(tx.value > 0, "output value must be nonzero");
+                validate_lock_extra_for_staking_requirements::<T>(stash_account, controller_account)
+            }
+            _non_staking_destinations => {
+                fail!(Error::<T>::InvalidOperation)
+            }
+        }
+    }
+
+    /// Checks whether a transaction is valid to do `lock_for_staking`.
+    fn validate_lock_for_staking_requirements<T: Config>(
+        stash_account: &T::AccountId,
+        controller_account: &T::AccountId,
+        session_key: &Vec<u8>,
+    ) -> DispatchResultWithPostInfo {
+        // ---------- check for clearance INSIDE the utxo system. ----------
+        ensure!(
+            !<StakingCount<T>>::contains_key(stash_account.clone()),
+            Error::<T>::StashAccountAlreadyRegistered
+        );
+
+        // ---------- check for clearance OUTSIDE the utxo system. ----------
+        ensure!(
+            T::StakingHelper::can_decode_session_key(session_key),
+            "please input a valid session key."
+        );
+
+        ensure!(
+            !T::StakingHelper::is_controller_account_exist(stash_account),
+            "specified stash account is a controller account"
+        );
+
+        ensure!(
+            !T::StakingHelper::is_controller_account_exist(controller_account),
+            "specified controller account is already used."
+        );
+
+        Ok(().into())
+    }
+
+    /// Checks whether a transaction is valid to do extra locking of utxos for staking
+    fn validate_lock_extra_for_staking_requirements<T: Config>(
+        stash_account: &T::AccountId,
+        controller_account: &T::AccountId,
+    ) -> DispatchResultWithPostInfo {
+        ensure!(
+            <StakingCount<T>>::contains_key(stash_account),
+            Error::<T>::StashAccountNotFound
+        );
+
+        // if the funds are already unlocked, it means you should withdraw them first,
+        // then perform a `LockForStaking`.
+        ensure!(
+            T::StakingHelper::are_funds_locked(controller_account),
+            "Cannot perform locking of stake when pending unlocked funds are not withdrawn."
+        );
+
+        // the pair should match. 1 stash account has 1 controller account, and vice versa.
+        ensure!(
+            T::StakingHelper::check_accounts_matched(controller_account, stash_account),
+            "the provided account pairs do not match."
+        );
+
+        Ok(().into())
+    }
+
+    /// Checks whether unlock request is allowed.
+    pub(crate) fn validate_unlock_request_for_withdrawal<T: Config>(
+        stash_account: &T::AccountId,
+    ) -> DispatchResultWithPostInfo {
+        ensure!(
+            <StakingCount<T>>::contains_key(stash_account.clone()),
+            Error::<T>::StashAccountNotFound
+        );
+
+        let controller_account = T::StakingHelper::get_controller_account(stash_account)?;
+
+        // unlock operation is allowed ONLY for locked funds.
+        ensure!(
+            T::StakingHelper::are_funds_locked(&controller_account),
+            Error::<T>::FundsAtUnlockedState
+        );
+
+        Ok(().into())
+    }
+
+    /// It includes:
+    /// 1. Check if the pub key is a controller.
+    /// 2. Checking the number of outpoints owned by the given pub key
+    /// 3. Checking each outpoints if they are indeed owned by the pub key
+    /// Returns a Result with an empty Ok, or an Err in string.
+    pub fn validate_withdrawal<T: Config>(
+        stash_account: &T::AccountId,
+    ) -> Result<ValidTransaction, &'static str> {
+        ensure!(
+            <StakingCount<T>>::contains_key(stash_account),
+            Error::<T>::StashAccountNotFound
+        );
+
+        let (num_of_utxos, _) = <StakingCount<T>>::get(stash_account.clone())
+            .ok_or("cannot find the stash account inside the StakingCount storage")?;
+
+        let outpoints = get_all_locked_utxo_outpoints::<T>(stash_account);
+
+        ensure!(
+            num_of_utxos == outpoints.len() as u64,
+            "Unsynced actual locked utxos from the expected count."
+        );
+
+        let controller_account = T::StakingHelper::get_controller_account(stash_account)?;
+        // if the funds are already unlocked, it means you should withdraw them first,
+        // then perform a `LockForStaking`.
+        ensure!(
+            !T::StakingHelper::are_funds_locked(&controller_account),
+            "Funds are still locked. Perform `unlock_request_for_withdrawal` first."
+        );
+
+        let new_hash = BlakeTwo256::hash_of(&outpoints).as_fixed_bytes().to_vec();
+
+        Ok(ValidTransaction {
+            priority: 1,
+            requires: vec![],
+            provides: vec![new_hash],
+            longevity: TransactionLongevity::MAX,
+            propagate: true,
+        })
+    }
+}
+
+mod utils {
+    use super::*;
+    use sp_runtime::DispatchError;
+
+    /// Retrieves all the outpoints owned by the given stash acount.
+    // TODO: keep track of "our" Locked UTXO separately?
+    pub fn get_all_locked_utxo_outpoints<T: Config>(stash_acc: &T::AccountId) -> Vec<H256> {
+        LockedUtxos::<T>::iter()
+            .filter_map(|(k, v)| match v.destination {
+                Destination::LockForStaking {
+                    stash_account,
+                    controller_account: _,
+                    session_key: _,
+                }
+                | Destination::LockExtraForStaking {
+                    stash_account,
+                    controller_account: _,
+                } => {
+                    if *stash_acc == stash_account {
+                        Some(k)
+                    } else {
+                        None
+                    }
+                }
+                _non_staking_destination => None,
+            })
+            .collect()
+    }
+
+    /// removes all locked utxos of the given stash_account.
+    /// returns the list of outpoints removed from the `LockedUtxo` storage
+    pub fn remove_locked_utxos<T: Config>(stash_account: &T::AccountId) -> Vec<H256> {
+        let outpoints = get_all_locked_utxo_outpoints::<T>(stash_account);
+        for k in &outpoints {
+            LockedUtxos::<T>::remove(*k)
+        }
+
+        outpoints
+    }
+
+    /// adds to the `LockedUtxo` storage
+    /// add to the `StakingCount` storage
+    pub fn add_to_locked_utxos<T: Config>(
+        hash_key: H256,
+        output: &TransactionOutput<T::AccountId>,
+        stash_account: &T::AccountId,
+    ) -> DispatchResultWithPostInfo {
+        log::debug!("Locking utxo({:?}) of stash {:?}", hash_key, stash_account);
+        let (num_of_utxos, total) = <StakingCount<T>>::get(stash_account).unwrap_or((0, 0));
+        <StakingCount<T>>::insert(
+            stash_account.clone(),
+            (
+                num_of_utxos.checked_add(1).ok_or(DispatchError::Other(
+                    "exceeded limit of total number of utxos locked",
+                ))?,
+                total
+                    .checked_add(output.value)
+                    .ok_or(DispatchError::Other("exceeded limit of total utxos locked"))?,
+            ),
+        );
+
+        log::debug!(
+            "inserting to LockedUtxos {:?} as key {:?}",
+            output,
+            hash_key
+        );
+        <LockedUtxos<T>>::insert(hash_key, output);
+
+        Ok(().into())
+    }
+}

--- a/pallets/utxo/src/staking_tests.rs
+++ b/pallets/utxo/src/staking_tests.rs
@@ -1,0 +1,340 @@
+// Copyright (c) 2021 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): C. Yap
+
+use crate::{
+    mock::*, Destination, Error, LockedUtxos, StakingCount, Transaction, TransactionInput,
+    TransactionOutput, UtxoStore,
+};
+use codec::Encode;
+use frame_support::{assert_err, assert_ok, sp_io::crypto};
+use sp_core::{sp_std::vec, testing::SR25519, H256};
+
+#[test]
+fn simple_staking() {
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+        let (karl_pub_key, karl_genesis) = keys_and_hashes[1];
+        let (alice_pub_key, _) = keys_and_hashes[0];
+        let (greg_pub_key, _) = keys_and_hashes[2];
+
+        let utxo = UtxoStore::<Test>::get(karl_genesis).expect("tom's utxo does not exist");
+
+        let tx = Transaction {
+            inputs: vec![TransactionInput::new_empty(karl_genesis)],
+            outputs: vec![
+                // KARL (index 1) wants to be a validator. He will use GREG (index 2) as the controller account.
+                // minimum value to stake is 10,
+                TransactionOutput::new_lock_for_staking(
+                    10,
+                    H256::from(karl_pub_key),
+                    H256::from(greg_pub_key),
+                    vec![2, 1],
+                ),
+                TransactionOutput::new_pubkey(90, H256::from(karl_pub_key)),
+            ],
+            time_lock: Default::default(),
+        }
+        .sign(&[utxo], 0, &karl_pub_key)
+        .expect("karl's pub key not found");
+        let locked_utxo_hash = tx.outpoint(0);
+        let new_utxo_hash = tx.outpoint(1);
+
+        assert_ok!(Utxo::spend(Origin::signed(H256::zero()), tx));
+        assert!(UtxoStore::<Test>::contains_key(new_utxo_hash));
+        assert!(LockedUtxos::<Test>::contains_key(locked_utxo_hash));
+        assert!(StakingCount::<Test>::contains_key(H256::from(
+            alice_pub_key
+        )));
+        assert!(StakingCount::<Test>::contains_key(H256::from(karl_pub_key)));
+        assert_eq!(
+            StakingCount::<Test>::get(H256::from(karl_pub_key)),
+            Some((1, 10))
+        );
+    })
+}
+
+#[test]
+fn less_than_minimum_stake() {
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+        let (karl_pub_key, karl_genesis) = keys_and_hashes[1];
+        let (greg_pub_key, _) = keys_and_hashes[2];
+        let mut tx = Transaction {
+            inputs: vec![TransactionInput::new_empty(karl_genesis)],
+            outputs: vec![
+                // KARL (index 1) wants to be a validator. He will use GREG (index 2) as the controller account.
+                // minimum value to stake is 10, but KARL only staked 5.
+                TransactionOutput::new_lock_for_staking(
+                    5,
+                    H256::from(karl_pub_key),
+                    H256::from(greg_pub_key),
+                    vec![2, 1],
+                ),
+                TransactionOutput::new_pubkey(90, H256::from(karl_pub_key)),
+            ],
+            time_lock: Default::default(),
+        };
+        let karl_sig = crypto::sr25519_sign(SR25519, &karl_pub_key, &tx.encode()).unwrap();
+        tx.inputs[0].witness = karl_sig.0.to_vec();
+
+        assert_err!(
+            Utxo::spend(Origin::signed(H256::zero()), tx),
+            "output value must be equal or more than the minimum stake"
+        );
+    })
+}
+
+#[test]
+fn non_mlt_staking() {
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+        let (karl_pub_key, karl_genesis) = keys_and_hashes[1];
+        let (greg_pub_key, _) = keys_and_hashes[2];
+        let mut tx = Transaction {
+            inputs: vec![TransactionInput::new_empty(karl_genesis)],
+            outputs: vec![
+                // KARL (index 1) wants to be a validator. He will use GREG (index 2) as the controller account.
+                // minimum value to stake is 10, but KARL only staked 5.
+                TransactionOutput {
+                    value: 5,
+                    header: 1, // not an MLT token
+                    destination: Destination::LockForStaking {
+                        stash_account: H256::from(karl_pub_key),
+                        controller_account: H256::from(greg_pub_key),
+                        session_key: vec![2, 1],
+                    },
+                },
+                TransactionOutput::new_pubkey(90, H256::from(karl_pub_key)),
+            ],
+            time_lock: Default::default(),
+        };
+        let karl_sig = crypto::sr25519_sign(SR25519, &karl_pub_key, &tx.encode()).unwrap();
+        tx.inputs[0].witness = karl_sig.0.to_vec();
+
+        assert_err!(
+            Utxo::spend(Origin::signed(H256::zero()), tx),
+            "only MLT tokens are supported for staking"
+        );
+    })
+}
+
+#[test]
+fn controller_staking_again() {
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+        let (tom_pub_key, tom_genesis) = keys_and_hashes[0];
+        let (greg_pub_key, _) = keys_and_hashes[2];
+        let utxo = UtxoStore::<Test>::get(tom_genesis).expect("alice's utxo does not exist");
+        let tx = Transaction {
+            inputs: vec![TransactionInput::new_empty(tom_genesis)],
+            outputs: vec![
+                // ALICE (index 0) wants to stake again. He will use GREG (index 2) as the controller account.
+                TransactionOutput::new_lock_for_staking(
+                    10,
+                    H256::from(tom_pub_key),
+                    H256::from(greg_pub_key),
+                    vec![2, 0],
+                ),
+                TransactionOutput::new_pubkey(90, H256::from(tom_pub_key)),
+            ],
+            time_lock: Default::default(),
+        }
+        .sign(&[utxo], 0, &tom_pub_key)
+        .expect(" tom's pub key not found");
+
+        assert_err!(
+            Utxo::spend(Origin::signed(H256::zero()), tx),
+            "StashAccountAlreadyRegistered"
+        );
+    })
+}
+
+#[test]
+fn stash_account_is_staking() {
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+        let (alice_pub_key, alice_genesis) = keys_and_hashes[0];
+        let (greg_pub_key, _) = keys_and_hashes[2];
+
+        let utxo = UtxoStore::<Test>::get(alice_genesis).expect("alice's utxo does not exist");
+        let tx = Transaction {
+            inputs: vec![TransactionInput::new_empty(alice_genesis)],
+            outputs: vec![
+                // ALice (index 3) wants to stake. But he's a stash account already!
+                TransactionOutput::new_lock_for_staking(
+                    10,
+                    H256::from(alice_pub_key),
+                    H256::from(greg_pub_key),
+                    vec![2, 3],
+                ),
+                TransactionOutput::new_pubkey(90, H256::from(alice_pub_key)),
+            ],
+            time_lock: Default::default(),
+        }
+        .sign(&[utxo.clone()], 0, &alice_pub_key)
+        .expect("alice's public key not found");
+
+        assert_err!(
+            Utxo::spend(Origin::signed(H256::zero()), tx),
+            "StashAccountAlreadyRegistered"
+        );
+    })
+}
+
+#[test]
+fn simple_staking_extra() {
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+        let (alice_pub_key, alice_genesis) = keys_and_hashes[0];
+        let (tom_pub_key, _) = keys_and_hashes[3];
+        let utxo = UtxoStore::<Test>::get(alice_genesis).expect("alice's utxo does not exist");
+        let tx = Transaction {
+            inputs: vec![TransactionInput::new_empty(alice_genesis)],
+            outputs: vec![
+                // ALICE (index 0) wants to add extra stake.
+                TransactionOutput::new_lock_extra_for_staking(
+                    20,
+                    H256::from(alice_pub_key),
+                    H256::from(tom_pub_key),
+                ),
+                TransactionOutput::new_pubkey(70, H256::from(alice_pub_key)),
+            ],
+            time_lock: Default::default(),
+        }
+        .sign(&[utxo], 0, &alice_pub_key)
+        .expect(" alice's pub key not found");
+
+        let locked_utxo_hash = tx.outpoint(0);
+        let new_utxo_hash = tx.outpoint(1);
+
+        assert_ok!(Utxo::spend(Origin::signed(H256::zero()), tx));
+        assert!(UtxoStore::<Test>::contains_key(new_utxo_hash));
+        assert!(LockedUtxos::<Test>::contains_key(locked_utxo_hash));
+        assert_eq!(
+            StakingCount::<Test>::get(H256::from(alice_pub_key)),
+            Some((2, 30))
+        );
+    })
+}
+
+#[test]
+fn non_validator_staking_extra() {
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+        let (greg_pub_key, greg_genesis) = keys_and_hashes[2];
+        let (karl_pub_key, _) = keys_and_hashes[1];
+
+        let utxo = UtxoStore::<Test>::get(greg_genesis).expect("tom's utxo does not exist");
+
+        let tx = Transaction {
+            inputs: vec![TransactionInput::new_empty(greg_genesis)],
+            outputs: vec![
+                // GREG (index 2) wants to stake extra funds. But he's not a validator...
+                TransactionOutput::new_lock_extra_for_staking(
+                    20,
+                    H256::from(greg_pub_key),
+                    H256::from(karl_pub_key),
+                ),
+                TransactionOutput::new_pubkey(100, H256::from(greg_pub_key)),
+            ],
+            time_lock: Default::default(),
+        }
+        .sign(&[utxo], 0, &greg_pub_key)
+        .expect("greg's pub key not found");
+
+        assert_err!(
+            Utxo::spend(Origin::signed(H256::zero()), tx),
+            "StashAccountNotFound"
+        );
+    })
+}
+
+#[test]
+fn pausing_and_withdrawing() {
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+        let mut alice_locked_utxo: Vec<H256> =
+            LockedUtxos::<Test>::iter().map(|(key, _)| key).collect();
+        let alice_locked_utxo = alice_locked_utxo.pop().unwrap();
+
+        // ALICE (index 0) wants to stop validating.
+        let (alice_pub_key, _) = keys_and_hashes[0];
+
+        assert_ok!(Utxo::unlock_request_for_withdrawal(Origin::signed(
+            H256::from(alice_pub_key)
+        ),));
+
+        // increase the block number 6 times, as if new blocks has been created.
+        for _ in 1..6 {
+            next_block();
+        }
+        assert_ok!(Utxo::withdraw_stake(Origin::signed(H256::from(
+            alice_pub_key
+        ))));
+
+        assert!(!LockedUtxos::<Test>::contains_key(alice_locked_utxo));
+    })
+}
+
+#[test]
+fn non_validator_pausing() {
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+        let (karl_pub_key, _) = keys_and_hashes[1];
+        assert_err!(
+            Utxo::unlock_request_for_withdrawal(Origin::signed(H256::from(karl_pub_key)),),
+            Error::<Test>::StashAccountNotFound
+        );
+    })
+}
+
+#[test]
+fn non_validator_withdrawing() {
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+        let (karl_pub_key, _) = keys_and_hashes[1];
+
+        assert_err!(
+            Utxo::withdraw_stake(Origin::signed(H256::from(karl_pub_key))),
+            "StashAccountNotFound"
+        );
+    })
+}
+
+#[test]
+fn withdrawing_before_expected_period() {
+    let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
+    test_ext.execute_with(|| {
+        let mut alice_locked_utxo: Vec<H256> =
+            LockedUtxos::<Test>::iter().map(|(key, _)| key).collect();
+
+        // ALICE (index 0) wants to stop validating.
+        let (alice_pub_key, _) = keys_and_hashes[0];
+
+        assert_ok!(Utxo::unlock_request_for_withdrawal(Origin::signed(
+            H256::from(alice_pub_key)
+        )));
+
+        // ALICE is not waiting for the withdrawal period.
+        assert_err!(
+            Utxo::withdraw_stake(Origin::signed(H256::from(alice_pub_key))),
+            "not yet time to withdraw"
+        );
+    })
+}
+
+//TODO: add more test scenarios

--- a/pallets/utxo/src/staking_tests.rs
+++ b/pallets/utxo/src/staking_tests.rs
@@ -319,8 +319,6 @@ fn non_validator_withdrawing() {
 fn withdrawing_before_expected_period() {
     let (mut test_ext, keys_and_hashes) = multiple_keys_test_ext();
     test_ext.execute_with(|| {
-        let mut alice_locked_utxo: Vec<H256> =
-            LockedUtxos::<Test>::iter().map(|(key, _)| key).collect();
 
         // ALICE (index 0) wants to stop validating.
         let (alice_pub_key, _) = keys_and_hashes[0];

--- a/pallets/utxo/src/tests.rs
+++ b/pallets/utxo/src/tests.rs
@@ -40,7 +40,7 @@ fn execute_with_alice<F, R>(mut execute: F) -> R
 where
     F: FnMut(Public) -> R,
 {
-    new_test_ext().execute_with(|| {
+    alice_test_ext().execute_with(|| {
         let alice_pub_key = crypto::sr25519_public_keys(SR25519)[0];
         execute(alice_pub_key)
     })
@@ -149,7 +149,7 @@ fn test_simple_tx() {
 
 #[test]
 fn attack_with_sending_to_own_account() {
-    let (mut test_ext, _alice, karl_pub_key) = new_test_ext_and_keys();
+    let (mut test_ext, _alice, karl_pub_key) = alice_test_ext_and_keys();
     test_ext.execute_with(|| {
         // Karl wants to send himself a new utxo of value 50 out of thin air.
         let mut tx = Transaction {
@@ -170,7 +170,7 @@ fn attack_with_sending_to_own_account() {
 
 #[test]
 fn attack_with_empty_transactions() {
-    new_test_ext().execute_with(|| {
+    alice_test_ext().execute_with(|| {
         assert_err!(
             Utxo::spend(Origin::signed(H256::zero()), Transaction::default()), // empty tx
             "no inputs"
@@ -296,7 +296,7 @@ fn attack_by_overspending() {
 // then send the rest of the tokens to karl
 #[test]
 fn tx_from_alice_to_karl() {
-    let (mut test_ext, alice_pub_key, karl_pub_key) = new_test_ext_and_keys();
+    let (mut test_ext, alice_pub_key, karl_pub_key) = alice_test_ext_and_keys();
     test_ext.execute_with(|| {
         // alice sends 10 tokens to karl and the rest back to herself
         let (utxo0, input0) = tx_input_gen_no_signature();
@@ -415,7 +415,7 @@ fn test_time_lock_script_fail() {
 fn test_tokens() {
     use crate::TokensHigherID;
 
-    let (mut test_ext, alice_pub_key, karl_pub_key) = new_test_ext_and_keys();
+    let (mut test_ext, alice_pub_key, karl_pub_key) = alice_test_ext_and_keys();
     test_ext.execute_with(|| {
         // Let's create a new test token
         let token_id = <TokensHigherID<Test>>::get()
@@ -509,7 +509,7 @@ fn attack_double_spend_by_tweaking_input() {
 
 #[test]
 fn test_send_to_address() {
-    let (mut test_ext, alice_pub_key, _karl_pub_key) = new_test_ext_and_keys();
+    let (mut test_ext, alice_pub_key, _karl_pub_key) = alice_test_ext_and_keys();
     test_ext.execute_with(|| {
         // `addr` is bech32-encoded, SCALE-encoded `Destination::Pubkey(alice_pub_key)`
         let addr = "ml1qrft7juyfhl06emj4zzrue5ljs6q39n2jalr4c40rhtcur647n0kwueyfsn";

--- a/pallets/utxo/src/weights.rs
+++ b/pallets/utxo/src/weights.rs
@@ -57,4 +57,22 @@ impl<T: frame_system::Config> crate::WeightInfo for WeightInfo<T> {
             .saturating_add(T::DbWeight::get().reads(3 as Weight))
             .saturating_add(T::DbWeight::get().writes(3 as Weight))
     }
+
+    //TODO this needs a benchmark
+    fn unlock_request_for_withdrawal(s: u32) -> Weight {
+        (548_270_000 as Weight)
+            //TODO: literally just copying from substrate's
+            .saturating_add((1_146_000 as Weight).saturating_mul(s as Weight))
+            .saturating_add(T::DbWeight::get().reads(3 as Weight))
+            .saturating_add(T::DbWeight::get().writes(3 as Weight))
+    }
+
+    //TODO this needs a benchmark
+    fn withdraw_stake(s: u32) -> Weight {
+        (548_270_000 as Weight)
+            //TODO: literally just copying from substrate's
+            .saturating_add((1_146_000 as Weight).saturating_mul(s as Weight))
+            .saturating_add(T::DbWeight::get().reads(3 as Weight))
+            .saturating_add(T::DbWeight::get().writes(3 as Weight))
+    }
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -16,6 +16,7 @@ version = '5.0.0-dev'
 branch = "master"
 
 [dependencies]
+log = "0.4.14"
 pallet-utxo-tokens = { path = "../pallets/utxo/tokens" }
 
 [dependencies.codec]
@@ -30,6 +31,12 @@ git = 'https://github.com/paritytech/substrate.git'
 optional = true
 branch = "master"
 version = '4.0.0-dev'
+
+[dependencies.frame-election-provider-support]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+version = '4.0.0-dev'
+branch = "master"
 
 [dependencies.frame-executive]
 default-features = false
@@ -72,6 +79,12 @@ git = 'https://github.com/paritytech/substrate.git'
 version = '4.0.0-dev'
 branch = "master"
 
+[dependencies.pallet-authorship]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+version = '4.0.0-dev'
+branch = "master"
+
 [dependencies.pallet-balances]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
@@ -85,6 +98,18 @@ version = '4.0.0-dev'
 branch = "master"
 
 [dependencies.pallet-randomness-collective-flip]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+version = '4.0.0-dev'
+branch = "master"
+
+[dependencies.pallet-session]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+version = '4.0.0-dev'
+branch = "master"
+
+[dependencies.pallet-staking]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 version = '4.0.0-dev'
@@ -157,6 +182,12 @@ branch = "master"
 version = '4.0.0-dev'
 
 [dependencies.sp-session]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+version = '4.0.0-dev'
+branch = "master"
+
+[dependencies.sp-staking]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
 version = '4.0.0-dev'
@@ -237,9 +268,12 @@ std = [
     'frame-system-rpc-runtime-api/std',
     'frame-system/std',
     'pallet-aura/std',
+    'pallet-authorship/std',
     'pallet-balances/std',
     'pallet-grandpa/std',
     'pallet-randomness-collective-flip/std',
+    'pallet-session/std',
+    'pallet-staking/std',
     'pallet-sudo/std',
     'pallet-template/std',
     'pallet-timestamp/std',
@@ -257,6 +291,7 @@ std = [
     'sp-offchain/std',
     'sp-runtime/std',
     'sp-session/std',
+    'sp-staking/std',
     'sp-std/std',
     'sp-transaction-pool/std',
     'sp-version/std',

--- a/runtime/src/staking.rs
+++ b/runtime/src/staking.rs
@@ -1,0 +1,223 @@
+// Copyright (c) 2021 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://spdx.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author(s): C. Yap
+
+use crate::Perbill;
+
+use codec::Decode;
+use frame_support::dispatch::{DispatchResult, DispatchResultWithPostInfo, Vec};
+use frame_support::fail;
+use frame_system::{Config as SysConfig, RawOrigin};
+use pallet_staking::{BalanceOf, Pallet as StakingPallet};
+use pallet_utxo::staking::StakingHelper;
+use sp_core::sp_std::vec;
+use sp_runtime::traits::StaticLookup;
+
+type StakeAccountId<T> = <T as SysConfig>::AccountId;
+type LookupSourceOf<T> = <<T as SysConfig>::Lookup as StaticLookup>::Source;
+
+pub struct StakeOps<T>(sp_core::sp_std::marker::PhantomData<T>);
+
+impl<T: pallet_staking::Config + pallet_utxo::Config + pallet_session::Config> StakeOps<T>
+where
+    StakeAccountId<T>: From<[u8; 32]>,
+    BalanceOf<T>: From<u128>,
+{
+    fn get_stash_account(
+        controller_account: StakeAccountId<T>,
+    ) -> Result<StakeAccountId<T>, pallet_utxo::Error<T>> {
+        match <StakingPallet<T>>::ledger(controller_account.clone()) {
+            None => {
+                log::debug!("check sync with pallet-staking.");
+                return Err(pallet_utxo::Error::<T>::ControllerAccountNotFound)?;
+            }
+            Some(stake_ledger) => Ok(stake_ledger.stash),
+        }
+    }
+
+    fn bond(
+        controller_account: StakeAccountId<T>,
+        stash_account: StakeAccountId<T>,
+        value: pallet_utxo::Value,
+    ) -> DispatchResult {
+        let controller_lookup: LookupSourceOf<T> = T::Lookup::unlookup(controller_account.clone());
+        let reward_destination = pallet_staking::RewardDestination::Staked;
+
+        // bond the funds
+        StakingPallet::<T>::bond(
+            RawOrigin::Signed(stash_account.clone()).into(),
+            controller_lookup,
+            value.into(),
+            reward_destination,
+        )
+    }
+
+    fn unbond(controller_account: StakeAccountId<T>) -> DispatchResult {
+        let stake_ledger = <StakingPallet<T>>::ledger(controller_account.clone())
+            .ok_or(pallet_utxo::Error::<T>::ControllerAccountNotFound)?;
+
+        StakingPallet::<T>::unbond(
+            RawOrigin::Signed(controller_account).into(),
+            stake_ledger.total,
+        )
+    }
+
+    fn set_session_keys(
+        controller_account: StakeAccountId<T>,
+        session_key: &Vec<u8>,
+    ) -> DispatchResult {
+        // session keys
+        let sesh_key = <T as pallet_session::Config>::Keys::decode(&mut &session_key[..])
+            .expect("SessionKeys decoded successfully");
+        pallet_session::Pallet::<T>::set_keys(
+            RawOrigin::Signed(controller_account).into(),
+            sesh_key,
+            vec![],
+        )
+    }
+
+    fn apply_for_validator_role(controller_account: StakeAccountId<T>) -> DispatchResult {
+        let validator_prefs = pallet_staking::ValidatorPrefs {
+            commission: Perbill::from_percent(0),
+            ..Default::default()
+        };
+
+        // applying for the role of "validator".
+        StakingPallet::<T>::validate(
+            RawOrigin::Signed(controller_account).into(),
+            validator_prefs,
+        )
+    }
+}
+
+impl<T: pallet_staking::Config + pallet_utxo::Config + pallet_session::Config>
+    StakingHelper<T::AccountId> for StakeOps<T>
+where
+    StakeAccountId<T>: From<[u8; 32]>,
+    BalanceOf<T>: From<u128>,
+{
+    fn get_controller_account(
+        stash_account: &StakeAccountId<T>,
+    ) -> Result<StakeAccountId<T>, &'static str> {
+        <StakingPallet<T>>::bonded(stash_account.clone())
+            .ok_or(pallet_utxo::Error::<T>::StashAccountNotFound.into())
+    }
+
+    fn is_controller_account_exist(controller_account: &StakeAccountId<T>) -> bool {
+        Self::get_stash_account(controller_account.clone()).is_ok()
+    }
+
+    fn can_decode_session_key(session_key: &Vec<u8>) -> bool {
+        <T as pallet_session::Config>::Keys::decode(&mut &session_key[..]).is_ok()
+    }
+
+    fn are_funds_locked(controller_account: &StakeAccountId<T>) -> bool {
+        // Information of unlocked funds are found in the `pallet-staking` ledger.
+        // The ledger is stored as a map, with the controller_account as the key.
+        match <StakingPallet<T>>::ledger(controller_account.clone()) {
+            None => {
+                log::error!("Controller account {:?} not found", controller_account);
+            }
+            Some(stake_ledger) => {
+                if stake_ledger.unlocking.is_empty() {
+                    return true;
+                } else if stake_ledger.unlocking.len() > 1 {
+                    log::error!(
+                        "Pallet-staking ledger's unlocking field should only contain ONE element."
+                    );
+                }
+            }
+        }
+        false
+    }
+
+    fn check_accounts_matched(
+        controller_account: &StakeAccountId<T>,
+        stash_account: &StakeAccountId<T>,
+    ) -> bool {
+        if let Ok(ledger_stash_acc) = Self::get_stash_account(controller_account.clone()) {
+            if stash_account == &ledger_stash_acc {
+                return true;
+            }
+        }
+        log::error!(
+            "Make sure to match correctly the stash account {:?} with the controller account.",
+            stash_account
+        );
+
+        false
+    }
+
+    fn lock_for_staking(
+        stash_account: &StakeAccountId<T>,
+        controller_account: &StakeAccountId<T>,
+        session_key: &Vec<u8>,
+        value: u128,
+    ) -> DispatchResultWithPostInfo {
+        Self::bond(controller_account.clone(), stash_account.clone(), value)?;
+        Self::set_session_keys(controller_account.clone(), session_key)?;
+        Self::apply_for_validator_role(controller_account.clone())?;
+
+        Ok(().into())
+    }
+
+    fn lock_extra_for_staking(
+        stash_account: &StakeAccountId<T>,
+        value: u128,
+    ) -> DispatchResultWithPostInfo {
+        StakingPallet::<T>::bond_extra(
+            RawOrigin::Signed(stash_account.clone()).into(),
+            value.into(),
+        )?;
+
+        Ok(().into())
+    }
+
+    fn unlock_request_for_withdrawal(
+        stash_account: &StakeAccountId<T>,
+    ) -> DispatchResultWithPostInfo {
+        // get the controller account, given the stash_account.
+        let controller_account = <StakingPallet<T>>::bonded(stash_account.clone())
+            .ok_or(pallet_utxo::Error::<T>::StashAccountNotFound)?;
+
+        // stop validating / block producing
+        StakingPallet::<T>::chill(RawOrigin::Signed(controller_account.clone()).into())?;
+
+        // unbond
+        Self::unbond(controller_account)?;
+
+        Ok(().into())
+    }
+
+    fn withdraw(stash_account: &StakeAccountId<T>) -> DispatchResultWithPostInfo {
+        // get the controller account, given the stash_account.
+        let controller_account = <StakingPallet<T>>::bonded(stash_account.clone())
+            .ok_or(pallet_utxo::Error::<T>::StashAccountNotFound)?;
+
+        let res = StakingPallet::<T>::withdraw_unbonded(
+            RawOrigin::Signed(controller_account.clone()).into(),
+            0,
+        )?;
+
+        // if the staking still exists, withdrawal was unsuccessful.
+        if <StakingPallet<T>>::ledger(controller_account).is_some() {
+            log::error!("no withdrawal was done.");
+            fail!(pallet_utxo::Error::<T>::InvalidOperation)
+        }
+
+        Ok(res)
+    }
+}

--- a/test/functional/custom-types.json
+++ b/test/functional/custom-types.json
@@ -17,12 +17,30 @@
 				[ "input_data", "Vec<u8>" ]
 			]
 		},
+		"DestinationStake": {
+			"type": "struct",
+			"type_mapping": [
+				[ "stash_account", "AccountId" ],
+				[ "controller_account", "AccountId" ],
+				[ "session_key", "Vec<u8>" ]
+			]
+		},
+		"DestinationStakeExtra": {
+			"type": "struct",
+			"type_mapping": [
+				[ "stash_account", "AccountId" ],
+				[ "controller_account", "AccountId" ]
+			]
+		},
 		"Destination": {
 			"type": "enum",
 			"type_mapping": [
 				[ "Pubkey", "Pubkey" ],
 				[ "CreatePP", "DestinationCreatePP" ],
-				[ "CallPP", "DestinationCallPP" ]
+				[ "CallPP", "DestinationCallPP" ],
+				[ "ScriptHash", "H256"],
+				[ "LockForStaking", "DestinationStake" ],
+				[ "LockExtraForStaking", "DestinationStakeExtra" ]
 			]
 		},
 		"TransactionInput": {
@@ -74,6 +92,7 @@
 			]
 		},
 		"Pubkey": "H256",
+		"Public": "H256",
 		"SignatureData": {
 			"type": "struct",
 			"type_mapping": [

--- a/test/functional/feature_smart_contract_test.py
+++ b/test/functional/feature_smart_contract_test.py
@@ -92,7 +92,7 @@ class ExampleTest(MintlayerTestFramework):
         ).sign(alice, [initial_utxo[1]])
 
         # submit transaction and get the extrinsic and block hashes
-        (ext, blk) = client.submit(alice, tx0)
+        (ext, blk,_) = client.submit(alice, tx0)
 
         # each new smart contract instantiation creates a new account
         # fetch this SS58-formatted account address and return it
@@ -136,7 +136,7 @@ class ExampleTest(MintlayerTestFramework):
                 ),
             ]
         ).sign(alice, [tx0.outputs[0]], [0])
-        (ext_hash, blk_hash) = client.submit(alice, tx1)
+        (ext_hash, blk_hash,_) = client.submit(alice, tx1)
 
         result = contractInstance.read(alice, "get")
         assert_equal(result.contract_result_data.value, True)

--- a/test/functional/feature_staking_diff_addresses.py
+++ b/test/functional/feature_staking_diff_addresses.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""An example functional test
+
+Using Alice's utxo,  Charlie and Dave stakes for the first time.
+"""
+
+from substrateinterface import Keypair
+import test_framework.mintlayer.utxo as utxo
+
+from test_framework.test_framework import MintlayerTestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    wait_until,
+)
+from test_framework.messages import COIN
+
+
+class ExampleTest(MintlayerTestFramework):
+    # Each functional test is a subclass of the MintlayerTestFramework class.
+
+    # Override the set_test_params(), add_options(), setup_chain(), setup_network()
+    # and setup_nodes() methods to customize the test setup as required.
+
+    def set_test_params(self):
+        """Override test parameters for your individual test.
+
+        This method must be overridden and num_nodes must be exlicitly set."""
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        # Use self.extra_args to change command-line arguments for the nodes
+        self.extra_args = [['--alice'],['--bob']]
+
+        # self.log.info("I've finished set_test_params")  # Oops! Can't run self.log before run_test()
+
+    def setup_network(self):
+        """Setup the test network topology
+
+        Often you won't need to override this, since the standard network topology
+        (linear: node0 <-> node1 <-> node2 <-> ...) is fine for most tests.
+
+        If you do override this method, remember to start the nodes, assign
+        them to self.nodes, connect them and then sync."""
+
+        self.setup_nodes()
+
+    def custom_method(self):
+        """Do some custom behaviour for this test
+
+        Define it in a method here because you're going to use it repeatedly.
+        If you think it's useful in general, consider moving it to the base
+        MintlayerTestFramework class so other tests can use it."""
+
+        self.log.info("Running custom_method")
+
+    def run_test(self):
+        client = self.nodes[0].rpc_client
+
+        alice = Keypair.create_from_uri('//Alice')
+
+        charlie = Keypair.create_from_uri('//Charlie')
+        charlie_stash = Keypair.create_from_uri('//Charlie//stash')
+
+        dave = Keypair.create_from_uri('//Dave')
+        dave_stash = Keypair.create_from_uri('//Dave//stash')
+
+        # fetch the genesis utxo from storage
+        utxos = list(client.utxos_for(alice))
+
+        # there's only 2 record of staking, which are alice and bob.
+        assert_equal( len(list(client.staking_count())), 2 )
+
+        # charlie and dave are funded from alice but directly as stakers.
+        tx1 = utxo.Transaction(
+            client,
+            inputs=[
+                utxo.Input(utxos[0][0]),
+            ],
+            outputs=[
+                 utxo.Output(
+                    value=40000 * COIN,
+                    header=0,
+                    destination=utxo.DestLockForStaking(charlie_stash.public_key, charlie.public_key,'0x7e0dd8c53a47b22451dc3a73b29d72a2ce1405a4191f3c31ff927fea7b0514182f81ffc984364cc85499595eaefc509a06710c5277dcd22ebd7464917dfd9230')
+                ),
+                utxo.Output(
+                    value=40001 * COIN,
+                    header=0,
+                    destination=utxo.DestLockForStaking(dave_stash.public_key, dave.public_key,'0x0699553a3c5bfa89e41d94a45ceb9103ae9f87089b4a70de4c2a3eb922e1b9362fe0d8868ae4c9d5a9fba98d29b45d2c2630f4936077999f9334da1cca2e37e9')
+                ),
+                utxo.Output(
+                    value=39999919999 * COIN,
+                    header=0,
+                    destination=utxo.DestPubkey(charlie.public_key)
+                )
+            ]
+        ).sign(alice, [utxos[0][1]])
+        client.submit(alice, tx1)
+
+        # there should already be 4 accounts, adding Charlie and Dave in the list.
+        assert_equal(len(list(client.staking_count())), 4)
+
+        # Get Charlie
+        charlie_count = list(client.get_staking_count(charlie_stash))[0][1]
+        # charlie should have 1 locked utxos
+        assert_equal(charlie_count[0], 1)
+        # charlie should have a total of 50000 * COINS locked
+        assert_equal(charlie_count[1], 40000 * COIN)
+
+        # Get Dave
+        dave_count = list(client.get_staking_count(dave_stash))[0][1]
+        # dave should have 1 locked utxos
+        assert_equal(dave_count[0], 1)
+        # dave should have a total of 40001 * COINS locked
+        assert_equal(dave_count[1], 40001 * COIN)
+
+        # fetch the locked utxos from storage
+        locked_utxos = list(client.utxos('LockedUtxos'))
+        # there should already be 4 in the list; 1 from alice, 1 from bob, 1 from charlie, 1 from dave
+        assert_equal(len(locked_utxos),4)
+
+        # pallet-staking's ledger should have the same number of stakers
+        assert_equal( len(list(client.get_staking_ledger())), 4)
+
+if __name__ == '__main__':
+    ExampleTest().main()

--- a/test/functional/feature_staking_extra.py
+++ b/test/functional/feature_staking_extra.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""An example functional test
+
+Alice stakes an extra 40_000 utxo
+"""
+
+from substrateinterface import Keypair
+import test_framework.mintlayer.utxo as utxo
+
+from test_framework.test_framework import MintlayerTestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    wait_until,
+)
+from test_framework.messages import COIN
+
+
+class ExampleTest(MintlayerTestFramework):
+    # Each functional test is a subclass of the MintlayerTestFramework class.
+
+    # Override the set_test_params(), add_options(), setup_chain(), setup_network()
+    # and setup_nodes() methods to customize the test setup as required.
+
+    def set_test_params(self):
+        """Override test parameters for your individual test.
+
+        This method must be overridden and num_nodes must be exlicitly set."""
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        # Use self.extra_args to change command-line arguments for the nodes
+        self.extra_args = [[]]
+
+        # self.log.info("I've finished set_test_params")  # Oops! Can't run self.log before run_test()
+
+    def setup_network(self):
+        """Setup the test network topology
+
+        Often you won't need to override this, since the standard network topology
+        (linear: node0 <-> node1 <-> node2 <-> ...) is fine for most tests.
+
+        If you do override this method, remember to start the nodes, assign
+        them to self.nodes, connect them and then sync."""
+
+        self.setup_nodes()
+
+    def custom_method(self):
+        """Do some custom behaviour for this test
+
+        Define it in a method here because you're going to use it repeatedly.
+        If you think it's useful in general, consider moving it to the base
+        MintlayerTestFramework class so other tests can use it."""
+
+        self.log.info("Running custom_method")
+
+    def run_test(self):
+        client = self.nodes[0].rpc_client
+
+        alice = Keypair.create_from_uri('//Alice')
+        alice_stash = Keypair.create_from_uri('//Alice//stash')
+
+        # fetch the genesis utxo from storage
+        utxos = list(client.utxos_for(alice_stash))
+
+        # Get Alice stash
+        orig_count = list(client.get_staking_count(alice_stash))[0][1]
+        # there should be 1 count of alice's locked utxo
+        assert_equal(orig_count[0],1)
+        # the amount that alice locked is 40_000 * MLT_UNIT
+        assert_equal(orig_count[1],40000 * COIN)
+
+        tx1 = utxo.Transaction(
+            client,
+            inputs=[
+                utxo.Input(utxos[0][0]),
+            ],
+            outputs=[
+                utxo.Output(
+                    value=40000 * COIN,
+                    header=0,
+                    destination=utxo.DestLockExtraForStaking(alice_stash.public_key, alice.public_key)
+                ),
+            ]
+        ).sign(alice_stash, [utxos[0][1]])
+        (_,_,events) = client.submit(alice_stash, tx1)
+
+        assert_equal(events[0].value['module_id'],'Staking')
+        assert_equal(events[0].value['event_id'], 'Bonded')
+
+        assert_equal(events[1].value['module_id'],'Utxo')
+        assert_equal(events[1].value['event_id'], 'TransactionSuccess')
+
+        # Get Alice stash
+        new_count = list(client.get_staking_count(alice_stash))[0][1]
+
+        # there should already by 2 utxos locked
+        assert_equal(new_count[0],2)
+
+        # the original stake + new stake
+        assert_equal(new_count[1],80000 * COIN)
+
+if __name__ == '__main__':
+    ExampleTest().main()

--- a/test/functional/feature_staking_extra_not_validator.py
+++ b/test/functional/feature_staking_extra_not_validator.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""An example functional test
+
+Charlie tries to stake extra 40_000 utxo, even though it's his first time;
+and he's not actually a validator.
+"""
+
+from substrateinterface import Keypair
+import test_framework.mintlayer.utxo as utxo
+
+from test_framework.test_framework import MintlayerTestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    wait_until,
+)
+from test_framework.messages import COIN
+
+
+class ExampleTest(MintlayerTestFramework):
+    # Each functional test is a subclass of the MintlayerTestFramework class.
+
+    # Override the set_test_params(), add_options(), setup_chain(), setup_network()
+    # and setup_nodes() methods to customize the test setup as required.
+
+    def set_test_params(self):
+        """Override test parameters for your individual test.
+
+        This method must be overridden and num_nodes must be exlicitly set."""
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        # Use self.extra_args to change command-line arguments for the nodes
+        self.extra_args = [[]]
+
+        # self.log.info("I've finished set_test_params")  # Oops! Can't run self.log before run_test()
+
+    def setup_network(self):
+        """Setup the test network topology
+
+        Often you won't need to override this, since the standard network topology
+        (linear: node0 <-> node1 <-> node2 <-> ...) is fine for most tests.
+
+        If you do override this method, remember to start the nodes, assign
+        them to self.nodes, connect them and then sync."""
+
+        self.setup_nodes()
+
+    def custom_method(self):
+        """Do some custom behaviour for this test
+
+        Define it in a method here because you're going to use it repeatedly.
+        If you think it's useful in general, consider moving it to the base
+        MintlayerTestFramework class so other tests can use it."""
+
+        self.log.info("Running custom_method")
+
+    def run_test(self):
+        client = self.nodes[0].rpc_client
+
+        orig_count = list(client.staking_count())
+        # there should only be 1 count of each staker's locked utxo
+        assert_equal(orig_count[0][1][0], 1)
+        assert_equal(orig_count[1][1][0], 1)
+        # the amount that alice/bob locked is 40_000 * MLT_UNIT
+        assert_equal(orig_count[0][1][1], 40000 * COIN)
+        # the amount that alice/bob locked is 40_000 * MLT_UNIT
+        assert_equal(orig_count[1][1][1], 40000 * COIN)
+
+        alice = Keypair.create_from_uri('//Alice')
+        alice_stash = Keypair.create_from_uri('//Alice//stash')
+        charlie = Keypair.create_from_uri('//Charlie')
+        charlie_stash = Keypair.create_from_uri('//Charlie//stash')
+
+        # fetch the genesis utxo from storage
+        utxos = list(client.utxos_for(alice_stash))
+
+        tx1 = utxo.Transaction(
+            client,
+            inputs=[
+                utxo.Input(utxos[0][0]),
+            ],
+            outputs=[
+                utxo.Output(
+                    value=40000 * COIN,
+                    header=0,
+                    destination=utxo.DestLockExtraForStaking(charlie_stash.public_key, charlie.public_key)
+                ),
+            ]
+        ).sign(charlie_stash, [utxos[0][1]])
+        client.submit(charlie_stash, tx1)
+
+        new_count = list(client.staking_count())
+        # there should only be 2 count of staking, which are Alice and Bob
+        assert_equal(len(new_count), 2)
+
+if __name__ == '__main__':
+    ExampleTest().main()

--- a/test/functional/feature_staking_extra_wrong_controller.py
+++ b/test/functional/feature_staking_extra_wrong_controller.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""An example functional test
+
+Bob stakes an extra 40_000 utxo... but he inputted the wrong controller account
+"""
+
+from substrateinterface import Keypair
+import test_framework.mintlayer.utxo as utxo
+
+from test_framework.test_framework import MintlayerTestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    wait_until,
+)
+from test_framework.messages import COIN
+
+
+class ExampleTest(MintlayerTestFramework):
+    # Each functional test is a subclass of the MintlayerTestFramework class.
+
+    # Override the set_test_params(), add_options(), setup_chain(), setup_network()
+    # and setup_nodes() methods to customize the test setup as required.
+
+    def set_test_params(self):
+        """Override test parameters for your individual test.
+
+        This method must be overridden and num_nodes must be exlicitly set."""
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        # Use self.extra_args to change command-line arguments for the nodes
+        self.extra_args = [['--alice'],['--bob']]
+
+        # self.log.info("I've finished set_test_params")  # Oops! Can't run self.log before run_test()
+
+    def setup_network(self):
+        """Setup the test network topology
+
+        Often you won't need to override this, since the standard network topology
+        (linear: node0 <-> node1 <-> node2 <-> ...) is fine for most tests.
+
+        If you do override this method, remember to start the nodes, assign
+        them to self.nodes, connect them and then sync."""
+
+        self.setup_nodes()
+
+    def custom_method(self):
+        """Do some custom behaviour for this test
+
+        Define it in a method here because you're going to use it repeatedly.
+        If you think it's useful in general, consider moving it to the base
+        MintlayerTestFramework class so other tests can use it."""
+
+        self.log.info("Running custom_method")
+
+    def run_test(self):
+        client = self.nodes[0].rpc_client
+
+        bob = Keypair.create_from_uri('//Bob')
+        alice_stash = Keypair.create_from_uri('//Alice//stash')
+
+        # fetch the genesis utxo from storage
+        utxos = list(client.utxos_for(alice_stash))
+
+        # Get Bob stash
+        orig_count = list(client.get_staking_count(alice_stash))[0][1]
+        # there should be 1 count of bob's locked utxo
+        assert_equal(orig_count[0],1)
+        # the amount that bob locked is 40_000 * MLT_UNIT
+        assert_equal(orig_count[1],40000 * COIN)
+
+        tx1 = utxo.Transaction(
+            client,
+            inputs=[
+                utxo.Input(utxos[0][0]),
+            ],
+            outputs=[
+                utxo.Output(
+                    value=40000 * COIN,
+                    header=0,
+                    destination=utxo.DestLockExtraForStaking(alice_stash.public_key, bob.public_key)
+                ),
+            ]
+        ).sign(alice_stash, [utxos[0][1]])
+
+        client.submit(alice_stash, tx1)
+
+        # Get Bob's stash
+        new_count = list(client.get_staking_count(alice_stash))[0][1]
+
+        # there should still be only 1.
+        assert_equal(new_count[0],1)
+
+        # the stake stays the same
+        assert_equal(new_count[1],40000 * COIN)
+
+if __name__ == '__main__':
+    ExampleTest().main()

--- a/test/functional/feature_staking_first_time.py
+++ b/test/functional/feature_staking_first_time.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""An example functional test
+
+Send a transaction from Alice to Charlie, then Charlie stakes for the first time.
+"""
+
+from substrateinterface import Keypair
+import test_framework.mintlayer.utxo as utxo
+
+from test_framework.test_framework import MintlayerTestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    wait_until,
+)
+from test_framework.messages import COIN
+
+
+class ExampleTest(MintlayerTestFramework):
+    # Each functional test is a subclass of the MintlayerTestFramework class.
+
+    # Override the set_test_params(), add_options(), setup_chain(), setup_network()
+    # and setup_nodes() methods to customize the test setup as required.
+
+    def set_test_params(self):
+        """Override test parameters for your individual test.
+
+        This method must be overridden and num_nodes must be exlicitly set."""
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        # Use self.extra_args to change command-line arguments for the nodes
+        self.extra_args = [[]]
+
+        # self.log.info("I've finished set_test_params")  # Oops! Can't run self.log before run_test()
+
+    def setup_network(self):
+        """Setup the test network topology
+
+        Often you won't need to override this, since the standard network topology
+        (linear: node0 <-> node1 <-> node2 <-> ...) is fine for most tests.
+
+        If you do override this method, remember to start the nodes, assign
+        them to self.nodes, connect them and then sync."""
+
+        self.setup_nodes()
+
+    def custom_method(self):
+        """Do some custom behaviour for this test
+
+        Define it in a method here because you're going to use it repeatedly.
+        If you think it's useful in general, consider moving it to the base
+        MintlayerTestFramework class so other tests can use it."""
+
+        self.log.info("Running custom_method")
+
+    def run_test(self):
+        client = self.nodes[0].rpc_client
+
+        alice = Keypair.create_from_uri('//Alice')
+        charlie = Keypair.create_from_uri('//Charlie')
+        charlie_stash = Keypair.create_from_uri('//Charlie//stash')
+
+        # fetch the genesis utxo from storage
+        utxos = list(client.utxos_for(alice))
+
+        # there's only 2 record of staking, which are alice and bob.
+        assert_equal( len(list(client.staking_count())), 2 )
+
+        tx1 = utxo.Transaction(
+            client,
+            inputs=[
+                utxo.Input(utxos[0][0]),
+            ],
+            outputs=[
+                utxo.Output(
+                    value=50000 * COIN,
+                    header=0,
+                    destination=utxo.DestPubkey(charlie_stash.public_key)
+                ),
+            ]
+        ).sign(alice, [utxos[0][1]])
+        client.submit(alice, tx1)
+
+        tx2 = utxo.Transaction(
+            client,
+            inputs=[
+                utxo.Input(tx1.outpoint(0)),
+            ],
+            outputs=[
+                utxo.Output(
+                    value=40000 * COIN,
+                    header=0,
+                    destination=utxo.DestLockForStaking(charlie_stash.public_key, charlie.public_key,'0xa03bcfaac6ebdc26bb9c256c51b08f9c1c6d4569f48710a42939168d1d7e5b6086b20e145e97158f6a0b5bff2994439d3320543c8ff382d1ab3e5eafffaf1a18')
+                ),
+                utxo.Output(
+                    value=9999 * COIN,
+                    header=0,
+                    destination=utxo.DestPubkey(charlie_stash.public_key)
+                ),
+            ]
+        ).sign(charlie_stash, tx1.outputs)
+        (_,_,events) = client.submit(charlie_stash, tx2)
+
+        # there should already be 3 staking, adding Charlie in the list.
+        assert_equal( len(list(client.staking_count())), 3 )
+
+        # pallet-staking's ledger should have the same number of stakers
+        assert_equal( len(list(client.get_staking_ledger())), 3)
+
+if __name__ == '__main__':
+    ExampleTest().main()

--- a/test/functional/feature_staking_less_than_minimum.py
+++ b/test/functional/feature_staking_less_than_minimum.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""An example functional test
+
+Send a transaction from Alice to Charlie, but Charlie stakes less than the minimum required.
+"""
+
+from substrateinterface import Keypair
+import test_framework.mintlayer.utxo as utxo
+
+from test_framework.test_framework import MintlayerTestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    wait_until,
+)
+from test_framework.messages import COIN
+
+
+class ExampleTest(MintlayerTestFramework):
+    # Each functional test is a subclass of the MintlayerTestFramework class.
+
+    # Override the set_test_params(), add_options(), setup_chain(), setup_network()
+    # and setup_nodes() methods to customize the test setup as required.
+
+    def set_test_params(self):
+        """Override test parameters for your individual test.
+
+        This method must be overridden and num_nodes must be exlicitly set."""
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        # Use self.extra_args to change command-line arguments for the nodes
+        self.extra_args = [[]]
+
+        # self.log.info("I've finished set_test_params")  # Oops! Can't run self.log before run_test()
+
+    def setup_network(self):
+        """Setup the test network topology
+
+        Often you won't need to override this, since the standard network topology
+        (linear: node0 <-> node1 <-> node2 <-> ...) is fine for most tests.
+
+        If you do override this method, remember to start the nodes, assign
+        them to self.nodes, connect them and then sync."""
+
+        self.setup_nodes()
+
+    def custom_method(self):
+        """Do some custom behaviour for this test
+
+        Define it in a method here because you're going to use it repeatedly.
+        If you think it's useful in general, consider moving it to the base
+        MintlayerTestFramework class so other tests can use it."""
+
+        self.log.info("Running custom_method")
+
+    def run_test(self):
+        client = self.nodes[0].rpc_client
+
+        alice = Keypair.create_from_uri('//Alice')
+        charlie = Keypair.create_from_uri('//Charlie')
+        charlie_stash = Keypair.create_from_uri('//Charlie//stash')
+
+        # fetch the genesis utxo from storage
+        utxos = list(client.utxos_for(alice))
+
+        # there's only 2 record of staking, which are alice and bob.
+        assert_equal( len(list(client.staking_count())), 2 )
+
+        tx1 = utxo.Transaction(
+            client,
+            inputs=[
+                utxo.Input(utxos[0][0]),
+            ],
+            outputs=[
+                utxo.Output(
+                    value=50000 * COIN,
+                    header=0,
+                    destination=utxo.DestPubkey(charlie_stash.public_key)
+                ),
+            ]
+        ).sign(alice, [utxos[0][1]])
+        client.submit(alice, tx1)
+
+        tx2 = utxo.Transaction(
+            client,
+            inputs=[
+                utxo.Input(tx1.outpoint(0)),
+            ],
+            outputs=[
+                utxo.Output(
+                    value=4000 * COIN,
+                    header=0,
+                    destination=utxo.DestLockForStaking(charlie_stash.public_key, charlie.public_key,'0xa03bcfaac6ebdc26bb9c256c51b08f9c1c6d4569f48710a42939168d1d7e5b6086b20e145e97158f6a0b5bff2994439d3320543c8ff382d1ab3e5eafffaf1a18')
+                ),
+                utxo.Output(
+                    value=45999 * COIN,
+                    header=0,
+                    destination=utxo.DestPubkey(charlie_stash.public_key)
+                ),
+            ]
+        ).sign(charlie_stash, tx1.outputs)
+        client.submit(charlie_stash, tx2)
+
+        # there should only be 2 still, because Charlie failed on the staking.
+        assert_equal(len(list(client.staking_count())), 2 )
+
+if __name__ == '__main__':
+    ExampleTest().main()

--- a/test/functional/feature_staking_unlock_and_withdraw.py
+++ b/test/functional/feature_staking_unlock_and_withdraw.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""An example functional test
+
+Alice wants to unlock her locked utxos, and withdraw; leaving Bob all alone.
+This was tested with Block time of 20 seconds.
+
+"""
+
+from substrateinterface import Keypair
+import test_framework.mintlayer.utxo as utxo
+import time
+from test_framework.test_framework import MintlayerTestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    wait_until,
+)
+from test_framework.messages import COIN
+
+
+class ExampleTest(MintlayerTestFramework):
+    # Each functional test is a subclass of the MintlayerTestFramework class.
+
+    # Override the set_test_params(), add_options(), setup_chain(), setup_network()
+    # and setup_nodes() methods to customize the test setup as required.
+
+    def set_test_params(self):
+        """Override test parameters for your individual test.
+
+        This method must be overridden and num_nodes must be exlicitly set."""
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        # Use self.extra_args to change command-line arguments for the nodes
+        self.extra_args = [['--alice'],['--bob']]
+        # self.log.info("I've finished set_test_params")  # Oops! Can't run self.log before run_test()
+
+    def setup_network(self):
+        """Setup the test network topology
+
+        Often you won't need to override this, since the standard network topology
+        (linear: node0 <-> node1 <-> node2 <-> ...) is fine for most tests.
+
+        If you do override this method, remember to start the nodes, assign
+        them to self.nodes, connect them and then sync."""
+
+        self.setup_nodes()
+        connect_nodes(self.nodes[1], self.nodes[0])
+
+    def custom_method(self):
+        """Do some custom behaviour for this test
+
+        Define it in a method here because you're going to use it repeatedly.
+        If you think it's useful in general, consider moving it to the base
+        MintlayerTestFramework class so other tests can use it."""
+
+        self.log.info("Running custom_method")
+
+    def run_test(self):
+        client = self.nodes[0].rpc_client
+
+        ledger = list(client.get_staking_ledger())
+        assert_equal(len(ledger[0][1]['unlocking']),0)
+
+        alice_stash = Keypair.create_from_uri('//Alice//stash')
+
+        # fetch the genesis utxo from storage
+        utxos = list(client.utxos_for(alice_stash))
+
+        # Alice's locked utxo
+        locked_utxos = list(map(lambda e: e[0].value, list(client.locked_utxos_for(alice_stash))))
+
+        # there's 2 records of staking, Alice's and Bob's.
+        assert_equal( len(list(client.staking_count())), 2 )
+
+        (_, _, events) = client.unlock_request_for_withdrawal(alice_stash)
+
+        assert_equal(events[0].value['module_id'],'Staking')
+        assert_equal(events[0].value['event_id'], 'Chilled')
+
+        assert_equal(events[1].value['module_id'],'Staking')
+        assert_equal(events[1].value['event_id'], 'Unbonded')
+
+        assert_equal(events[2].value['module_id'],'Utxo')
+        assert_equal(events[2].value['event_id'], 'StakeUnlocked')
+
+        ledger = list(client.get_staking_ledger())
+        assert_equal(len(ledger),2)
+
+        time.sleep(500)
+
+        (_, _, w_events) = client.withdraw_stake(alice_stash)
+
+
+        assert_equal(w_events[0].value['module_id'],'Staking')
+        assert_equal(w_events[0].value['event_id'], 'Withdrawn')
+
+        assert_equal(w_events[1].value['module_id'],'Utxo')
+        assert_equal(w_events[1].value['event_id'], 'StakeWithdrawn')
+
+        assert_equal( len(list(client.staking_count())), 1)
+
+        updated_ledger = list(client.get_staking_ledger())
+        assert_equal(len(updated_ledger),1)
+
+
+if __name__ == '__main__':
+    ExampleTest().main()

--- a/test/functional/feature_staking_unlock_not_validator.py
+++ b/test/functional/feature_staking_unlock_not_validator.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""An example functional test
+
+Charlie tries to "unlock"
+"""
+
+from substrateinterface import Keypair
+import test_framework.mintlayer.utxo as utxo
+
+from test_framework.test_framework import MintlayerTestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    wait_until,
+)
+from test_framework.messages import COIN
+
+
+class ExampleTest(MintlayerTestFramework):
+    # Each functional test is a subclass of the MintlayerTestFramework class.
+
+    # Override the set_test_params(), add_options(), setup_chain(), setup_network()
+    # and setup_nodes() methods to customize the test setup as required.
+
+    def set_test_params(self):
+        """Override test parameters for your individual test.
+
+        This method must be overridden and num_nodes must be exlicitly set."""
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        # Use self.extra_args to change command-line arguments for the nodes
+        self.extra_args = [[]]
+
+        # self.log.info("I've finished set_test_params")  # Oops! Can't run self.log before run_test()
+
+    def setup_network(self):
+        """Setup the test network topology
+
+        Often you won't need to override this, since the standard network topology
+        (linear: node0 <-> node1 <-> node2 <-> ...) is fine for most tests.
+
+        If you do override this method, remember to start the nodes, assign
+        them to self.nodes, connect them and then sync."""
+
+        self.setup_nodes()
+
+    def custom_method(self):
+        """Do some custom behaviour for this test
+
+        Define it in a method here because you're going to use it repeatedly.
+        If you think it's useful in general, consider moving it to the base
+        MintlayerTestFramework class so other tests can use it."""
+
+        self.log.info("Running custom_method")
+
+    def run_test(self):
+        client = self.nodes[0].rpc_client
+
+        ledger = list(client.get_staking_ledger())
+        assert_equal(len(ledger[0][1]['unlocking']),0)
+        assert_equal(len(ledger[1][1]['unlocking']),0)
+
+        charlie = Keypair.create_from_uri('//Charlie')
+
+        client.unlock_request_for_withdrawal(charlie)
+
+        ledger = list(client.get_staking_ledger())
+        assert_equal(len(ledger[0][1]['unlocking']),0)
+        assert_equal(len(ledger[1][1]['unlocking']),0)
+
+        locked_utxos = list(client.utxos('LockedUtxos'))
+        # there should still be 2 utxos locked, no actual withdrawal happened.
+        assert_equal(len(locked_utxos),2)
+
+if __name__ == '__main__':
+    ExampleTest().main()

--- a/test/functional/feature_staking_withdraw_no_unlock.py
+++ b/test/functional/feature_staking_withdraw_no_unlock.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""An example functional test
+
+Alice wants to withdraw; forgetting to unlock first.
+
+"""
+
+from substrateinterface import Keypair
+import test_framework.mintlayer.utxo as utxo
+import time
+from test_framework.test_framework import MintlayerTestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    wait_until,
+)
+from test_framework.messages import COIN
+
+
+class ExampleTest(MintlayerTestFramework):
+    # Each functional test is a subclass of the MintlayerTestFramework class.
+
+    # Override the set_test_params(), add_options(), setup_chain(), setup_network()
+    # and setup_nodes() methods to customize the test setup as required.
+
+    def set_test_params(self):
+        """Override test parameters for your individual test.
+
+        This method must be overridden and num_nodes must be exlicitly set."""
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        # Use self.extra_args to change command-line arguments for the nodes
+        self.extra_args = [['--alice'],['--bob']]
+        # self.log.info("I've finished set_test_params")  # Oops! Can't run self.log before run_test()
+
+    def setup_network(self):
+        """Setup the test network topology
+
+        Often you won't need to override this, since the standard network topology
+        (linear: node0 <-> node1 <-> node2 <-> ...) is fine for most tests.
+
+        If you do override this method, remember to start the nodes, assign
+        them to self.nodes, connect them and then sync."""
+
+        self.setup_nodes()
+        connect_nodes(self.nodes[1], self.nodes[0])
+
+    def custom_method(self):
+        """Do some custom behaviour for this test
+
+        Define it in a method here because you're going to use it repeatedly.
+        If you think it's useful in general, consider moving it to the base
+        MintlayerTestFramework class so other tests can use it."""
+
+        self.log.info("Running custom_method")
+
+    def run_test(self):
+        client = self.nodes[0].rpc_client
+
+        ledger = list(client.get_staking_ledger())
+        assert_equal(len(ledger[0][1]['unlocking']),0)
+
+        alice_stash = Keypair.create_from_uri('//Alice//stash')
+
+        # Alice's locked utxo
+        locked_utxos = list(map(lambda e: e[0].value, list(client.locked_utxos_for(alice_stash))))
+
+        # there's 2 records of staking, Alice's and Bob's.
+        assert_equal( len(list(client.staking_count())), 2 )
+
+        ledger = list(client.get_staking_ledger())
+        assert_equal(len(ledger),2)
+
+        client.withdraw_stake(alice_stash)
+
+        assert_equal( len(list(client.staking_count())), 2)
+
+        # no withdrawal happened
+        updated_ledger = list(client.get_staking_ledger())
+        assert_equal(len(updated_ledger),2)
+
+
+if __name__ == '__main__':
+    ExampleTest().main()

--- a/test/functional/feature_staking_withdraw_not_validator.py
+++ b/test/functional/feature_staking_withdraw_not_validator.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""An example functional test
+
+Charlie tries to withdraw a stake which is not his.
+"""
+
+from substrateinterface import Keypair
+import test_framework.mintlayer.utxo as utxo
+
+from test_framework.test_framework import MintlayerTestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    wait_until,
+)
+from test_framework.messages import COIN
+
+
+class ExampleTest(MintlayerTestFramework):
+    # Each functional test is a subclass of the MintlayerTestFramework class.
+
+    # Override the set_test_params(), add_options(), setup_chain(), setup_network()
+    # and setup_nodes() methods to customize the test setup as required.
+
+    def set_test_params(self):
+        """Override test parameters for your individual test.
+
+        This method must be overridden and num_nodes must be exlicitly set."""
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        # Use self.extra_args to change command-line arguments for the nodes
+        self.extra_args = [[]]
+
+        # self.log.info("I've finished set_test_params")  # Oops! Can't run self.log before run_test()
+
+    def setup_network(self):
+        """Setup the test network topology
+
+        Often you won't need to override this, since the standard network topology
+        (linear: node0 <-> node1 <-> node2 <-> ...) is fine for most tests.
+
+        If you do override this method, remember to start the nodes, assign
+        them to self.nodes, connect them and then sync."""
+
+        self.setup_nodes()
+
+    def custom_method(self):
+        """Do some custom behaviour for this test
+
+        Define it in a method here because you're going to use it repeatedly.
+        If you think it's useful in general, consider moving it to the base
+        MintlayerTestFramework class so other tests can use it."""
+
+        self.log.info("Running custom_method")
+
+    def run_test(self):
+        client = self.nodes[0].rpc_client
+
+        ledger = list(client.get_staking_ledger())
+        assert_equal(len(ledger[0][1]['unlocking']),0)
+        assert_equal(len(ledger[1][1]['unlocking']),0)
+
+        charlie = Keypair.create_from_uri('//Charlie')
+        client.withdraw_stake(charlie)
+
+        ledger = list(client.get_staking_ledger())
+        assert_equal(len(ledger[0][1]['unlocking']),0)
+        assert_equal(len(ledger[1][1]['unlocking']),0)
+
+        locked_utxos = list(client.utxos('LockedUtxos'))
+        # there should still be 2 utxo locked, no actual withdrawal happened.
+        assert_equal(len(locked_utxos),2)
+
+        #check that unlocking is successful, after an error happened
+        alice_stash = Keypair.create_from_uri('//Alice//stash')
+        (_, _, events) = client.unlock_request_for_withdrawal(alice_stash)
+
+        assert_equal(events[0].value['module_id'],'Staking')
+        assert_equal(events[0].value['event_id'], 'Chilled')
+
+        assert_equal(events[1].value['module_id'],'Staking')
+        assert_equal(events[1].value['event_id'], 'Unbonded')
+
+        assert_equal(events[2].value['module_id'],'Utxo')
+        assert_equal(events[2].value['event_id'], 'StakeUnlocked')
+
+
+
+
+if __name__ == '__main__':
+    ExampleTest().main()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -36,7 +36,7 @@ MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version 
 MAX_INV_SZ = 50000
 MAX_BLOCK_BASE_SIZE = 1000000
 
-COIN = 100000000 # 1 bitcoin in satoshis
+COIN = 1000 * 100000000 # 1 MLT Coin
 COINBASE_MATURITY = 10
 STAKE_COMBINE_THRESHOLD = Decimal('1000.')
 STAKE_SPLIT_AGE = 60 * 60  # in regtest

--- a/test/functional/test_framework/mintlayer/_staking.py
+++ b/test/functional/test_framework/mintlayer/_staking.py
@@ -1,0 +1,13 @@
+import substrateinterface
+
+
+class Staking(object):
+
+    """ Query the node for the staking ledger """
+    def get_staking_ledger(self):
+        query = self.substrate.query_map(
+            module='Staking',
+            storage_function='Ledger'
+        )
+
+        return ((h, o.value) for (h, o) in query)

--- a/test/functional/test_framework/mintlayer/utxo.py
+++ b/test/functional/test_framework/mintlayer/utxo.py
@@ -8,7 +8,7 @@ import os
 import logging
 
 """ Client. A thin wrapper over SubstrateInterface """
-class Client:
+class Client():
     def __init__(self, url="ws://127.0.0.1", port=9944):
         source_dir = os.path.dirname(os.path.abspath(__file__))
         types_file = os.path.join(source_dir, "..", "..", "custom-types.json")
@@ -36,10 +36,10 @@ class Client:
         return '0x' + str(substrateinterface.utils.hasher.blake2_256(encoded))
 
     """ Query the node for the list of utxos """
-    def utxos(self):
+    def utxos(self, storage_name):
         query = self.substrate.query_map(
             module="Utxo",
-            storage_function="UtxoStore",
+            storage_function=storage_name,
             ignore_decoding_errors=False
         )
 
@@ -48,7 +48,40 @@ class Client:
     """ Get UTXOs for given key """
     def utxos_for(self, keypair):
         matching = lambda e: e[1].destination.get_pubkey() == keypair.public_key
-        return filter(matching, self.utxos())
+        return filter(matching, self.utxos('UtxoStore'))
+
+    """ Get UTXOs for given key """
+    def locked_utxos_for(self, keypair):
+        matching = lambda e: e[1].destination.get_ss58_address() == keypair.ss58_address
+        return filter(matching, self.utxos('LockedUtxos'))
+
+    """ Query the node for the list of public keys with staking """
+    def staking_count(self):
+        query = self.substrate.query_map(
+            module="Utxo",
+            storage_function="StakingCount",
+            ignore_decoding_errors=False
+        )
+
+        return ((h, tuple(map(int,str(obj)[1:-1].split(', ')))) for (h, obj) in query)
+
+    def get_staking_count(self, stash_keypair):
+        staking_count = list(self.staking_count())
+        matching = lambda e: e[0].value == stash_keypair.ss58_address
+
+        return filter(matching , staking_count)
+
+
+    # TODO: move to a separate file
+    """ accesses pallet-staking to retrieve the ledger """
+    def get_staking_ledger(self):
+        query = self.substrate.query_map(
+            module='Staking',
+            storage_function='Ledger'
+        )
+
+        return ((h, o.value) for (h, o) in query)
+
 
     """ Submit a transaction onto the blockchain """
     def submit(self, keypair, tx):
@@ -63,7 +96,41 @@ class Client:
         try:
             receipt = self.substrate.submit_extrinsic(extrinsic, wait_for_inclusion=True)
             self.log.debug("Extrinsic '{}' sent and included in block '{}'".format(receipt.extrinsic_hash, receipt.block_hash))
-            return (receipt.extrinsic_hash, receipt.block_hash)
+            return (receipt.extrinsic_hash, receipt.block_hash, receipt.triggered_events)
+        except SubstrateRequestException as e:
+            self.log.debug("Failed to send: {}".format(e))
+
+    """ Submit a transaction onto the blockchain: unlock """
+    def unlock_request_for_withdrawal(self, keypair):
+        call = self.substrate.compose_call(
+            call_module = 'Utxo',
+            call_function = 'unlock_request_for_withdrawal'
+        )
+        #TODO ^ same code as above; put them in 1 func
+        extrinsic = self.substrate.create_signed_extrinsic(call=call, keypair=keypair)
+        self.log.debug("unlock request extrinsic submitted...")
+
+        try:
+            receipt = self.substrate.submit_extrinsic(extrinsic, wait_for_inclusion=True)
+            self.log.debug("Extrinsic '{}' sent and included in block '{}'".format(receipt.extrinsic_hash, receipt.block_hash))
+            return (receipt.extrinsic_hash, receipt.block_hash, receipt.triggered_events)
+        except SubstrateRequestException as e:
+            self.log.debug("Failed to send: {}".format(e))
+
+    """ Submit a transaction onto the blockchain: withdraw """
+    def withdraw_stake(self, keypair):
+        call = self.substrate.compose_call(
+            call_module = 'Utxo',
+            call_function = 'withdraw_stake'
+        )
+        #TODO ^ same code as above; put them in 1 func
+        extrinsic = self.substrate.create_signed_extrinsic(call=call, keypair=keypair)
+        self.log.debug("withdraw extrinsic submitted...")
+
+        try:
+            receipt = self.substrate.submit_extrinsic(extrinsic, wait_for_inclusion=True)
+            self.log.debug("Extrinsic '{}' sent and included in block '{}'".format(receipt.extrinsic_hash, receipt.block_hash))
+            return (receipt.extrinsic_hash, receipt.block_hash, receipt.triggered_events)
         except SubstrateRequestException as e:
             self.log.info("Failed to send: {}".format(e))
 
@@ -76,12 +143,19 @@ class Destination():
             return DestCreatePP.load(obj['CreatePP'])
         if 'CallPP' in obj:
             return DestCallPP.load(obj['CallPP'])
+        if 'LockForStaking' in obj:
+            return DestLockForStaking.load(obj['LockForStaking'])
+        if 'LockExtraForStaking' in obj:
+            return DestLockExtraForStaking.load(obj['LockExtraForStaking'])
         return None
 
     def type_string(self):
         return 'Destination'
 
     def get_pubkey(self):
+        return None
+
+    def get_ss58_address(self):
         return None
 
 # Only Schnorr pubkey type supported now.
@@ -134,6 +208,38 @@ class DestCallPP(Destination):
 
     def json(self):
         return { 'CallPP': { 'dest_account': self.acct, 'fund': self.fund, 'input_data': self.data } }
+
+class DestLockForStaking(Destination):
+    def __init__(self, stash_account, controller_account, session_key):
+        self.stash = stash_account
+        self.controller = controller_account
+        self.sesh = session_key
+
+    @staticmethod
+    def load(obj):
+        return DestLockForStaking(obj['stash_account'], obj['controller_account'], ['session_key'])
+
+    def json(self):
+        return { 'LockForStaking': { 'stash_account': self.stash, 'controller_account': self.controller, 'session_key': self.sesh } }
+
+    def get_ss58_address(self):
+        return self.stash
+
+class DestLockExtraForStaking(Destination):
+    def __init__(self, stash_account, controller_account):
+        self.stash = stash_account
+        self.controller = controller_account
+
+    @staticmethod
+    def load(obj):
+        return DestLockExtraForStaking(obj['stash_account'], obj['controller_account'])
+
+    def json(self):
+        return { 'LockExtraForStaking': { 'stash_account': self.stash, 'controller_account': self.controller } }
+
+    def get_ss58_address(self):
+        return self.stash
+
 
 class Output():
     def __init__(self, value, header, destination):

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -140,7 +140,7 @@ class TestNode():
                 url = "ws://127.0.0.1"  # TODO: move this to a parameter in the constructor
                 rpc_client = mintlayer.utxo.Client(url, port)
                 # let's run some functions that show that the node is running
-                rpc_client.utxos()
+                rpc_client.utxos('UtxoStore')
                 rpc_client.substrate.get_block_hash(0)
                 node_id_response = rpc_client.substrate.rpc_request("system_localPeerId", [])
                 self.peer_id = node_id_response["result"]

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -57,6 +57,16 @@ BASE_SCRIPTS= [
     'example_test.py',
     'feature_alice_bob_test.py',
     'feature_smart_contract_test.py',
+    'feature_staking_extra.py',
+    'feature_staking_extra_not_validator.py',
+    'feature_staking_extra_wrong_controller.py',
+    'feature_staking_first_time.py',
+    'feature_staking_less_than_minimum.py',
+    'feature_staking_diff_addresses.py',
+    'feature_staking_unlock_not_validator.py',
+    'feature_staking_withdraw_no_unlock.py',
+    'feature_staking_withdraw_not_validator.py'
+#     'feature_staking_unlock_and_withdraw.py' ## should be ran on 20 secs
     # Don't append tests at the end to avoid merge conflicts
     # Put them in a random line within the section that fits their approximate run-time
 ]

--- a/traits/utxo-api/src/lib.rs
+++ b/traits/utxo-api/src/lib.rs
@@ -33,6 +33,12 @@ pub trait UtxoApi {
         sig: H512,
     ) -> DispatchResultWithPostInfo;
 
+    fn unlock_request_for_withdrawal(
+        stash_account_caller: &Self::AccountId,
+    ) -> DispatchResultWithPostInfo;
+
+    fn withdraw_stake(stash_account_caller: &Self::AccountId) -> DispatchResultWithPostInfo;
+
     fn send_conscrit_p2pk(
         caller: &Self::AccountId,
         destination: &Self::AccountId,


### PR DESCRIPTION
To continue from https://github.com/mintlayer/core/pull/83

Staking
 - uses [Substrate's staking module](https://github.com/paritytech/substrate/tree/master/frame/staking#readme) of controller and stash accounts
 
Reward
  - with  [Substrate's authorship module](https://github.com/paritytech/substrate/blob/master/frame/authorship/README.md) to give a fixed reward to block authors; with the reward depreciating over time.
  

## pallet-utxo
### `lib.rs`
  - added more config:
    - constants:
      - **`RewardReductionFraction`** - the percentage drop of a reward value. (e.g. 10%, 15%, etc.)
      - **`RewardReductionPeriod`** - the next block number to execute a drop of reward value.
      - **`MinimumStake`** - minimum value to start staking/validating
      - **`StakeWithdrawalFee`** - the cost of withdrawing an unlocked staked utxo.**
      - **`StakingHelper`** - a trait for performing staking OUTSIDE of pallet-utxo
      -  **`InitialReward`** - the initial reward to give to block authors
      -**`DefaultMinimumReward`** - the minimum reward to give to block authors, when depreciation results to zero.
 - added `Destinations`:
   - **`LockForStaking`** - first time of the node to do staking. Requires the `stash_account`, the `controller_account`, and the ~~`session key`
   - **`LockExtraForStaking`** - if the validator wants to stake extra utxos. Can be done ONLY for existing validators.
 - added pallet calls:
   - **`unlock_request_for_withdrawal`** - using the stash account, unlock the locked utxos and to stop being a validator. This will enable withdrawal depending on the `BondingDuration` set in `pallet-staking`'s config.
   - **`withdraw_stake`** - Withdrawal will be allowed after the `BondingDuration` set in `pallet-staking`'s config has reached.
 
  - added more storage:
   - **`BlockAuthor`** - the current block author
   - **`LockedUtxos`** - the "staked" utxos of the validators. Cannot be withdrawn.
   - **`StakingCount`** - tracks the number of utxos a controller has locked, **and the total amount locked.**
 - more events:
   - **`BlockAuthorRewarded`** - shows how much a validator is rewarded for producing a block
   - **`StakeUnlocked`** - shows a validator quiting the role.
   - **`StakeWithdrawn`** - shows a node withdrawing its staked/locked utxos; in other words, moving the utxo back to `UtxoStore`.
 - added Errors:
   - **`ControllerAccountNotFound`**,
   - **`StashAccountNotFound`**,
   - **`StashAccountAlreadyRegistered`**,
   - **`InvalidOperation`**
   - **`OutpointDoesNotExist`**
   - **`FundsAtUnlockedStake`**
 - added fields in `GenesisConfig`:
   - **`locked_utxos`** - the initial utxos locked (the initial authorities/validators)
 - removed fields in `GenesisConfig`:
   - **`marker`**
   

### `staking.rs` 
 - handles the staking. Also contains the trait definition of `StakeHelper`. For implementation, go to `runtime/src/staking.rs`.
   - **`fn get_controller_account(stash_account)`** - given the stash account, get its corresponding controller account
   - **`fn is_controller_account(account)`** - checks if the account provided is a registered controller account
   - **`fn can_decode_session_key(session_key:Vec<u8>)`** - makes sure the provided session key is "decode"-able
   - **`fn are_funds_locked(controller_account)`** - given the controller account, check if the funds are still at "Locked" state.
   - **`fn check_accounts_matched(controller_account, stash_account)`** - checks if these keys s a pair.
   - **`fn lock_for_staking(...)`**- handles the locking of funds outside of `pallet-utxo.`
   - **`fn lock_extra_for_staking(...)`**- handles the locking of extra funds outside of `pallet-utxo`. Only for existing controller- stash account pairs.
   - **`fn unlock_request_for_withdrawal(stash_account)`** - stops the validator from validating, and sets funds at "Unlocked" state.
   - **`fn withdraw()`** - withdraw funds back to free balance. Only done when `BondingDuration` from `pallet-staking` has elapsed.
 - the validate module houses the validation of the operations: LockForStaking, LockExtraForStaking, UnlockRequestForWithdrawal, Withdrawal 
 - util module for helper functions
  
### `rewards.rs` 
 - handles assigning and rewarding block authors 

### mock.rs` 
 - aura and the timestamp are not needed actually.**

### `staking_test.rs` 
 - test cases for testing.  

## runtime
- `lib.rs`
  - added the ff. pallets:
    - **`pallet-staking`** - the pallet used for its logic on staking. This follows the NPoS Consensus, BUT the configuration is only making use of its "validator" role.
    - **`pallet-session`** - this is a required pallet of `pallet-staking`
    -**`pallet-authorship`** - to identify the block author  

- `staking.rs` - implementation of StakeHelper.


## node
- `chainspec.rs` - a "release" config using the actual keys of the initial validators. Keys are found in the `assets` folder
- `cli.rs` - adding the release command, to use the officially generated keys, and not the usual alice, bob, charlie, etc.