### PR TITLE
chain_spec: Protocol ID for testnet

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -87,7 +87,7 @@ pub fn testnet_config(endowed_accounts: Vec<MltKeysInfo>) -> Result<ChainSpec, S
         // Telemetry
         None,
         // Protocol ID
-        None,
+        "MintlayerTestV0".into(),
         // Properties
         None,
         // Extensions


### PR DESCRIPTION
This is used to differentiate between Substrate-based chains