### PR TITLE
utxo: Initial support for unsigned transactions

### DIFF
--- a/pallets/utxo/src/lib.rs
+++ b/pallets/utxo/src/lib.rs
@@ -1142,12 +1142,12 @@ pub mod pallet {
                         Some(OutputData::TokenTransferV1 { .. }) | None => continue,
                     }
                 }
-                Destination::CreatePP(script, data) => {
+                Destination::CreatePP(_script, _data) => {
                     //log::debug!("inserting to UtxoStore {:?} as key {:?}", output, hash);
                     //<UtxoStore<T>>::insert(hash, output);
                     //create::<T>(caller, script, hash, output.value, &data)?;
                 }
-                Destination::CallPP(acct_id, fund, data) => {
+                Destination::CallPP(_acct_id, _fund, _data) => {
                     //log::debug!("inserting to UtxoStore {:?} as key {:?}", output, hash);
                     //<UtxoStore<T>>::insert(hash, output);
                     //call::<T>(caller, acct_id, hash, output.value, *fund, data)?;
@@ -1441,7 +1441,7 @@ where
     }
 
     fn submit_c2pk_tx(
-        caller: &T::AccountId,
+        _caller: &T::AccountId,
         dest: &T::AccountId,
         value: u128,
         outpoints: &Vec<H256>,
@@ -1460,7 +1460,7 @@ where
     }
 
     fn submit_c2c_tx(
-        caller: &Self::AccountId,
+        _caller: &Self::AccountId,
         dest: &Self::AccountId,
         value: u128,
         data: &Vec<u8>,

--- a/pallets/utxo/src/lib.rs
+++ b/pallets/utxo/src/lib.rs
@@ -1213,9 +1213,10 @@ pub mod pallet {
     impl<T: Config> Pallet<T> {
         #[pallet::weight(<T as Config>::WeightInfo::spend(tx.inputs.len().saturating_add(tx.outputs.len()) as u32))]
         pub fn spend(
-            _origin: OriginFor<T>,
+            origin: OriginFor<T>,
             tx: Transaction<T::AccountId>,
         ) -> DispatchResultWithPostInfo {
+            ensure_none(origin)?;
             spend::<T>(&tx)?;
             Self::deposit_event(Event::<T>::TransactionSuccess(tx));
             Ok(().into())

--- a/pallets/utxo/src/staking_tests.rs
+++ b/pallets/utxo/src/staking_tests.rs
@@ -42,7 +42,7 @@ fn staking_first_time() {
         .sign(&[utxo], 0, &karl_pub_key)
         .expect("karl's pub key not found");
         let utxo = &tx1.outputs[0];
-        assert_ok!(Utxo::spend(Origin::signed(H256::zero()), tx1.clone()));
+        assert_ok!(Utxo::spend(Origin::none(), tx1.clone()));
 
         let tx2 = Transaction {
             inputs: vec![TransactionInput::new_empty(tx1.outpoint(0))],
@@ -66,7 +66,7 @@ fn staking_first_time() {
         .expect("Alice's pub key not found");
         let new_utxo_hash = tx2.outpoint(1);
 
-        assert_ok!(Utxo::spend(Origin::signed(H256::zero()), tx2));
+        assert_ok!(Utxo::spend(Origin::none(), tx2));
         assert!(UtxoStore::<Test>::contains_key(new_utxo_hash));
         assert!(StakingCount::<Test>::contains_key(H256::from(greg_pub_key)));
         assert!(StakingCount::<Test>::contains_key(H256::from(
@@ -109,7 +109,7 @@ fn simple_staking() {
         let locked_utxo_hash = tx.outpoint(0);
         let new_utxo_hash = tx.outpoint(1);
 
-        assert_ok!(Utxo::spend(Origin::signed(H256::zero()), tx));
+        assert_ok!(Utxo::spend(Origin::none(), tx));
         assert!(UtxoStore::<Test>::contains_key(new_utxo_hash));
         assert!(LockedUtxos::<Test>::contains_key(locked_utxo_hash));
         assert!(StakingCount::<Test>::contains_key(H256::from(
@@ -148,7 +148,7 @@ fn less_than_minimum_stake() {
         tx.inputs[0].witness = karl_sig.0.to_vec();
 
         assert_err!(
-            Utxo::spend(Origin::signed(H256::zero()), tx),
+            Utxo::spend(Origin::none(), tx),
             "output value must be equal or more than the minimum stake"
         );
     })
@@ -193,7 +193,7 @@ fn non_mlt_staking() {
         .expect("karl's pub key not found");
 
         assert_err!(
-            Utxo::spend(Origin::signed(H256::zero()), tx),
+            Utxo::spend(Origin::none(), tx),
             "only MLT tokens are supported for staking"
         );
     })
@@ -224,7 +224,7 @@ fn controller_staking_again() {
         .expect(" tom's pub key not found");
 
         assert_err!(
-            Utxo::spend(Origin::signed(H256::zero()), tx),
+            Utxo::spend(Origin::none(), tx),
             "StashAccountAlreadyRegistered"
         );
     })
@@ -256,7 +256,7 @@ fn stash_account_is_staking() {
         .expect("alice's public key not found");
 
         assert_err!(
-            Utxo::spend(Origin::signed(H256::zero()), tx),
+            Utxo::spend(Origin::none(), tx),
             "StashAccountAlreadyRegistered"
         );
     })
@@ -288,7 +288,7 @@ fn simple_staking_extra() {
         let locked_utxo_hash = tx.outpoint(0);
         let new_utxo_hash = tx.outpoint(1);
 
-        assert_ok!(Utxo::spend(Origin::signed(H256::zero()), tx));
+        assert_ok!(Utxo::spend(Origin::none(), tx));
         assert!(UtxoStore::<Test>::contains_key(new_utxo_hash));
         assert!(LockedUtxos::<Test>::contains_key(locked_utxo_hash));
         assert_eq!(
@@ -324,7 +324,7 @@ fn non_validator_staking_extra() {
         .expect("greg's pub key not found");
 
         assert_err!(
-            Utxo::spend(Origin::signed(H256::zero()), tx),
+            Utxo::spend(Origin::none(), tx),
             "StashAccountNotFound"
         );
     })

--- a/test/functional/feature_staking_extra.py
+++ b/test/functional/feature_staking_extra.py
@@ -91,13 +91,15 @@ class ExampleTest(MintlayerTestFramework):
                 )
             ]
         ).sign(alice_stash, [utxos[0][1]])
-        (_,_,events) = client.submit(alice_stash, tx1)
+        (_, block_hash, _events) = client.submit(alice_stash, tx1)
 
-        assert_equal(events[0].value['module_id'],'Staking')
-        assert_equal(events[0].value['event_id'], 'Bonded')
+        events = client.substrate.get_events(block_hash = block_hash)
 
-        assert_equal(events[1].value['module_id'],'Utxo')
-        assert_equal(events[1].value['event_id'], 'TransactionSuccess')
+        assert_equal(events[1].value['module_id'],'Staking')
+        assert_equal(events[1].value['event_id'], 'Bonded')
+
+        assert_equal(events[2].value['module_id'],'Utxo')
+        assert_equal(events[2].value['event_id'], 'TransactionSuccess')
 
         # Get Alice stash
         new_count = list(client.get_staking_count(alice_stash))[0][1]

--- a/test/functional/test_framework/mintlayer/utxo.py
+++ b/test/functional/test_framework/mintlayer/utxo.py
@@ -95,6 +95,25 @@ class Client():
     def withdrawal_era(self, keypair):
         return self.staking.withdrawal_era(keypair)
 
+    def submit_extrinsic(self, extrinsic):
+        def result_handler(message, update_nr, sub_id):
+            if 'params' in message and type(message['params']['result']) is dict:
+                res = message['params']['result']
+                if 'inBlock' in res:
+                    return substrateinterface.ExtrinsicReceipt(
+                        substrate = self.substrate,
+                        block_hash = res['inBlock'],
+                        extrinsic_hash = "Unknown"
+                    )
+
+        result = self.substrate.rpc_request(
+            "author_submitAndWatchExtrinsic",
+            [str(extrinsic.data)],
+            result_handler=result_handler
+        )
+
+        return result
+
     """ Submit a transaction onto the blockchain """
     def submit(self, keypair, tx):
         call = self.substrate.compose_call(
@@ -102,13 +121,13 @@ class Client():
             call_function = 'spend',
             call_params = { 'tx': tx.json() },
         )
-        extrinsic = self.substrate.create_signed_extrinsic(call=call, keypair=keypair)
+        extrinsic = self.substrate.create_unsigned_extrinsic(call=call)
         self.log.debug("extrinsic submitted...")
 
         try:
-            receipt = self.substrate.submit_extrinsic(extrinsic, wait_for_inclusion=True)
+            receipt = self.submit_extrinsic(extrinsic)
             self.log.debug("Extrinsic '{}' sent and included in block '{}'".format(receipt.extrinsic_hash, receipt.block_hash))
-            return (receipt.extrinsic_hash, receipt.block_hash, receipt.triggered_events)
+            return (receipt.extrinsic_hash, receipt.block_hash, [])
         except SubstrateRequestException as e:
             self.log.debug("Failed to send: {}".format(e))
             raise e


### PR DESCRIPTION
This uses unsigned transactions for UTXO transactions. Avoids the problem with fees coming off of the pallet_balances funds. The docs from Parity [1] suggest that some extra anti-spam measures are required to let the transactions through but that is not what I observed. Seems to work for me like it is in this patch. Not yet ready for merge, some cleanups and more testing required.

[1] https://docs.substrate.io/v3/concepts/extrinsics/#unsigned-transactions