### PR TITLE
runtime: Cargo feature to make block production faster

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,9 +67,9 @@ jobs:
       with:
         submodules: recursive
     - name: Build
-      run: cargo build --release
+      run: cargo build --release --features short-block-time
     - name: Run tests
-      run: cargo test --release
+      run: cargo test --release --features short-block-time
     - name: Prepare functional tests
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,5 +84,5 @@ jobs:
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: test-artifacts
+        name: functional-tests-logs
         path: /tmp/mintlayer*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,3 +80,9 @@ jobs:
       run: python -m pip install 'scalecodec == 0.11.18'
     - name: Run functional tests
       run: python test/functional/test_runner.py
+    - name: Save test artifacts on failure
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: test-artifacts
+        path: /tmp/mintlayer*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Install scalecodec
       run: python -m pip install 'scalecodec == 0.11.18'
     - name: Run functional tests
-      run: python test/functional/test_runner.py
+      run: python test/functional/test_runner.py --jobs 1
     - name: Save test artifacts on failure
       uses: actions/upload-artifact@v2
       if: failure()

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -248,6 +248,7 @@ path = "../pallets/pp"
 
 [features]
 default = ['std']
+short-block-time = []
 runtime-benchmarks = [
     'frame-benchmarking',
     'frame-support/runtime-benchmarks',

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -125,7 +125,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 /// up by `pallet_aura` to implement `fn slot_duration()`.
 ///
 /// Change this to adjust the block time.
-pub const MILLISECS_PER_BLOCK: u64 = 60_000; //1 min
+#[cfg(not(feature = "short-block-time"))]
+pub const MILLISECS_PER_BLOCK: u64 = 60_000; // 1 min
+#[cfg(feature = "short-block-time")]
+pub const MILLISECS_PER_BLOCK: u64 = 3_000; // 3 sec
 
 // NOTE: Currently it is not possible to change the slot duration after the chain has started.
 //       Attempting to do so will brick block production.

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -65,6 +65,7 @@ class TestNode():
         port_rpc = rpc_port(i)
         port_p2p = p2p_port(i)
         self.args = [self.binary, "--dev",
+                     "--database", "paritydb-experimental",
                      "--base-path", self.datadir,
                      "--log", "trace",
                      "--name", "testnode%d" % i,

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -52,8 +52,8 @@ class TestNode():
         if timewait:
             self.rpc_timeout = timewait
         else:
-            # Wait for up to 600 seconds for the RPC server to respond
-            self.rpc_timeout = 600
+            # Wait for up to 120 seconds for the RPC server to respond
+            self.rpc_timeout = 120
         if binary is None:
             self.binary = os.getenv("NODEEXE", "mintlayer-core")
         else:

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -411,7 +411,7 @@ def check_script_list(src_dir):
     python_files = set([t for t in os.listdir(script_dir) if t[-3:] == ".py"])
     missed_tests = list(python_files - set(map(lambda x: x.split()[0], ALL_SCRIPTS + NON_SCRIPTS)))
     if len(missed_tests) != 0:
-        print("%sWARNING!%s The following scripts are not being run: %s. Check the test lists in test_runner.py." % (BOLD[1], BOLD[0], str(missed_tests)))
+        print("%sWARNING!%s The following scripts are not being run: %s. Check the test lists in test_runner.py." % (BOLD[1], BOLD[0], str(missed_tests)), flush=True)
         if os.getenv('TRAVIS') == 'true':
             # On travis this warning is an error to prevent merging incomplete commits into master
             sys.exit(1)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -331,7 +331,7 @@ class TestHandler:
         running_test_names = [test_data[0] for test_data in self.jobs]
         running_test_names_list = ["{}{}{}".format(BOLD[1], nm, BOLD[0]) for nm in running_test_names]
         running_test_names_list = ", ".join(running_test_names_list)
-        logging.debug("Tests currently running: %s", running_test_names_list)
+        logging.debug("Test%s currently running: %s", "s" if len(running_test_names) > 1 else "", running_test_names_list)
 
         while True:
             # Return first proc that finishes

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -326,6 +326,13 @@ class TestHandler:
                               log_stderr))
         if not self.jobs:
             raise IndexError('pop from empty list')
+
+        # print test names that are running
+        running_test_names = [test_data[0] for test_data in self.jobs]
+        running_test_names_list = ["{}{}{}".format(BOLD[1], nm, BOLD[0]) for nm in running_test_names]
+        running_test_names_list = ", ".join(running_test_names_list)
+        logging.debug("Tests currently running: %s", running_test_names_list)
+
         while True:
             # Return first proc that finishes
             time.sleep(.5)
@@ -336,6 +343,7 @@ class TestHandler:
                     # providing useful output.
                     proc.send_signal(signal.SIGINT)
                 if proc.poll() is not None:
+                    # check if the test has finished
                     log_out.seek(0), log_err.seek(0)
                     [stdout, stderr] = [l.read().decode('utf-8') for l in (log_out, log_err)]
                     log_out.close(), log_err.close()


### PR DESCRIPTION
Add a compilation-time feature to shorten the block interval to 3 seconds. Intended mainly for testing.

This is the approach to adjusting block interval that I found easiest to implement. The PR is mainly intended as a discussion starter. Do we want a command-line switch (would require some hacks)? Is this sufficient for testing?

Use `cargo build --release --features fast` to enable 3s block times.